### PR TITLE
Update apiDefinition.swagger.json

### DIFF
--- a/samples/Facebook/apiDefinition.swagger.json
+++ b/samples/Facebook/apiDefinition.swagger.json
@@ -381,6 +381,15 @@
             "x-ms-visibility": "important"
           },
           {
+            "description": "URL to post",
+            "in": "query",
+            "name": "link",
+            "required": false,
+            "type": "string",
+            "x-ms-summary": "URL to post",
+            "x-ms-visibility": "important"
+          },          
+          {
             "description": "Page access token.",
             "in": "query",
             "name": "access_token",


### PR DESCRIPTION
Adds a non-required parameter / input to the "PostToMyPage" operation so you can specify a URL / Link.  Posting the link directly in the message doesn't "expand" the URL on Facebook to use the social media cards/details.  (the "link" parameter is documented per Facebook)



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).
