### PR TITLE
Improved download and create connector experience

### DIFF
--- a/tools/paconn-cli/paconn.pyproj
+++ b/tools/paconn-cli/paconn.pyproj
@@ -45,7 +45,7 @@
     <Compile Include="paconn\apimanager\apimanager.py" />
     <Compile Include="paconn\commands\download.py" />
     <Compile Include="paconn\commands\login.py" />
-    <Compile Include="paconn\operations\create_update.py" />
+    <Compile Include="paconn\operations\upsert.py" />
     <Compile Include="paconn\settings\settings.py" />
     <Compile Include="paconn\apimanager\flowrp.py" />
     <Compile Include="paconn\apimanager\iconuploader.py" />

--- a/tools/paconn-cli/paconn/authentication/profile.py
+++ b/tools/paconn-cli/paconn/authentication/profile.py
@@ -12,7 +12,8 @@ import adal
 from msrestazure.azure_active_directory import AADTokenCredentials
 
 CLIENT_ID = '04b07795-8ddb-461a-bbee-02f9e1bf7b46'
-AUTHORITY_URL = 'https://login.microsoftonline.com/{tenant}'
+TENANT = 'common'
+AUTHORITY_URL = 'https://login.microsoftonline.com/{}'
 RESOURCE = 'https://management.core.windows.net/'
 
 
@@ -26,17 +27,16 @@ class Profile:
         self.authority_url = authority_url
 
     def _get_authentication_context(self, tenant):
-        auth_url = self.authority_url.format(
-            tenant=tenant)
+        auth_url = self.authority_url.format(tenant)
         return adal.AuthenticationContext(
             authority=auth_url,
             api_version=None)
 
-    def authenticate_device_code(self, client_id=CLIENT_ID):
+    def authenticate_device_code(self, tenant=TENANT, client_id=CLIENT_ID):
         """
         Authenticate the end-user using device auth.
         """
-        context = self._get_authentication_context('common')
+        context = self._get_authentication_context(tenant)
 
         code = context.acquire_user_code(
             resource=self.resource,

--- a/tools/paconn-cli/paconn/commands/create.py
+++ b/tools/paconn-cli/paconn/commands/create.py
@@ -11,7 +11,7 @@ Create command.
 from paconn import _CREATE
 from paconn.common.util import display
 from paconn.settings.util import load_settings_and_powerapps_rp
-from paconn.operations.create_update import create_update
+from paconn.operations.upsert import upsert
 
 
 # pylint: disable=too-many-arguments
@@ -23,7 +23,8 @@ def create(
         powerapps_url,
         powerapps_version,
         client_secret,
-        settings_file):
+        settings_file,
+        overwrite_settings):
     """
     Create command.
     """
@@ -38,10 +39,11 @@ def create(
         powerapps_version=powerapps_version,
         command_context=_CREATE)
 
-    connector_id = create_update(
+    connector_id = upsert(
         powerapps_rp=powerapps_rp,
         settings=settings,
         client_secret=client_secret,
-        is_update=False)
+        is_update=False,
+        overwrite_settings=overwrite_settings)
 
     display('{} created successfully.'.format(connector_id))

--- a/tools/paconn-cli/paconn/commands/download.py
+++ b/tools/paconn-cli/paconn/commands/download.py
@@ -16,7 +16,14 @@ import paconn.operations.download
 
 
 # pylint: disable=too-many-arguments
-def download(environment, connector_id, destination, powerapps_url, powerapps_version, settings_file):
+def download(
+        environment,
+        connector_id,
+        destination,
+        powerapps_url,
+        powerapps_version,
+        settings_file,
+        overwrite):
     """
     Download command.
     """
@@ -34,6 +41,7 @@ def download(environment, connector_id, destination, powerapps_url, powerapps_ve
     directory = paconn.operations.download.download(
         powerapps_rp=powerapps_rp,
         settings=settings,
-        destination=destination)
+        destination=destination,
+        overwrite=overwrite)
 
     display('The connector is downloaded to {}.'.format(directory))

--- a/tools/paconn-cli/paconn/commands/params.py
+++ b/tools/paconn-cli/paconn/commands/params.py
@@ -34,7 +34,7 @@ CONNECTOR_ID_HELP = 'The custom connector ID.'
 
 DESTINATION = 'destination'
 DESTINATION_OPTIONS = ['--dest', '-d']
-DESTINATION_HELP = 'Destination directory.'
+DESTINATION_HELP = 'Destination directory. Non-existent directories will be created.'
 
 POWERAPPS_URL = 'powerapps_url'
 POWERAPPS_URL_OPTIONS = ['--pau', '-u']
@@ -49,16 +49,24 @@ SETTINGS_OPTIONS = ['--settings', '-s']
 SETTINGS_HELP = 'A settings file containing required parameters. When a settings file is specified some commandline parameters are ignored.'  # noqa: E501
 
 API_PROPERTIES = 'api_properties'
-API_PROPERTIES_OPTIONS = ['--api-prop']
+API_PROPERTIES_OPTIONS = ['--api-prop', '-p']
 API_PROPERTIES_HELP = 'Location of the API properties JSON document.'
 
 API_DEFINITION = 'api_definition'
-API_DEFINITION_OPTIONS = ['--api-def']
+API_DEFINITION_OPTIONS = ['--api-def', '-d']
 API_DEFINITION_HELP = 'Location of the Open API definition JSON document.'
 
 ICON = 'icon'
-ICON_OPTIONS = ['--icon']
+ICON_OPTIONS = ['--icon', '-i']
 ICON_HELP = 'Location for the icon file.'
+
+OVERWRITE = 'overwrite'
+OVERWRITE_OPTIONS = ['--overwrite']
+OVERWRITE_HELP = 'Overwrite all the existing connector and settings files.'
+
+OVERWRITE_SETTINGS = 'overwrite_settings'
+OVERWRITE_SETTINGS_OPTIONS = ['--overwrite-settings']
+OVERWRITE_SETTINGS_HELP = 'Overwrite the existing settings file.'
 
 
 # pylint: disable=unused-argument
@@ -106,6 +114,15 @@ def load_arguments(self, command):
             type=str,
             required=False,
             help=SETTINGS_HELP)
+        arg_context.argument(
+            OVERWRITE,
+            options_list=OVERWRITE_OPTIONS,
+            type=bool,
+            required=False,
+            nargs='?',
+            default=False,
+            const=True,
+            help=OVERWRITE_HELP)
 
     with ArgumentsContext(self, _CREATE) as arg_context:
         arg_context.argument(
@@ -156,6 +173,15 @@ def load_arguments(self, command):
             type=str,
             required=False,
             help=SETTINGS_HELP)
+        arg_context.argument(
+            OVERWRITE_SETTINGS,
+            options_list=OVERWRITE_SETTINGS_OPTIONS,
+            type=bool,
+            required=False,
+            nargs='?',
+            default=False,
+            const=True,
+            help=OVERWRITE_SETTINGS_HELP)
 
     with ArgumentsContext(self, _UPDATE) as arg_context:
         arg_context.argument(

--- a/tools/paconn-cli/paconn/commands/update.py
+++ b/tools/paconn-cli/paconn/commands/update.py
@@ -10,7 +10,7 @@ Update command.
 from paconn import _UPDATE
 from paconn.common.util import display
 from paconn.settings.util import load_settings_and_powerapps_rp
-from paconn.operations.create_update import create_update
+from paconn.operations.upsert import upsert
 
 
 # pylint: disable=too-many-arguments
@@ -38,10 +38,11 @@ def update(
         powerapps_version=powerapps_version,
         command_context=_UPDATE)
 
-    connector_id = create_update(
+    connector_id = upsert(
         powerapps_rp=powerapps_rp,
         settings=settings,
         client_secret=client_secret,
-        is_update=True)
+        is_update=True,
+        overwrite=False)
 
     display('{} updated successfully.'.format(connector_id))

--- a/tools/paconn-cli/paconn/common/util.py
+++ b/tools/paconn-cli/paconn/common/util.py
@@ -11,6 +11,7 @@ import os
 import json
 
 from knack.util import CLIError
+from knack.prompting import prompt_y_n
 
 
 def get_config_dir():
@@ -46,6 +47,23 @@ def ensure_file_exists(file, file_type):
     """
 
     if not file:
-        raise CLIError('{file_type} must be specified.'.format(file_type=file_type))
+        raise CLIError('{} must be specified.'.format(file_type))
     if not os.path.exists(file):
-        raise CLIError('File does not exist: {file}'.format(file=file))
+        raise CLIError('File does not exist: {}'.format(file))
+
+
+def ensure_overwrite(filename):
+    overwrite = True
+    if os.path.exists(filename):
+        msg = '{} file exists. Do you want to overwrite?'.format(filename)
+        overwrite = prompt_y_n(msg)
+
+    return overwrite
+
+
+def write_with_prompt(filename, mode, content, overwrite):
+    if not overwrite:
+        overwrite = ensure_overwrite(filename)
+
+    if overwrite:
+        open(filename, mode=mode).write(content)

--- a/tools/paconn-cli/paconn/operations/upsert.py
+++ b/tools/paconn-cli/paconn/operations/upsert.py
@@ -14,6 +14,7 @@ import urllib.parse
 from knack.util import CLIError
 
 from paconn.common.util import ensure_file_exists
+from paconn.settings.util import write_settings
 from paconn.apimanager.iconuploader import upload_icon
 from paconn.operations.json_keys import (
     _PROPERTIES,
@@ -59,7 +60,7 @@ def _create_backendservice_url(openapi_definition):
     return url
 
 
-def create_update(powerapps_rp, settings, client_secret, is_update):
+def upsert(powerapps_rp, settings, client_secret, is_update, overwrite_settings):
     """
     Method for create/update operation
     """
@@ -137,5 +138,9 @@ def create_update(powerapps_rp, settings, client_secret, is_update):
             environment=settings.environment,
             payload=property_definition)
         connector_id = json.loads(api_registration)[_NAME]
+
+        # Save the settings
+        settings.connector_id = connector_id
+        write_settings(settings, overwrite_settings)
 
     return connector_id

--- a/tools/paconn-cli/paconn/settings/settingsserializer.py
+++ b/tools/paconn-cli/paconn/settings/settingsserializer.py
@@ -35,12 +35,20 @@ class SettingsSerializer:
     Serializes and deserializes a settings object
     """
     @staticmethod
+    def to_json_string(settings):
+        """
+        Serializes a settings object into string
+        """
+        settings_dict = SettingsSerializer.serialize(settings)
+        json_str = format_json(settings_dict)
+        return json_str
+
+    @staticmethod
     def to_json(settings, filename):
         """
         Serializes a settings object into the settings.json
         """
-        settings_dict = SettingsSerializer.serialize(settings)
-        json_str = format_json(settings_dict)
+        json_str = SettingsSerializer.to_json_string(settings)
         open(filename, 'w').write(json_str)
 
     @staticmethod

--- a/tools/paconn-cli/paconn/settings/util.py
+++ b/tools/paconn-cli/paconn/settings/util.py
@@ -8,11 +8,16 @@ Utility for loading settings.
 """
 
 from paconn import _UPDATE, _DOWNLOAD, _VALIDATE
+from paconn.common.util import write_with_prompt
 from paconn.authentication.tokenmanager import TokenManager
 from paconn.apimanager.powerappsrpbuilder import PowerAppsRPBuilder
 from paconn.apimanager.flowrpbuilder import FlowRPBuilder
 from paconn.common.prompts import get_environment, get_connector_id
 from paconn.settings.settingsbuilder import SettingsBuilder
+from paconn.settings.settingsserializer import SettingsSerializer
+
+# Setting file name
+SETTINGS_FILE = 'settings.json'
 
 
 def prompt_for_environment(settings, flow_rp):
@@ -87,3 +92,13 @@ def load_settings_and_powerapps_rp(
             powerapps_rp=powerapps_rp)
 
     return settings, powerapps_rp, flow_rp
+
+
+def write_settings(settings, overwrite):
+    filename = SETTINGS_FILE
+    settings_json = SettingsSerializer.to_json_string(settings)
+    write_with_prompt(
+        filename=filename,
+        mode='w',
+        content=settings_json,
+        overwrite=overwrite)


### PR DESCRIPTION
- Specified directory during download is created when doesn't exists, but no extra sub-drectory with connector_id is created.
- A sub-drectory with connector_id is still created when destination parameter isn't specified during download.
- A --overwrite option is added during download. When this is parameter specified ALL destination file will be overwritten. Customer will be prompted for file replacement when this parameter is not specified.
- A settings file is now written after the create operation.
- A --overwriter-setting option is added for create. When this is parameter specified the settings file will be overwritten. Customer will be prompted for settings file replacement when this parameter is not specified.



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).
