### PR TITLE
[Encodian] Updating outdated brand names

### DIFF
--- a/certified-connectors/Encodian/apiDefinition.swagger.json
+++ b/certified-connectors/Encodian/apiDefinition.swagger.json
@@ -3,7 +3,7 @@
   "info": {
     "version": "v1.0",
     "title": "Encodian",
-    "description": "Enhanced document format conversion, OCR, watermarking, data extraction, redaction + much more. For Flow, Logic Apps and REST.",
+    "description": "Enhanced document format conversion, OCR, watermarking, data extraction, redaction + much more. For Power Automate, Logic Apps and REST.",
     "termsOfService": "https://support.encodian.com/hc/en-gb/articles/360010642813-Terms-of-Service",
     "contact": {
       "name": "Encodian Support",
@@ -11,7 +11,7 @@
       "email": "support@encodian.com"
     },
     "license": {
-      "name": "Requires an 'Encodian PDF Converter for SharePoint Online' or 'Document Manager for Microsoft Flow' subscription",
+      "name": "Requires an 'Encodian PDF Converter for SharePoint Online' or 'Document Manager for Microsoft Power Automate' subscription",
       "url": "https://www.encodian.com/products/document-manager-for-microsoft-flow/"
     },
     "x-ms-api-annotation": {


### PR DESCRIPTION
Updated brand names like below:

Microsoft Flow -> Microsoft Power Automate
Flow -> Power Automate (only in Descriptions & Summaries)
PowerApps -> Power Apps
LogicApps -> Logic Apps