### PR TITLE
[VS Code] Add schemas for common files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,16 +1,53 @@
 {
+  "files.associations": {
+    "*.schema.json": "jsonc"
+  },
+  "editor.insertSpaces": true,
+  "[json]": {
     "editor.insertSpaces": true,
-    "[json]": {
-        "editor.detectIndentation": false,
-        "editor.tabSize": 2,
-        "files.trimTrailingWhitespace": true
+    "editor.detectIndentation": false,
+    "editor.tabSize": 2,
+    "files.trimTrailingWhitespace": true,
+    "editor.quickSuggestions": {
+      "strings": true
     },
-    "json.schemas": [
-        {
-            "fileMatch": [
-                "/apiDefinition.swagger.json"
-            ],
-            "url": "http://json.schemastore.org/swagger-2.0"
-        }
-    ]
+    "editor.suggest.insertMode": "replace"
+  },
+  "[jsonc]": {
+    "editor.insertSpaces": true,
+    "editor.detectIndentation": false,
+    "editor.tabSize": 2,
+    "files.trimTrailingWhitespace": true,
+    "editor.quickSuggestions": {
+      "strings": true
+    },
+    "editor.suggest.insertMode": "replace"
+  },
+  "json.schemas": [
+    {
+      "fileMatch": [
+        "/apiDefinition*.swagger.json"
+      ],
+      "url": "./schemas/apiDefinition.swagger.schema.json"
+    },
+    {
+      "fileMatch": [
+        "/*.swagger.json"
+      ],
+      "url": "http://json.schemastore.org/swagger-2.0"
+    },
+    {
+      "fileMatch": [
+        "/certified-connectors/**/settings.json",
+        "/custom-connectors/**/settings.json"
+      ],
+      "url": "./schemas/paconn-settings.schema.json"
+    },
+    {
+      "fileMatch": [
+        "/apiProperties.json",
+      ],
+      "url": "./schemas/paconn-apiProperties.schema.json"
+    }
+  ]
 }

--- a/schemas/apiDefinition.swagger.schema.json
+++ b/schemas/apiDefinition.swagger.schema.json
@@ -1,0 +1,1607 @@
+{
+  "title": "A JSON Schema for Swagger 2.0 API.",
+  "id": "http://swagger.io/v2/schema.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "swagger",
+    "info",
+    "paths"
+  ],
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-": {
+      "$ref": "#/definitions/vendorExtension"
+    }
+  },
+  "properties": {
+    "swagger": {
+      "type": "string",
+      "enum": [
+        "2.0"
+      ],
+      "description": "The Swagger version of this document."
+    },
+    "info": {
+      "$ref": "#/definitions/info"
+    },
+    "host": {
+      "type": "string",
+      "pattern": "^[^{}/ :\\\\]+(?::\\d+)?$",
+      "description": "The host (name or ip) of the API. Example: 'swagger.io'"
+    },
+    "basePath": {
+      "type": "string",
+      "pattern": "^/",
+      "description": "The base path to the API. Example: '/api'."
+    },
+    "schemes": {
+      "$ref": "#/definitions/schemesList"
+    },
+    "consumes": {
+      "description": "A list of MIME types accepted by the API.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/mediaTypeList"
+        }
+      ]
+    },
+    "produces": {
+      "description": "A list of MIME types the API can produce.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/mediaTypeList"
+        }
+      ]
+    },
+    "paths": {
+      "$ref": "#/definitions/paths"
+    },
+    "definitions": {
+      "$ref": "#/definitions/definitions"
+    },
+    "parameters": {
+      "$ref": "#/definitions/parameterDefinitions"
+    },
+    "responses": {
+      "$ref": "#/definitions/responseDefinitions"
+    },
+    "security": {
+      "$ref": "#/definitions/security"
+    },
+    "securityDefinitions": {
+      "$ref": "#/definitions/securityDefinitions"
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/tag"
+      },
+      "uniqueItems": true
+    },
+    "externalDocs": {
+      "$ref": "#/definitions/externalDocs"
+    }
+  },
+  "definitions": {
+    "info": {
+      "type": "object",
+      "description": "General information about the API.",
+      "required": [
+        "version",
+        "title"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "A unique and precise title of the API."
+        },
+        "version": {
+          "type": "string",
+          "description": "A semantic version number of the API."
+        },
+        "description": {
+          "type": "string",
+          "description": "A longer description of the API. Should be different from the title.  GitHub Flavored Markdown is allowed."
+        },
+        "termsOfService": {
+          "type": "string",
+          "description": "The terms of service for the API."
+        },
+        "contact": {
+          "$ref": "#/definitions/contact"
+        },
+        "license": {
+          "$ref": "#/definitions/license"
+        }
+      }
+    },
+    "contact": {
+      "type": "object",
+      "description": "Contact information for the owners of the API.",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The identifying name of the contact person/organization."
+        },
+        "url": {
+          "type": "string",
+          "description": "The URL pointing to the contact information.",
+          "format": "uri"
+        },
+        "email": {
+          "type": "string",
+          "description": "The email address of the contact person/organization.",
+          "format": "email"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "license": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the license type. It's encouraged to use an OSI compatible license."
+        },
+        "url": {
+          "type": "string",
+          "description": "The URL pointing to the license.",
+          "format": "uri"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "paths": {
+      "type": "object",
+      "description": "Relative paths to the individual endpoints. They must be relative to the 'basePath'.",
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        },
+        "^/": {
+          "$ref": "#/definitions/pathItem"
+        }
+      },
+      "additionalProperties": false
+    },
+    "definitions": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/schema"
+      },
+      "description": "One or more JSON objects describing the schemas being consumed and produced by the API."
+    },
+    "parameterDefinitions": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/parameter"
+      },
+      "description": "One or more JSON representations for parameters"
+    },
+    "responseDefinitions": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/response"
+      },
+      "description": "One or more JSON representations for responses"
+    },
+    "externalDocs": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "information about external documentation",
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "examples": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "mimeType": {
+      "type": "string",
+      "description": "The MIME type of the HTTP message."
+    },
+    "operation": {
+      "type": "object",
+      "required": [
+        "responses"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "summary": {
+          "type": "string",
+          "description": "A brief summary of the operation."
+        },
+        "description": {
+          "type": "string",
+          "description": "A longer description of the operation, GitHub Flavored Markdown is allowed."
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/externalDocs"
+        },
+        "operationId": {
+          "type": "string",
+          "description": "A unique identifier of the operation."
+        },
+        "produces": {
+          "description": "A list of MIME types the API can produce.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/mediaTypeList"
+            }
+          ]
+        },
+        "consumes": {
+          "description": "A list of MIME types the API can consume.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/mediaTypeList"
+            }
+          ]
+        },
+        "parameters": {
+          "$ref": "#/definitions/parametersList"
+        },
+        "responses": {
+          "$ref": "#/definitions/responses"
+        },
+        "schemes": {
+          "$ref": "#/definitions/schemesList"
+        },
+        "deprecated": {
+          "type": "boolean",
+          "default": false
+        },
+        "security": {
+          "$ref": "#/definitions/security"
+        }
+      }
+    },
+    "pathItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "$ref": {
+          "type": "string"
+        },
+        "get": {
+          "$ref": "#/definitions/operation"
+        },
+        "put": {
+          "$ref": "#/definitions/operation"
+        },
+        "post": {
+          "$ref": "#/definitions/operation"
+        },
+        "delete": {
+          "$ref": "#/definitions/operation"
+        },
+        "options": {
+          "$ref": "#/definitions/operation"
+        },
+        "head": {
+          "$ref": "#/definitions/operation"
+        },
+        "patch": {
+          "$ref": "#/definitions/operation"
+        },
+        "parameters": {
+          "$ref": "#/definitions/parametersList"
+        }
+      }
+    },
+    "responses": {
+      "type": "object",
+      "description": "Response objects names can either be any valid HTTP status code or 'default'.",
+      "minProperties": 1,
+      "additionalProperties": false,
+      "patternProperties": {
+        "^([0-9]{3})$|^(default)$": {
+          "$ref": "#/definitions/responseValue"
+        },
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "not": {
+        "type": "object",
+        "additionalProperties": false,
+        "patternProperties": {
+          "^x-": {
+            "$ref": "#/definitions/vendorExtension"
+          }
+        }
+      }
+    },
+    "responseValue": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/response"
+        },
+        {
+          "$ref": "#/definitions/jsonReference"
+        }
+      ]
+    },
+    "response": {
+      "type": "object",
+      "required": [
+        "description"
+      ],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "schema": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/schema"
+            },
+            {
+              "$ref": "#/definitions/fileSchema"
+            }
+          ]
+        },
+        "headers": {
+          "$ref": "#/definitions/headers"
+        },
+        "examples": {
+          "$ref": "#/definitions/examples"
+        }
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "headers": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/header"
+      }
+    },
+    "header": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "array"
+          ]
+        },
+        "format": {
+          "type": "string"
+        },
+        "items": {
+          "$ref": "#/definitions/primitivesItems"
+        },
+        "collectionFormat": {
+          "$ref": "#/definitions/collectionFormat"
+        },
+        "default": {
+          "$ref": "#/definitions/default"
+        },
+        "maximum": {
+          "$ref": "#/definitions/maximum"
+        },
+        "exclusiveMaximum": {
+          "$ref": "#/definitions/exclusiveMaximum"
+        },
+        "minimum": {
+          "$ref": "#/definitions/minimum"
+        },
+        "exclusiveMinimum": {
+          "$ref": "#/definitions/exclusiveMinimum"
+        },
+        "maxLength": {
+          "$ref": "#/definitions/maxLength"
+        },
+        "minLength": {
+          "$ref": "#/definitions/minLength"
+        },
+        "pattern": {
+          "$ref": "#/definitions/pattern"
+        },
+        "maxItems": {
+          "$ref": "#/definitions/maxItems"
+        },
+        "minItems": {
+          "$ref": "#/definitions/minItems"
+        },
+        "uniqueItems": {
+          "$ref": "#/definitions/uniqueItems"
+        },
+        "enum": {
+          "$ref": "#/definitions/enum"
+        },
+        "multipleOf": {
+          "$ref": "#/definitions/multipleOf"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "vendorExtension": {
+      "description": "Any property starting with x- is valid.",
+      "additionalProperties": true,
+      "additionalItems": true
+    },
+    "bodyParameter": {
+      "type": "object",
+      "required": [
+        "name",
+        "in",
+        "schema"
+      ],
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the parameter."
+        },
+        "in": {
+          "type": "string",
+          "description": "Determines the location of the parameter.",
+          "enum": [
+            "body"
+          ]
+        },
+        "required": {
+          "type": "boolean",
+          "description": "Determines whether or not this parameter is required or optional.",
+          "default": false
+        },
+        "schema": {
+          "$ref": "#/definitions/schema"
+        }
+      },
+      "additionalProperties": false
+    },
+    "headerParameterSubSchema": {
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "required": {
+          "type": "boolean",
+          "description": "Determines whether or not this parameter is required or optional.",
+          "default": false
+        },
+        "in": {
+          "type": "string",
+          "description": "Determines the location of the parameter.",
+          "enum": [
+            "header"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "description": "A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the parameter."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "number",
+            "boolean",
+            "integer",
+            "array"
+          ]
+        },
+        "format": {
+          "type": "string"
+        },
+        "items": {
+          "$ref": "#/definitions/primitivesItems"
+        },
+        "collectionFormat": {
+          "$ref": "#/definitions/collectionFormat"
+        },
+        "default": {
+          "$ref": "#/definitions/default"
+        },
+        "maximum": {
+          "$ref": "#/definitions/maximum"
+        },
+        "exclusiveMaximum": {
+          "$ref": "#/definitions/exclusiveMaximum"
+        },
+        "minimum": {
+          "$ref": "#/definitions/minimum"
+        },
+        "exclusiveMinimum": {
+          "$ref": "#/definitions/exclusiveMinimum"
+        },
+        "maxLength": {
+          "$ref": "#/definitions/maxLength"
+        },
+        "minLength": {
+          "$ref": "#/definitions/minLength"
+        },
+        "pattern": {
+          "$ref": "#/definitions/pattern"
+        },
+        "maxItems": {
+          "$ref": "#/definitions/maxItems"
+        },
+        "minItems": {
+          "$ref": "#/definitions/minItems"
+        },
+        "uniqueItems": {
+          "$ref": "#/definitions/uniqueItems"
+        },
+        "enum": {
+          "$ref": "#/definitions/enum"
+        },
+        "multipleOf": {
+          "$ref": "#/definitions/multipleOf"
+        }
+      }
+    },
+    "queryParameterSubSchema": {
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "required": {
+          "type": "boolean",
+          "description": "Determines whether or not this parameter is required or optional.",
+          "default": false
+        },
+        "in": {
+          "type": "string",
+          "description": "Determines the location of the parameter.",
+          "enum": [
+            "query"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "description": "A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the parameter."
+        },
+        "allowEmptyValue": {
+          "type": "boolean",
+          "default": false,
+          "description": "allows sending a parameter by name only or with an empty value."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "number",
+            "boolean",
+            "integer",
+            "array"
+          ]
+        },
+        "format": {
+          "type": "string"
+        },
+        "items": {
+          "$ref": "#/definitions/primitivesItems"
+        },
+        "collectionFormat": {
+          "$ref": "#/definitions/collectionFormatWithMulti"
+        },
+        "default": {
+          "$ref": "#/definitions/default"
+        },
+        "maximum": {
+          "$ref": "#/definitions/maximum"
+        },
+        "exclusiveMaximum": {
+          "$ref": "#/definitions/exclusiveMaximum"
+        },
+        "minimum": {
+          "$ref": "#/definitions/minimum"
+        },
+        "exclusiveMinimum": {
+          "$ref": "#/definitions/exclusiveMinimum"
+        },
+        "maxLength": {
+          "$ref": "#/definitions/maxLength"
+        },
+        "minLength": {
+          "$ref": "#/definitions/minLength"
+        },
+        "pattern": {
+          "$ref": "#/definitions/pattern"
+        },
+        "maxItems": {
+          "$ref": "#/definitions/maxItems"
+        },
+        "minItems": {
+          "$ref": "#/definitions/minItems"
+        },
+        "uniqueItems": {
+          "$ref": "#/definitions/uniqueItems"
+        },
+        "enum": {
+          "$ref": "#/definitions/enum"
+        },
+        "multipleOf": {
+          "$ref": "#/definitions/multipleOf"
+        }
+      }
+    },
+    "formDataParameterSubSchema": {
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "required": {
+          "type": "boolean",
+          "description": "Determines whether or not this parameter is required or optional.",
+          "default": false
+        },
+        "in": {
+          "type": "string",
+          "description": "Determines the location of the parameter.",
+          "enum": [
+            "formData"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "description": "A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the parameter."
+        },
+        "allowEmptyValue": {
+          "type": "boolean",
+          "default": false,
+          "description": "allows sending a parameter by name only or with an empty value."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "number",
+            "boolean",
+            "integer",
+            "array",
+            "file"
+          ]
+        },
+        "format": {
+          "type": "string"
+        },
+        "items": {
+          "$ref": "#/definitions/primitivesItems"
+        },
+        "collectionFormat": {
+          "$ref": "#/definitions/collectionFormatWithMulti"
+        },
+        "default": {
+          "$ref": "#/definitions/default"
+        },
+        "maximum": {
+          "$ref": "#/definitions/maximum"
+        },
+        "exclusiveMaximum": {
+          "$ref": "#/definitions/exclusiveMaximum"
+        },
+        "minimum": {
+          "$ref": "#/definitions/minimum"
+        },
+        "exclusiveMinimum": {
+          "$ref": "#/definitions/exclusiveMinimum"
+        },
+        "maxLength": {
+          "$ref": "#/definitions/maxLength"
+        },
+        "minLength": {
+          "$ref": "#/definitions/minLength"
+        },
+        "pattern": {
+          "$ref": "#/definitions/pattern"
+        },
+        "maxItems": {
+          "$ref": "#/definitions/maxItems"
+        },
+        "minItems": {
+          "$ref": "#/definitions/minItems"
+        },
+        "uniqueItems": {
+          "$ref": "#/definitions/uniqueItems"
+        },
+        "enum": {
+          "$ref": "#/definitions/enum"
+        },
+        "multipleOf": {
+          "$ref": "#/definitions/multipleOf"
+        }
+      }
+    },
+    "pathParameterSubSchema": {
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "required": [
+        "required"
+      ],
+      "properties": {
+        "required": {
+          "type": "boolean",
+          "enum": [
+            true
+          ],
+          "description": "Determines whether or not this parameter is required or optional."
+        },
+        "in": {
+          "type": "string",
+          "description": "Determines the location of the parameter.",
+          "enum": [
+            "path"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "description": "A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the parameter."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "number",
+            "boolean",
+            "integer",
+            "array"
+          ]
+        },
+        "format": {
+          "type": "string"
+        },
+        "items": {
+          "$ref": "#/definitions/primitivesItems"
+        },
+        "collectionFormat": {
+          "$ref": "#/definitions/collectionFormat"
+        },
+        "default": {
+          "$ref": "#/definitions/default"
+        },
+        "maximum": {
+          "$ref": "#/definitions/maximum"
+        },
+        "exclusiveMaximum": {
+          "$ref": "#/definitions/exclusiveMaximum"
+        },
+        "minimum": {
+          "$ref": "#/definitions/minimum"
+        },
+        "exclusiveMinimum": {
+          "$ref": "#/definitions/exclusiveMinimum"
+        },
+        "maxLength": {
+          "$ref": "#/definitions/maxLength"
+        },
+        "minLength": {
+          "$ref": "#/definitions/minLength"
+        },
+        "pattern": {
+          "$ref": "#/definitions/pattern"
+        },
+        "maxItems": {
+          "$ref": "#/definitions/maxItems"
+        },
+        "minItems": {
+          "$ref": "#/definitions/minItems"
+        },
+        "uniqueItems": {
+          "$ref": "#/definitions/uniqueItems"
+        },
+        "enum": {
+          "$ref": "#/definitions/enum"
+        },
+        "multipleOf": {
+          "$ref": "#/definitions/multipleOf"
+        }
+      }
+    },
+    "nonBodyParameter": {
+      "type": "object",
+      "required": [
+        "name",
+        "in",
+        "type"
+      ],
+      "oneOf": [
+        {
+          "$ref": "#/definitions/headerParameterSubSchema"
+        },
+        {
+          "$ref": "#/definitions/formDataParameterSubSchema"
+        },
+        {
+          "$ref": "#/definitions/queryParameterSubSchema"
+        },
+        {
+          "$ref": "#/definitions/pathParameterSubSchema"
+        }
+      ]
+    },
+    "parameter": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/bodyParameter"
+        },
+        {
+          "$ref": "#/definitions/nonBodyParameter"
+        }
+      ]
+    },
+    "schema": {
+      "type": "object",
+      "description": "A deterministic version of a JSON Schema object.",
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "$ref": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "title": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
+        },
+        "description": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/description"
+        },
+        "default": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/default"
+        },
+        "multipleOf": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/multipleOf"
+        },
+        "maximum": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/maximum"
+        },
+        "exclusiveMaximum": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMaximum"
+        },
+        "minimum": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/minimum"
+        },
+        "exclusiveMinimum": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMinimum"
+        },
+        "maxLength": {
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+        },
+        "minLength": {
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+        },
+        "pattern": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/pattern"
+        },
+        "maxItems": {
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+        },
+        "minItems": {
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+        },
+        "uniqueItems": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/uniqueItems"
+        },
+        "maxProperties": {
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+        },
+        "minProperties": {
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+        },
+        "required": {
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray"
+        },
+        "enum": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/enum"
+        },
+        "additionalProperties": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/schema"
+            },
+            {
+              "type": "boolean"
+            }
+          ],
+          "default": {}
+        },
+        "type": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/type"
+        },
+        "items": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/schema"
+            },
+            {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/definitions/schema"
+              }
+            }
+          ],
+          "default": {}
+        },
+        "allOf": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/schema"
+          }
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/schema"
+          },
+          "default": {}
+        },
+        "discriminator": {
+          "type": "string"
+        },
+        "readOnly": {
+          "type": "boolean",
+          "default": false
+        },
+        "xml": {
+          "$ref": "#/definitions/xml"
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/externalDocs"
+        },
+        "example": {}
+      },
+      "additionalProperties": false
+    },
+    "fileSchema": {
+      "type": "object",
+      "description": "A deterministic version of a JSON Schema object.",
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "format": {
+          "type": "string"
+        },
+        "title": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
+        },
+        "description": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/description"
+        },
+        "default": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/default"
+        },
+        "required": {
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "file"
+          ]
+        },
+        "readOnly": {
+          "type": "boolean",
+          "default": false
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/externalDocs"
+        },
+        "example": {}
+      },
+      "additionalProperties": false
+    },
+    "primitivesItems": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "array"
+          ]
+        },
+        "format": {
+          "type": "string"
+        },
+        "items": {
+          "$ref": "#/definitions/primitivesItems"
+        },
+        "collectionFormat": {
+          "$ref": "#/definitions/collectionFormat"
+        },
+        "default": {
+          "$ref": "#/definitions/default"
+        },
+        "maximum": {
+          "$ref": "#/definitions/maximum"
+        },
+        "exclusiveMaximum": {
+          "$ref": "#/definitions/exclusiveMaximum"
+        },
+        "minimum": {
+          "$ref": "#/definitions/minimum"
+        },
+        "exclusiveMinimum": {
+          "$ref": "#/definitions/exclusiveMinimum"
+        },
+        "maxLength": {
+          "$ref": "#/definitions/maxLength"
+        },
+        "minLength": {
+          "$ref": "#/definitions/minLength"
+        },
+        "pattern": {
+          "$ref": "#/definitions/pattern"
+        },
+        "maxItems": {
+          "$ref": "#/definitions/maxItems"
+        },
+        "minItems": {
+          "$ref": "#/definitions/minItems"
+        },
+        "uniqueItems": {
+          "$ref": "#/definitions/uniqueItems"
+        },
+        "enum": {
+          "$ref": "#/definitions/enum"
+        },
+        "multipleOf": {
+          "$ref": "#/definitions/multipleOf"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "security": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/securityRequirement"
+      },
+      "uniqueItems": true
+    },
+    "securityRequirement": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "uniqueItems": true
+      }
+    },
+    "xml": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": "string"
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "attribute": {
+          "type": "boolean",
+          "default": false
+        },
+        "wrapped": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "tag": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/externalDocs"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "securityDefinitions": {
+      "type": "object",
+      "additionalProperties": {
+        "oneOf": [
+          {
+            "$ref": "#/definitions/basicAuthenticationSecurity"
+          },
+          {
+            "$ref": "#/definitions/apiKeySecurity"
+          },
+          {
+            "$ref": "#/definitions/oauth2ImplicitSecurity"
+          },
+          {
+            "$ref": "#/definitions/oauth2PasswordSecurity"
+          },
+          {
+            "$ref": "#/definitions/oauth2ApplicationSecurity"
+          },
+          {
+            "$ref": "#/definitions/oauth2AccessCodeSecurity"
+          }
+        ]
+      }
+    },
+    "basicAuthenticationSecurity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "basic"
+          ]
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "apiKeySecurity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "name",
+        "in"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "apiKey"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "in": {
+          "type": "string",
+          "enum": [
+            "header",
+            "query"
+          ]
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "oauth2ImplicitSecurity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "flow",
+        "authorizationUrl"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "oauth2"
+          ]
+        },
+        "flow": {
+          "type": "string",
+          "enum": [
+            "implicit"
+          ]
+        },
+        "scopes": {
+          "$ref": "#/definitions/oauth2Scopes"
+        },
+        "authorizationUrl": {
+          "type": "string",
+          "format": "uri"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "oauth2PasswordSecurity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "flow",
+        "tokenUrl"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "oauth2"
+          ]
+        },
+        "flow": {
+          "type": "string",
+          "enum": [
+            "password"
+          ]
+        },
+        "scopes": {
+          "$ref": "#/definitions/oauth2Scopes"
+        },
+        "tokenUrl": {
+          "type": "string",
+          "format": "uri"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "oauth2ApplicationSecurity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "flow",
+        "tokenUrl"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "oauth2"
+          ]
+        },
+        "flow": {
+          "type": "string",
+          "enum": [
+            "application"
+          ]
+        },
+        "scopes": {
+          "$ref": "#/definitions/oauth2Scopes"
+        },
+        "tokenUrl": {
+          "type": "string",
+          "format": "uri"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "oauth2AccessCodeSecurity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "flow",
+        "authorizationUrl",
+        "tokenUrl"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "oauth2"
+          ]
+        },
+        "flow": {
+          "type": "string",
+          "enum": [
+            "accessCode"
+          ]
+        },
+        "scopes": {
+          "$ref": "#/definitions/oauth2Scopes"
+        },
+        "authorizationUrl": {
+          "type": "string",
+          "format": "uri"
+        },
+        "tokenUrl": {
+          "type": "string",
+          "format": "uri"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "oauth2Scopes": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "mediaTypeList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/mimeType"
+      },
+      "uniqueItems": true
+    },
+    "parametersList": {
+      "type": "array",
+      "description": "The parameters needed to send a valid API call.",
+      "additionalItems": false,
+      "items": {
+        "oneOf": [
+          {
+            "$ref": "#/definitions/parameter"
+          },
+          {
+            "$ref": "#/definitions/jsonReference"
+          }
+        ]
+      },
+      "uniqueItems": true
+    },
+    "schemesList": {
+      "type": "array",
+      "description": "The transfer protocol of the API.",
+      "items": {
+        "type": "string",
+        "enum": [
+          "http",
+          "https",
+          "ws",
+          "wss"
+        ]
+      },
+      "uniqueItems": true
+    },
+    "collectionFormat": {
+      "type": "string",
+      "enum": [
+        "csv",
+        "ssv",
+        "tsv",
+        "pipes"
+      ],
+      "default": "csv"
+    },
+    "collectionFormatWithMulti": {
+      "type": "string",
+      "enum": [
+        "csv",
+        "ssv",
+        "tsv",
+        "pipes",
+        "multi"
+      ],
+      "default": "csv"
+    },
+    "title": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
+    },
+    "description": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/description"
+    },
+    "default": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/default"
+    },
+    "multipleOf": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/multipleOf"
+    },
+    "maximum": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/maximum"
+    },
+    "exclusiveMaximum": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMaximum"
+    },
+    "minimum": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/minimum"
+    },
+    "exclusiveMinimum": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMinimum"
+    },
+    "maxLength": {
+      "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+    },
+    "minLength": {
+      "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+    },
+    "pattern": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/pattern"
+    },
+    "maxItems": {
+      "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+    },
+    "minItems": {
+      "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+    },
+    "uniqueItems": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/uniqueItems"
+    },
+    "enum": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/enum"
+    },
+    "jsonReference": {
+      "type": "object",
+      "required": [
+        "$ref"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "$ref": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/schemas/apiDefinition.swagger.schema.json
+++ b/schemas/apiDefinition.swagger.schema.json
@@ -10,7 +10,10 @@
   ],
   "additionalProperties": false,
   "patternProperties": {
-    "^x-": {
+    "^x-ms-": {
+      "$ref": "#/definitions/x-ms-*"
+    },
+    "^x-(?!ms-)": {
       "$ref": "#/definitions/vendorExtension"
     }
   },
@@ -81,6 +84,9 @@
     },
     "externalDocs": {
       "$ref": "#/definitions/externalDocs"
+    },
+    "x-ms-capabilities": {
+      "$ref": "#/definitions/x-ms-capabilities"
     }
   },
   "definitions": {
@@ -93,7 +99,10 @@
       ],
       "additionalProperties": false,
       "patternProperties": {
-        "^x-": {
+        "^x-ms-": {
+          "$ref": "#/definitions/x-ms-*"
+        },
+        "^x-(?!ms-)": {
           "$ref": "#/definitions/vendorExtension"
         }
       },
@@ -119,6 +128,12 @@
         },
         "license": {
           "$ref": "#/definitions/license"
+        },
+        "x-ms-deployment-version": {
+          "$ref": "#/definitions/x-ms-deployment-version"
+        },
+        "x-ms-api-annotation": {
+          "$ref": "#/definitions/x-ms-api-annotation<info>"
         }
       }
     },
@@ -143,7 +158,10 @@
         }
       },
       "patternProperties": {
-        "^x-": {
+        "^x-ms-": {
+          "$ref": "#/definitions/x-ms-*"
+        },
+        "^x-(?!ms-)": {
           "$ref": "#/definitions/vendorExtension"
         }
       }
@@ -166,7 +184,10 @@
         }
       },
       "patternProperties": {
-        "^x-": {
+        "^x-ms-": {
+          "$ref": "#/definitions/x-ms-*"
+        },
+        "^x-(?!ms-)": {
           "$ref": "#/definitions/vendorExtension"
         }
       }
@@ -175,7 +196,10 @@
       "type": "object",
       "description": "Relative paths to the individual endpoints. They must be relative to the 'basePath'.",
       "patternProperties": {
-        "^x-": {
+        "^x-ms-": {
+          "$ref": "#/definitions/x-ms-*"
+        },
+        "^x-(?!ms-)": {
           "$ref": "#/definitions/vendorExtension"
         },
         "^/": {
@@ -187,7 +211,7 @@
     "definitions": {
       "type": "object",
       "additionalProperties": {
-        "$ref": "#/definitions/schema"
+        "$ref": "#/definitions/schema-dynamic-allowed"
       },
       "description": "One or more JSON objects describing the schemas being consumed and produced by the API."
     },
@@ -222,7 +246,10 @@
         }
       },
       "patternProperties": {
-        "^x-": {
+        "^x-ms-": {
+          "$ref": "#/definitions/x-ms-*"
+        },
+        "^x-(?!ms-)": {
           "$ref": "#/definitions/vendorExtension"
         }
       }
@@ -242,7 +269,10 @@
       ],
       "additionalProperties": false,
       "patternProperties": {
-        "^x-": {
+        "^x-ms-": {
+          "$ref": "#/definitions/x-ms-*"
+        },
+        "^x-(?!ms-)": {
           "$ref": "#/definitions/vendorExtension"
         }
       },
@@ -300,6 +330,15 @@
         },
         "security": {
           "$ref": "#/definitions/security"
+        },
+        "x-ms-api-annotation": {
+          "$ref": "#/definitions/x-ms-api-annotation<operation>"
+        },
+        "x-ms-no-generic-test": {
+          "$ref": "#/definitions/x-ms-no-generic-test"
+        },
+        "x-ms-visibility": {
+          "$ref": "#/definitions/x-ms-visibility"
         }
       }
     },
@@ -307,7 +346,10 @@
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {
-        "^x-": {
+        "^x-ms-": {
+          "$ref": "#/definitions/x-ms-*"
+        },
+        "^x-(?!ms-)": {
           "$ref": "#/definitions/vendorExtension"
         }
       },
@@ -350,7 +392,10 @@
         "^([0-9]{3})$|^(default)$": {
           "$ref": "#/definitions/responseValue"
         },
-        "^x-": {
+        "^x-ms-": {
+          "$ref": "#/definitions/x-ms-*"
+        },
+        "^x-(?!ms-)": {
           "$ref": "#/definitions/vendorExtension"
         }
       },
@@ -386,7 +431,7 @@
         "schema": {
           "oneOf": [
             {
-              "$ref": "#/definitions/schema"
+              "$ref": "#/definitions/schema-dynamic-allowed"
             },
             {
               "$ref": "#/definitions/fileSchema"
@@ -402,7 +447,10 @@
       },
       "additionalProperties": false,
       "patternProperties": {
-        "^x-": {
+        "^x-ms-": {
+          "$ref": "#/definitions/x-ms-*"
+        },
+        "^x-(?!ms-)": {
           "$ref": "#/definitions/vendorExtension"
         }
       }
@@ -483,7 +531,10 @@
         }
       },
       "patternProperties": {
-        "^x-": {
+        "^x-ms-": {
+          "$ref": "#/definitions/x-ms-*"
+        },
+        "^x-(?!ms-)": {
           "$ref": "#/definitions/vendorExtension"
         }
       }
@@ -501,7 +552,10 @@
         "schema"
       ],
       "patternProperties": {
-        "^x-": {
+        "^x-ms-": {
+          "$ref": "#/definitions/x-ms-*"
+        },
+        "^x-(?!ms-)": {
           "$ref": "#/definitions/vendorExtension"
         }
       },
@@ -527,7 +581,22 @@
           "default": false
         },
         "schema": {
-          "$ref": "#/definitions/schema"
+          "$ref": "#/definitions/schema-dynamic-allowed"
+        },
+        "x-ms-dynamic-list": {
+          "$ref": "#/definitions/x-ms-dynamic-list"
+        },
+        "x-ms-dynamic-values": {
+          "$ref": "#/definitions/x-ms-dynamic-values"
+        },
+        "x-ms-summary": {
+          "$ref": "#/definitions/x-ms-summary"
+        },
+        "x-ms-test-value": {
+          "$ref": "#/definitions/x-ms-test-value"
+        },
+        "x-ms-visibility": {
+          "$ref": "#/definitions/x-ms-visibility"
         }
       },
       "additionalProperties": false
@@ -535,7 +604,10 @@
     "headerParameterSubSchema": {
       "additionalProperties": false,
       "patternProperties": {
-        "^x-": {
+        "^x-ms-": {
+          "$ref": "#/definitions/x-ms-*"
+        },
+        "^x-(?!ms-)": {
           "$ref": "#/definitions/vendorExtension"
         }
       },
@@ -617,13 +689,31 @@
         },
         "multipleOf": {
           "$ref": "#/definitions/multipleOf"
+        },
+        "x-ms-dynamic-list": {
+          "$ref": "#/definitions/x-ms-dynamic-list"
+        },
+        "x-ms-dynamic-values": {
+          "$ref": "#/definitions/x-ms-dynamic-values"
+        },
+        "x-ms-summary": {
+          "$ref": "#/definitions/x-ms-summary"
+        },
+        "x-ms-test-value": {
+          "$ref": "#/definitions/x-ms-test-value"
+        },
+        "x-ms-visibility": {
+          "$ref": "#/definitions/x-ms-visibility"
         }
       }
     },
     "queryParameterSubSchema": {
       "additionalProperties": false,
       "patternProperties": {
-        "^x-": {
+        "^x-ms-": {
+          "$ref": "#/definitions/x-ms-*"
+        },
+        "^x-(?!ms-)": {
           "$ref": "#/definitions/vendorExtension"
         }
       },
@@ -710,13 +800,31 @@
         },
         "multipleOf": {
           "$ref": "#/definitions/multipleOf"
+        },
+        "x-ms-dynamic-list": {
+          "$ref": "#/definitions/x-ms-dynamic-list"
+        },
+        "x-ms-dynamic-values": {
+          "$ref": "#/definitions/x-ms-dynamic-values"
+        },
+        "x-ms-summary": {
+          "$ref": "#/definitions/x-ms-summary"
+        },
+        "x-ms-test-value": {
+          "$ref": "#/definitions/x-ms-test-value"
+        },
+        "x-ms-visibility": {
+          "$ref": "#/definitions/x-ms-visibility"
         }
       }
     },
     "formDataParameterSubSchema": {
       "additionalProperties": false,
       "patternProperties": {
-        "^x-": {
+        "^x-ms-": {
+          "$ref": "#/definitions/x-ms-*"
+        },
+        "^x-(?!ms-)": {
           "$ref": "#/definitions/vendorExtension"
         }
       },
@@ -804,13 +912,31 @@
         },
         "multipleOf": {
           "$ref": "#/definitions/multipleOf"
+        },
+        "x-ms-dynamic-list": {
+          "$ref": "#/definitions/x-ms-dynamic-list"
+        },
+        "x-ms-dynamic-values": {
+          "$ref": "#/definitions/x-ms-dynamic-values"
+        },
+        "x-ms-summary": {
+          "$ref": "#/definitions/x-ms-summary"
+        },
+        "x-ms-test-value": {
+          "$ref": "#/definitions/x-ms-test-value"
+        },
+        "x-ms-visibility": {
+          "$ref": "#/definitions/x-ms-visibility"
         }
       }
     },
     "pathParameterSubSchema": {
       "additionalProperties": false,
       "patternProperties": {
-        "^x-": {
+        "^x-ms-": {
+          "$ref": "#/definitions/x-ms-*"
+        },
+        "^x-(?!ms-)": {
           "$ref": "#/definitions/vendorExtension"
         }
       },
@@ -897,6 +1023,24 @@
         },
         "multipleOf": {
           "$ref": "#/definitions/multipleOf"
+        },
+        "x-ms-dynamic-list": {
+          "$ref": "#/definitions/x-ms-dynamic-list"
+        },
+        "x-ms-dynamic-values": {
+          "$ref": "#/definitions/x-ms-dynamic-values"
+        },
+        "x-ms-summary": {
+          "$ref": "#/definitions/x-ms-summary"
+        },
+        "x-ms-test-value": {
+          "$ref": "#/definitions/x-ms-test-value"
+        },
+        "x-ms-url-encoding": {
+          "$ref": "#/definitions/x-ms-url-encoding"
+        },
+        "x-ms-visibility": {
+          "$ref": "#/definitions/x-ms-visibility"
         }
       }
     },
@@ -936,7 +1080,10 @@
       "type": "object",
       "description": "A deterministic version of a JSON Schema object.",
       "patternProperties": {
-        "^x-": {
+        "^x-ms-": {
+          "$ref": "#/definitions/x-ms-*"
+        },
+        "^x-(?!ms-)": {
           "$ref": "#/definitions/vendorExtension"
         }
       },
@@ -1057,7 +1204,148 @@
         "externalDocs": {
           "$ref": "#/definitions/externalDocs"
         },
-        "example": {}
+        "example": {},
+        "x-ms-dynamic-list": {
+          "$ref": "#/definitions/x-ms-dynamic-list"
+        },
+        "x-ms-dynamic-values": {
+          "$ref": "#/definitions/x-ms-dynamic-values"
+        },
+        "x-ms-summary": {
+          "$ref": "#/definitions/x-ms-summary"
+        },
+        "x-ms-test-value": {
+          "$ref": "#/definitions/x-ms-test-value"
+        },
+        "x-ms-visibility": {
+          "$ref": "#/definitions/x-ms-visibility"
+        }
+      },
+      "additionalProperties": false
+    },
+    "schema-dynamic-allowed": {
+      "type": "object",
+      "description": "A deterministic version of a JSON Schema object which allows dynamic schema extensions.",
+      "patternProperties": {
+        "^x-ms-": {
+          "$ref": "#/definitions/x-ms-*"
+        },
+        "^x-(?!ms-)": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "$ref": {
+          "type": "string"
+        },
+        "format": {
+          "$ref": "#/definitions/schema/properties/format"
+        },
+        "title": {
+          "$ref": "#/definitions/schema/properties/title"
+        },
+        "description": {
+          "$ref": "#/definitions/schema/properties/description"
+        },
+        "default": {
+          "$ref": "#/definitions/schema/properties/default"
+        },
+        "multipleOf": {
+          "$ref": "#/definitions/schema/properties/multipleOf"
+        },
+        "maximum": {
+          "$ref": "#/definitions/schema/properties/maximum"
+        },
+        "exclusiveMaximum": {
+          "$ref": "#/definitions/schema/properties/exclusiveMaximum"
+        },
+        "minimum": {
+          "$ref": "#/definitions/schema/properties/minimum"
+        },
+        "exclusiveMinimum": {
+          "$ref": "#/definitions/schema/properties/exclusiveMinimum"
+        },
+        "maxLength": {
+          "$ref": "#/definitions/schema/properties/maxLength"
+        },
+        "minLength": {
+          "$ref": "#/definitions/schema/properties/minLength"
+        },
+        "pattern": {
+          "$ref": "#/definitions/schema/properties/pattern"
+        },
+        "maxItems": {
+          "$ref": "#/definitions/schema/properties/maxItems"
+        },
+        "minItems": {
+          "$ref": "#/definitions/schema/properties/minItems"
+        },
+        "uniqueItems": {
+          "$ref": "#/definitions/schema/properties/uniqueItems"
+        },
+        "maxProperties": {
+          "$ref": "#/definitions/schema/properties/maxProperties"
+        },
+        "minProperties": {
+          "$ref": "#/definitions/schema/properties/minProperties"
+        },
+        "required": {
+          "$ref": "#/definitions/schema/properties/required"
+        },
+        "enum": {
+          "$ref": "#/definitions/schema/properties/enum"
+        },
+        "additionalProperties": {
+          "$ref": "#/definitions/schema/properties/additionalProperties"
+        },
+        "type": {
+          "$ref": "#/definitions/schema/properties/type"
+        },
+        "items": {
+          "$ref": "#/definitions/schema/properties/items"
+        },
+        "allOf": {
+          "$ref": "#/definitions/schema/properties/allOf"
+        },
+        "properties": {
+          "$ref": "#/definitions/schema/properties/properties"
+        },
+        "discriminator": {
+          "$ref": "#/definitions/schema/properties/discriminator"
+        },
+        "readOnly": {
+          "$ref": "#/definitions/schema/properties/readOnly"
+        },
+        "xml": {
+          "$ref": "#/definitions/schema/properties/xml"
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/schema/properties/externalDocs"
+        },
+        "example": {
+          "$ref": "#/definitions/schema/properties/example"
+        },
+        "x-ms-dynamic-list": {
+          "$ref": "#/definitions/schema/properties/x-ms-dynamic-list"
+        },
+        "x-ms-dynamic-values": {
+          "$ref": "#/definitions/schema/properties/x-ms-dynamic-values"
+        },
+        "x-ms-summary": {
+          "$ref": "#/definitions/schema/properties/x-ms-summary"
+        },
+        "x-ms-test-value": {
+          "$ref": "#/definitions/schema/properties/x-ms-test-value"
+        },
+        "x-ms-visibility": {
+          "$ref": "#/definitions/schema/properties/x-ms-visibility"
+        },
+        "x-ms-dynamic-schema": {
+          "$ref": "#/definitions/x-ms-dynamic-schema"
+        },
+        "x-ms-dynamic-properties": {
+          "$ref": "#/definitions/x-ms-dynamic-properties"
+        }
       },
       "additionalProperties": false
     },
@@ -1065,7 +1353,10 @@
       "type": "object",
       "description": "A deterministic version of a JSON Schema object.",
       "patternProperties": {
-        "^x-": {
+        "^x-ms-": {
+          "$ref": "#/definitions/x-ms-*"
+        },
+        "^x-(?!ms-)": {
           "$ref": "#/definitions/vendorExtension"
         }
       },
@@ -1169,7 +1460,10 @@
         }
       },
       "patternProperties": {
-        "^x-": {
+        "^x-ms-": {
+          "$ref": "#/definitions/x-ms-*"
+        },
+        "^x-(?!ms-)": {
           "$ref": "#/definitions/vendorExtension"
         }
       }
@@ -1214,7 +1508,10 @@
         }
       },
       "patternProperties": {
-        "^x-": {
+        "^x-ms-": {
+          "$ref": "#/definitions/x-ms-*"
+        },
+        "^x-(?!ms-)": {
           "$ref": "#/definitions/vendorExtension"
         }
       }
@@ -1237,7 +1534,10 @@
         }
       },
       "patternProperties": {
-        "^x-": {
+        "^x-ms-": {
+          "$ref": "#/definitions/x-ms-*"
+        },
+        "^x-(?!ms-)": {
           "$ref": "#/definitions/vendorExtension"
         }
       }
@@ -1285,7 +1585,10 @@
         }
       },
       "patternProperties": {
-        "^x-": {
+        "^x-ms-": {
+          "$ref": "#/definitions/x-ms-*"
+        },
+        "^x-(?!ms-)": {
           "$ref": "#/definitions/vendorExtension"
         }
       }
@@ -1320,7 +1623,10 @@
         }
       },
       "patternProperties": {
-        "^x-": {
+        "^x-ms-": {
+          "$ref": "#/definitions/x-ms-*"
+        },
+        "^x-(?!ms-)": {
           "$ref": "#/definitions/vendorExtension"
         }
       }
@@ -1358,7 +1664,10 @@
         }
       },
       "patternProperties": {
-        "^x-": {
+        "^x-ms-": {
+          "$ref": "#/definitions/x-ms-*"
+        },
+        "^x-(?!ms-)": {
           "$ref": "#/definitions/vendorExtension"
         }
       }
@@ -1396,7 +1705,10 @@
         }
       },
       "patternProperties": {
-        "^x-": {
+        "^x-ms-": {
+          "$ref": "#/definitions/x-ms-*"
+        },
+        "^x-(?!ms-)": {
           "$ref": "#/definitions/vendorExtension"
         }
       }
@@ -1434,7 +1746,10 @@
         }
       },
       "patternProperties": {
-        "^x-": {
+        "^x-ms-": {
+          "$ref": "#/definitions/x-ms-*"
+        },
+        "^x-(?!ms-)": {
           "$ref": "#/definitions/vendorExtension"
         }
       }
@@ -1477,7 +1792,10 @@
         }
       },
       "patternProperties": {
-        "^x-": {
+        "^x-ms-": {
+          "$ref": "#/definitions/x-ms-*"
+        },
+        "^x-(?!ms-)": {
           "$ref": "#/definitions/vendorExtension"
         }
       }
@@ -1602,6 +1920,302 @@
           "type": "string"
         }
       }
+    },
+    "x-ms-*": {
+      "description": "Unknown 'x-ms-' vendor extention. Be sure to use one that is supported.",
+      "not": {
+        "title": "Doesn't match anything"
+      }
+    },
+    "x-ms-api-annotation<info>": {
+      "description": "[TODO] ???",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "Production",
+            "Preview"
+          ]
+        }
+      }
+    },
+    "x-ms-api-annotation<operation>": {
+      "description": "Used for versioning and life cycle management of an operation.",
+      "type": "object",
+      "required": [
+        "family",
+        "revision"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "family": {
+          "title": "Operation family",
+          "description": "Often the operationId of the first version of an operation.",
+          "type": "string"
+        },
+        "revision": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "status": {
+          "$ref": "#/definitions/x-ms-api-annotation<info>/properties/status"
+        },
+        "replacement": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "api": {
+              "type": "string"
+            },
+            "operationId": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "defaultSnippets": [
+        {
+          "label": "",
+          "body": {
+            "family": "${1:OperationId}",
+            "revision": "^${2:1}"
+          }
+        }
+      ]
+    },
+    "x-ms-deployment-version": {
+      "description": "[TODO] ???",
+      "type": "string",
+      "pattern": "^\\d+(\\.\\d+)+$"
+    },
+    "x-ms-dynamic-values": {
+      "description": "",
+      "type": "object",
+      "required": [
+        "operationId"
+      ],
+      "properties": {
+        "operationId": {
+          "description": "The operation that returns the values.",
+          "type": "string"
+        },
+        "parameters": {
+          "$ref": "#/definitions/DynamicOperationCall-parameters-static-or-parameter"
+        },
+        "value-collection": {
+          "description": "A path string that evaluates to an array of objects in the response payload. If value-collection isn't specified, the response is evaluated as an array.",
+          "type": "string"
+        },
+        "value-title": {
+          "description": "A path string in the object inside value-collection that refers to the value's description.",
+          "type": "string"
+        },
+        "value-path": {
+          "description": "A path string in the object inside value-collection that refers to the parameter value.",
+          "type": "string"
+        }
+      },
+      "defaultSnippets": [
+        {
+          "label": "Dynamic Values",
+          "body": {
+            "operationId": "${1}",
+            "value-collection": "${2:value}",
+            "value-title": "${3:Name}",
+            "value-path": "${4:Id}"
+          }
+        }
+      ]
+    },
+    "x-ms-dynamic-list": {
+      "description": "Specifies how the Power Automate designer can provide values for a parameter at design time by calling another operation to get a list of values.",
+      "type": "object",
+      "required": [
+        "operationId"
+      ],
+      "properties": {
+        "operationId": {
+          "description": "The operation that returns the values.",
+          "type": "string"
+        },
+        "parameters": {
+          "$ref": "#/definitions/DynamicOperationCall-parameters-value-or-parameterReference"
+        },
+        "itemsPath": {
+          "description": "A path string that evaluates to an array of objects in the response payload. If `itemsPath` isn't provided, the response is evaluated as an array.",
+          "type": "string"
+        },
+        "itemTitlePath": {
+          "description": "A path string in the object inside `itemsPath` that refers to the value's description.",
+          "type": "string"
+        },
+        "itemValuePath": {
+          "description": "A path string in the object inside `itemsPath` that refers to the item’s value.",
+          "type": "string"
+        }
+      },
+      "defaultSnippets": [
+        {
+          "label": "Dynamic List",
+          "body": {
+            "operationId": "${1}",
+            "itemsPath": "${2:value}",
+            "itemTitlePath": "${3:Name}",
+            "itemValuePath": "${4:Id}"
+          }
+        }
+      ]
+    },
+    "x-ms-dynamic-schema": {
+      "description": "Specifies how the Power Automate designer can provide values for a parameter at design time by calling another operation to get a list of values.",
+      "type": "object",
+      "required": [
+        "operationId"
+      ],
+      "properties": {
+        "operationId": {
+          "description": "The operation that returns the schema.",
+          "type": "string"
+        },
+        "parameters": {
+          "$ref": "#/definitions/DynamicOperationCall-parameters-static-or-parameter"
+        },
+        "value-path": {
+          "description": "A path string that refers to the property that has the schema. If not specified, the response is assumed to contain the schema in the root object's properties.",
+          "type": "string"
+        }
+      }
+    },
+    "x-ms-dynamic-properties": {
+      "description": "Specifies how the Power Automate designer can provide values for a parameter at design time by calling another operation to get a list of values.",
+      "type": "object",
+      "required": [
+        "operationId"
+      ],
+      "properties": {
+        "operationId": {
+          "description": "The operation that returns the schema.",
+          "type": "string"
+        },
+        "parameters": {
+          "$ref": "#/definitions/DynamicOperationCall-parameters-value-or-parameterReference"
+        },
+        "itemValuePath": {
+          "description": "A path string that refers to the property that has the schema. If not specified, the response is assumed to contain the schema in the root object.",
+          "type": "string"
+        }
+      }
+    },
+    "DynamicOperationCall-parameters-static-or-parameter": {
+      "description": "An object that provides the input parameters to invoke the operation. Each property is the name of a parameter on the target operation.",
+      "type": "object",
+      "additionalProperties": {
+        "oneOf": [
+          {
+            "description": "The literal value to be used for the input parameter.",
+            "type": [
+              "boolean",
+              "integer",
+              "number",
+              "string"
+            ]
+          },
+          {
+            "description": "A reference to a parameter on the source operation.",
+            "type": "object",
+            "required": [
+              "parameter"
+            ],
+            "properties": {
+              "parameter": {
+                "description": "The name of the parameter to use from the caller as the value for the dynamic call.",
+                "type": "string"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "DynamicOperationCall-parameters-value-or-parameterReference": {
+      "description": "An object that provides the input parameters to invoke the operation. Each property is the name of a parameter on the target operation.",
+      "type": "object",
+      "additionalProperties": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "value"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "value": {
+                "description": "The literal value to be used for the input parameter.",
+                "type": [
+                  "boolean",
+                  "integer",
+                  "number",
+                  "string",
+                  "array",
+                  "object"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "parameterReference"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "parameterReference": {
+                "description": "This is the full parameter reference path, starting from the parameter name, followed by the path string of the property to be referenced. e.g. 'body/appId'.",
+                "type": "string"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "x-ms-summary": {
+      "title": "Specifies the title for an entity.",
+      "description": "Recommended: Use title case for `x-ms-summary`.",
+      "type": "string"
+    },
+    "x-ms-test-value": {
+      "title": "A sample value to use when running a test.",
+      "description": "The value should be a valid value for this entity.\nDO NOT include any secrets, keys, or personally identifiable data."
+    },
+    "x-ms-no-generic-test": {
+      "type": "boolean"
+    },
+    "x-ms-visibility": {
+      "title": "Specifies the user-facing visibility for an entity.",
+      "type": "string",
+      "enum": [
+        "important",
+        "advanced",
+        "internal"
+      ]
+    },
+    "x-ms-url-encoding": {
+      "title": "Encoding style to use for this parameter",
+      "description": "Identifies if the current path parameter should be double url-encoded `double` or single url-encoded `single`. Absence of this field means `single` encoding.",
+      "type": "string",
+      "enum": [
+        "double",
+        "single"
+      ],
+      "default": "single"
+    },
+    "x-ms-capabilities": {
+      "$ref": "#/definitions/x-ms-NotSupported"
+    },
+    "x-ms-NotSupported": {
+      "title": "This 'x-ms-*' vendor extension is not supported for custom connectors or certified connectors.",
+      "not": {}
     }
   }
 }

--- a/schemas/paconn-apiProperties.schema.json
+++ b/schemas/paconn-apiProperties.schema.json
@@ -44,9 +44,6 @@
     },
     "PolicyTemplateInstance": {
       "anyOf": [
-        // {
-        //   "$ref": "#/definitions/PolicyTemplateInstanceBase"
-        // },
         {
           "oneOf": [
             {
@@ -254,7 +251,7 @@
           "enum": [
             "dynamichosturl",
             "DynamicHostUrl",
-            "dynamicHostUrl" // non-normalized id
+            "dynamicHostUrl"
           ]
         },
         "title": {
@@ -444,7 +441,7 @@
           "enum": [
             "setheader",
             "SetHeader",
-            "setHeader" // non-normalized id
+            "setHeader"
           ]
         },
         "title": {
@@ -540,7 +537,7 @@
           "enum": [
             "setqueryparameter",
             "SetQueryParameter",
-            "setQueryParameter" // non-normalized id
+            "setQueryParameter"
           ]
         },
         "title": {

--- a/schemas/paconn-apiProperties.schema.json
+++ b/schemas/paconn-apiProperties.schema.json
@@ -1,0 +1,743 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "https://github.com/microsoft/PowerPlatformConnectors/blob/master/schemas/paconn-apiProperties.schema.json#",
+  "type": "object",
+  "required": [
+    "properties"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "properties": {
+      "type": "object",
+      "required": [
+        "iconBrandColor"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "iconBrandColor": {
+          "type": "string"
+        },
+        "capabilities": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "connectionParameters": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ConnectionParameter"
+          }
+        },
+        "policyTemplateInstances": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PolicyTemplateInstance"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "ConnectionParameter": {
+      "type": "object"
+    },
+    "PolicyTemplateInstance": {
+      "anyOf": [
+        // {
+        //   "$ref": "#/definitions/PolicyTemplateInstanceBase"
+        // },
+        {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/PolicyTemplateInstance-convertarraytoobject"
+            },
+            {
+              "$ref": "#/definitions/PolicyTemplateInstance-convertobjecttoarray"
+            },
+            {
+              "$ref": "#/definitions/PolicyTemplateInstance-dynamichosturl"
+            },
+            {
+              "$ref": "#/definitions/PolicyTemplateInstance-encodepropertyvalue"
+            },
+            {
+              "$ref": "#/definitions/PolicyTemplateInstance-pollingtrigger"
+            },
+            {
+              "$ref": "#/definitions/PolicyTemplateInstance-routerequesttoendpoint"
+            },
+            {
+              "$ref": "#/definitions/PolicyTemplateInstance-setheader"
+            },
+            {
+              "$ref": "#/definitions/PolicyTemplateInstance-setproperty"
+            },
+            {
+              "$ref": "#/definitions/PolicyTemplateInstance-setqueryparameter"
+            },
+            {
+              "$ref": "#/definitions/PolicyTemplateInstance-setvaluefromurl"
+            },
+            {
+              "$ref": "#/definitions/PolicyTemplateInstance-stringreplace"
+            },
+            {
+              "$ref": "#/definitions/PolicyTemplateInstance-stringtoarray"
+            }
+          ]
+        }
+      ]
+    },
+    "PolicyTemplateInstanceBase": {
+      "type": "object",
+      "required": [
+        "templateId"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "templateId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "title": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "x-ms-apimTemplate-operationName": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "x-ms-apimTemplate-policySection": {
+              "type": "string",
+              "enum": [
+                "Request",
+                "Response"
+              ]
+            }
+          },
+          "patternProperties": {
+            "^x-ms-apimTemplateParameter.\\w+$": {
+              "description": "By convention, most template parameters are named like this."
+            }
+          }
+        }
+      }
+    },
+    "PolicyTemplateInstance-convertarraytoobject": {
+      "type": "object",
+      "required": [
+        "templateId"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "templateId": {
+          "type": "string",
+          "enum": [
+            "convertarraytoobject",
+            "ConvertArrayToObject"
+          ]
+        },
+        "title": {
+          "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/title"
+        },
+        "parameters": {
+          "type": "object",
+          "required": [
+            "x-ms-apimTemplateParameter.propertyParentPath",
+            "x-ms-apimTemplateParameter.keyWithinCollectionPath",
+            "x-ms-apimTemplateParameter.newPropertyPath"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "x-ms-apimTemplate-operationName": {
+              "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-operationName"
+            },
+            "x-ms-apimTemplate-policySection": {
+              "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-policySection"
+            },
+            "x-ms-apimTemplateParameter.propertyParentPath": {
+              "type": "string"
+            },
+            "x-ms-apimTemplateParameter.propertySubPath": {
+              "type": "string",
+              "default": "null"
+            },
+            "x-ms-apimTemplateParameter.keyWithinCollectionPath": {
+              "type": "string"
+            },
+            "x-ms-apimTemplateParameter.newPropertyPath": {
+              "type": "string"
+            },
+            "x-ms-apimTemplateParameter.retainKey": {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "default": "true"
+            }
+          }
+        }
+      }
+    },
+    "PolicyTemplateInstance-convertobjecttoarray": {
+      "type": "object",
+      "required": [
+        "templateId"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "templateId": {
+          "type": "string",
+          "enum": [
+            "convertobjecttoarray",
+            "ConvertObjectToArray"
+          ]
+        },
+        "title": {
+          "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/title"
+        },
+        "parameters": {
+          "type": "object",
+          "required": [
+            "x-ms-apimTemplateParameter.propertyParentPath",
+            "x-ms-apimTemplateParameter.newPropertyPath"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "x-ms-apimTemplate-operationName": {
+              "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-operationName"
+            },
+            "x-ms-apimTemplate-policySection": {
+              "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-policySection"
+            },
+            "x-ms-apimTemplateParameter.propertyParentPath": {
+              "type": "string"
+            },
+            "x-ms-apimTemplateParameter.propertySubPath": {
+              "type": "string",
+              "default": "null"
+            },
+            "x-ms-apimTemplateParameter.newPropertyPath": {
+              "type": "string"
+            },
+            "x-ms-apimTemplateParameter.keyName": {
+              "type": "string",
+              "default": "key"
+            },
+            "x-ms-apimTemplateParameter.valueName": {
+              "type": "string",
+              "default": "value"
+            }
+          }
+        }
+      }
+    },
+    "PolicyTemplateInstance-dynamichosturl": {
+      "type": "object",
+      "required": [
+        "templateId"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "templateId": {
+          "type": "string",
+          "enum": [
+            "dynamichosturl",
+            "DynamicHostUrl",
+            "dynamicHostUrl" // non-normalized id
+          ]
+        },
+        "title": {
+          "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/title"
+        },
+        "parameters": {
+          "type": "object",
+          "required": [
+            "x-ms-apimTemplateParameter.urlTemplate"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "x-ms-apimTemplate-operationName": {
+              "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-operationName"
+            },
+            "x-ms-apimTemplate-policySection": {
+              "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-policySection"
+            },
+            "x-ms-apimTemplateParameter.urlTemplate": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "PolicyTemplateInstance-encodepropertyvalue": {
+      "type": "object",
+      "required": [
+        "templateId"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "templateId": {
+          "type": "string",
+          "enum": [
+            "encodepropertyvalue",
+            "EncodePropertyValue"
+          ]
+        },
+        "title": {
+          "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/title"
+        },
+        "parameters": {
+          "type": "object",
+          "required": [
+            "x-ms-apimTemplateParameter.propertyParentPath",
+            "x-ms-apimTemplateParameter.newPropertyPath"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "x-ms-apimTemplate-operationName": {
+              "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-operationName"
+            },
+            "x-ms-apimTemplate-policySection": {
+              "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-policySection"
+            },
+            "x-ms-apimTemplateParameter.propertyParentPath": {
+              "type": "string"
+            },
+            "x-ms-apimTemplateParameter.propertySubPath": {
+              "type": "string",
+              "default": "null"
+            },
+            "x-ms-apimTemplateParameter.newPropertyPath": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "PolicyTemplateInstance-pollingtrigger": {
+      "type": "object",
+      "required": [
+        "templateId"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "templateId": {
+          "type": "string",
+          "enum": [
+            "pollingtrigger",
+            "PollingTrigger"
+          ]
+        },
+        "title": {
+          "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/title"
+        },
+        "type": {
+          "enum": [
+            "PollingTrigger"
+          ]
+        },
+        "parameters": {
+          "type": "object",
+          "required": [
+            "x-ms-apimTemplateParameter.triggerConfig",
+            "x-ms-apimTemplateParameter.triggerDataPath"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "x-ms-apimTemplate-operationName": {
+              "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-operationName"
+            },
+            "x-ms-apimTemplate-policySection": {
+              "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-policySection"
+            },
+            "x-ms-apimTemplateParameter.triggerConfig": {
+              "type": "object",
+              "description": "A dictionary where each key is a query param name and value is a value expression.\nNote: the key 'x-ms-triggerConfig-nextLink' is a special setting.",
+              "properties": {
+                "x-ms-triggerConfig-nextLink": {
+                  "type": "string",
+                  "format": "uri",
+                  "description": "The property name on the root response result object that is the semantic 'nextLink' to the next page of results. If not specified, the default at runtime is '@odata.nextLink'."
+                }
+              },
+              "additionalProperties": {
+                "description": "The value of the querystring parameter (property name is the parameter name) which may utilize SOME expression syntax."
+              }
+            },
+            "x-ms-apimTemplateParameter.triggerDataPath": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "PolicyTemplateInstance-routerequesttoendpoint": {
+      "type": "object",
+      "required": [
+        "templateId"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "templateId": {
+          "type": "string",
+          "enum": [
+            "routerequesttoendpoint",
+            "RouteRequestToEndpoint"
+          ]
+        },
+        "title": {
+          "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/title"
+        },
+        "parameters": {
+          "type": "object",
+          "required": [
+            "x-ms-apimTemplateParameter.newPath"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "x-ms-apimTemplate-operationName": {
+              "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-operationName"
+            },
+            "x-ms-apimTemplate-policySection": {
+              "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-policySection"
+            },
+            "x-ms-apimTemplateParameter.newPath": {
+              "type": "string"
+            },
+            "x-ms-apimTemplateParameter.httpMethod": {
+              "type": "string",
+              "enum": [
+                "GET",
+                "POST",
+                "PUT",
+                "PATCH",
+                "DELETE",
+                "OPTIONS",
+                "HEAD",
+                "@Request.OriginalHTTPMethod" // Same as not being specified
+              ]
+            }
+          }
+        }
+      }
+    },
+    "PolicyTemplateInstance-setheader": {
+      "type": "object",
+      "required": [
+        "templateId"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "templateId": {
+          "type": "string",
+          "enum": [
+            "setheader",
+            "SetHeader",
+            "setHeader" // non-normalized id
+          ]
+        },
+        "title": {
+          "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/title"
+        },
+        "parameters": {
+          "type": "object",
+          "required": [
+            "x-ms-apimTemplateParameter.name",
+            "x-ms-apimTemplateParameter.value"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "x-ms-apimTemplate-operationName": {
+              "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-operationName"
+            },
+            "x-ms-apimTemplate-policySection": {
+              "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-policySection"
+            },
+            "x-ms-apimTemplateParameter.name": {
+              "type": "string"
+            },
+            "x-ms-apimTemplateParameter.value": {
+              "type": "string"
+            },
+            "x-ms-apimTemplateParameter.existsAction": {
+              "type": "string",
+              "enum": [
+                "override",
+                "skip",
+                "append"
+              ],
+              "default": "override"
+            }
+          }
+        }
+      }
+    },
+    "PolicyTemplateInstance-setproperty": {
+      "type": "object",
+      "required": [
+        "templateId"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "templateId": {
+          "type": "string",
+          "enum": [
+            "setproperty",
+            "SetProperty"
+          ]
+        },
+        "title": {
+          "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/title"
+        },
+        "parameters": {
+          "type": "object",
+          "required": [
+            "x-ms-apimTemplateParameter.newPropertyParentPathTemplate",
+            "x-ms-apimTemplateParameter.newPropertySubPathTemplate",
+            "x-ms-apimTemplateParameter.propertyValuePathTemplate"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "x-ms-apimTemplate-operationName": {
+              "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-operationName"
+            },
+            "x-ms-apimTemplate-policySection": {
+              "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-policySection"
+            },
+            "x-ms-apimTemplateParameter.newPropertyParentPathTemplate": {
+              "type": "string"
+            },
+            "x-ms-apimTemplateParameter.newPropertySubPathTemplate": {
+              "type": "string"
+            },
+            "x-ms-apimTemplateParameter.propertyValuePathTemplate": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "PolicyTemplateInstance-setqueryparameter": {
+      "type": "object",
+      "required": [
+        "templateId"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "templateId": {
+          "type": "string",
+          "enum": [
+            "setqueryparameter",
+            "SetQueryParameter",
+            "setQueryParameter" // non-normalized id
+          ]
+        },
+        "title": {
+          "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/title"
+        },
+        "parameters": {
+          "type": "object",
+          "required": [
+            "x-ms-apimTemplateParameter.name",
+            "x-ms-apimTemplateParameter.value"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "x-ms-apimTemplate-operationName": {
+              "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-operationName"
+            },
+            "x-ms-apimTemplate-policySection": {
+              "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-policySection"
+            },
+            "x-ms-apimTemplateParameter.name": {
+              "type": "string"
+            },
+            "x-ms-apimTemplateParameter.value": {
+              "type": "string"
+            },
+            "x-ms-apimTemplateParameter.existsAction": {
+              "type": "string",
+              "enum": [
+                "override",
+                "skip",
+                "append"
+              ],
+              "default": "override"
+            }
+          }
+        }
+      }
+    },
+    "PolicyTemplateInstance-setvaluefromurl": {
+      "type": "object",
+      "required": [
+        "templateId"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "templateId": {
+          "type": "string",
+          "enum": [
+            "setvaluefromurl",
+            "SetValueFromUrl"
+          ]
+        },
+        "title": {
+          "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/title"
+        },
+        "parameters": {
+          "type": "object",
+          "required": [
+            "x-ms-apimTemplateParameter.parameterTemplate",
+            "x-ms-apimTemplateParameter.parameterValueUrl",
+            "x-ms-apimTemplateParameter.parameterValuePathTemplate"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "x-ms-apimTemplate-operationName": {
+              "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-operationName"
+            },
+            "x-ms-apimTemplate-policySection": {
+              "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-policySection"
+            },
+            "x-ms-apimTemplateParameter.parameterTemplate": {
+              "type": "string"
+            },
+            "x-ms-apimTemplateParameter.parameterValueUrl": {
+              "type": "string"
+            },
+            "x-ms-apimTemplateParameter.parameterValuePathTemplate": {
+              "type": "string"
+            },
+            "x-ms-apimTemplateParameter.httpMethod": {
+              "type": "string",
+              "enum": [
+                "GET",
+                "POST",
+                "PUT"
+              ],
+              "default": "GET"
+            }
+          }
+        }
+      }
+    },
+    "PolicyTemplateInstance-stringreplace": {
+      "type": "object",
+      "required": [
+        "templateId"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "templateId": {
+          "type": "string",
+          "enum": [
+            "stringreplace",
+            "StringReplace"
+          ]
+        },
+        "title": {
+          "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/title"
+        },
+        "parameters": {
+          "type": "object",
+          "required": [
+            "x-ms-apimTemplateParameter.propertyParentPath",
+            "x-ms-apimTemplateParameter.sourceString",
+            "x-ms-apimTemplateParameter.replacementString",
+            "x-ms-apimTemplateParameter.newPropertyPath"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "x-ms-apimTemplate-operationName": {
+              "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-operationName"
+            },
+            "x-ms-apimTemplate-policySection": {
+              "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-policySection"
+            },
+            "x-ms-apimTemplateParameter.propertyParentPath": {
+              "type": "string"
+            },
+            "x-ms-apimTemplateParameter.propertySubPath": {
+              "type": "string",
+              "default": "null"
+            },
+            "x-ms-apimTemplateParameter.sourceString": {
+              "type": "string"
+            },
+            "x-ms-apimTemplateParameter.replacementString": {
+              "type": "string"
+            },
+            "x-ms-apimTemplateParameter.newPropertyPath": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "PolicyTemplateInstance-stringtoarray": {
+      "type": "object",
+      "required": [
+        "templateId"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "templateId": {
+          "type": "string",
+          "enum": [
+            "stringtoarray",
+            "StringToArray"
+          ]
+        },
+        "title": {
+          "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/title"
+        },
+        "parameters": {
+          "type": "object",
+          "required": [
+            "x-ms-apimTemplateParameter.propertyParentPath",
+            "x-ms-apimTemplateParameter.delimiterList",
+            "x-ms-apimTemplateParameter.childPropertyName",
+            "x-ms-apimTemplateParameter.newPropertyPath"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "x-ms-apimTemplate-operationName": {
+              "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-operationName"
+            },
+            "x-ms-apimTemplate-policySection": {
+              "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-policySection"
+            },
+            "x-ms-apimTemplateParameter.propertyParentPath": {
+              "type": "string"
+            },
+            "x-ms-apimTemplateParameter.propertySubPath": {
+              "type": "string",
+              "default": "null"
+            },
+            "x-ms-apimTemplateParameter.delimiterList": {
+              "type": "string"
+            },
+            "x-ms-apimTemplateParameter.childPropertyName": {
+              "type": "string"
+            },
+            "x-ms-apimTemplateParameter.newPropertyPath": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/paconn-settings.schema.json
+++ b/schemas/paconn-settings.schema.json
@@ -9,7 +9,10 @@
       "type": "string"
     },
     "environment": {
-      "type": "string"
+      "title": "The GUID for the Power Apps environment",
+      "description": "Format: '00000000-0000-0000-0000-000000000000'.",
+      "type": "string",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
     },
     "apiProperties": {
       "type": "string",

--- a/schemas/paconn-settings.schema.json
+++ b/schemas/paconn-settings.schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "https://github.com/microsoft/PowerPlatformConnectors/blob/master/schemas/paconn-settings.schema.json#",
+  "type": "object",
+  "required": [],
+  "additionalProperties": false,
+  "properties": {
+    "connectorId": {
+      "type": "string"
+    },
+    "environment": {
+      "type": "string"
+    },
+    "apiProperties": {
+      "type": "string",
+      "default": "apiProperties.json"
+    },
+    "apiDefinition": {
+      "type": "string",
+      "default": "apiDefinition.swagger.json"
+    },
+    "icon": {
+      "type": "string",
+      "default": "icon.png"
+    },
+    "powerAppsUrl": {
+      "type": "string",
+      "format": "uri",
+      "default": "https://api.powerapps.com",
+      "defaultSnippets": [
+        {
+          "label": "PROD",
+          "body": "https://api.powerapps.com"
+        },
+        {
+          "label": "TIP1",
+          "body": "https://tip1.api.powerapps.com"
+        }
+      ]
+    },
+    "powerAppsApiVersion": {
+      "type": "string",
+      "default": "2016-11-01",
+      "enum": [
+        "2016-11-01"
+      ]
+    },
+    "flowUrl": {
+      "type": "string",
+      "format": "uri",
+      "default": "https://api.flow.microsoft.com",
+      "defaultSnippets": [
+        {
+          "label": "PROD",
+          "body": "https://api.flow.microsoft.com"
+        },
+        {
+          "label": "TIP1",
+          "body": "https://tip1.api.flow.microsoft.com"
+        }
+      ]
+    },
+    "flowApiVersion": {
+      "type": "string",
+      "default": "2016-11-01",
+      "enum": [
+        "2016-11-01"
+      ]
+    }
+  },
+  "definitions": {}
+}


### PR DESCRIPTION
[VS Code] Add schemas for common files
- settings.json (paconn settings file)
- apiProperties.json
- apiDefinition.swagger.json

The schema for apiDefinition.swagger.json files is modified from the one found at http://schemastore.org/json/. It includes many 'x-ms-' vendor extensions.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).
