### PR TITLE
Preserve the original swagger during download

### DIFF
--- a/tools/paconn-cli/paconn/operations/download.py
+++ b/tools/paconn-cli/paconn/operations/download.py
@@ -132,7 +132,11 @@ def download(powerapps_rp, settings, destination, overwrite):
         original_swagger_url = api_properties[_API_DEFINITIONS][_ORIGINAL_SWAGGER_URL]
         response = requests.get(original_swagger_url, allow_redirects=True)
         response_string = response.content.decode('utf-8-sig')
-        swagger = format_json(json.loads(response_string))
+        # NOTE: The following line is creating issues for partners.
+        # We should add an option to pretty format the swagger file.
+        # Until then, lets preserve the original swagger as is.
+        # swagger = format_json(json.loads(response_string))
+        swagger = response_string
         open(
             file=settings.api_definition,
             mode='w'


### PR DESCRIPTION
It looks like the CLI tool is re-writing the swagger JSON file.  So, folks see a difference in the behavior (esp the ordering of parameters).  We now have quite a few partners reporting this issue.
This is just a temporary fix to preserve the original swagger until we have a proper fix.



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).
