### PR TITLE
[Pushcut] Updating the outdated brand names

### DIFF
--- a/certified-connectors/Pushcut/readme.md
+++ b/certified-connectors/Pushcut/readme.md
@@ -9,4 +9,4 @@ Download Pushcut from the [App Store](https://pushcut.io/appstore) for free to g
 Find the API reference [here](https://www.pushcut.io/help/api_reference). Further documentation about the service can be found at [pushcut.io/help](https://www.pushcut.io/help).
 
 ## Deployment instructions
-Please use [these instructions](https://docs.microsoft.com/en-us/connectors/custom-connectors/paconn-cli) to deploy this connector as custom connector in Microsoft Flow and PowerApps
+Please use [these instructions](https://docs.microsoft.com/en-us/connectors/custom-connectors/paconn-cli) to deploy this connector as custom connector in Microsoft Power Automate and Power Apps


### PR DESCRIPTION
Updated brand names like below:

Microsoft Flow -> Microsoft Power Automate
Flow -> Power Automate (only in Descriptions & Summaries)
PowerApps -> Power Apps
LogicApps -> Logic Apps