### PR TITLE
[RencoreGovernance] Updating the outdated brand names

### DIFF
--- a/certified-connectors/Rencore Governance/readme.md
+++ b/certified-connectors/Rencore Governance/readme.md
@@ -25,4 +25,4 @@ Start by signing in to [Rencore Governance](https://app.rencore.com) using your 
 
 ## Deployment instructions
 
-Please use [these instructions](https://docs.microsoft.com/en-us/connectors/custom-connectors/paconn-cli) to deploy this connector as custom connector in Microsoft Flow and PowerApps
+Please use [these instructions](https://docs.microsoft.com/en-us/connectors/custom-connectors/paconn-cli) to deploy this connector as custom connector in Microsoft Power Automate and Power Apps


### PR DESCRIPTION
Updated brand names like below:

Microsoft Flow -> Microsoft Power Automate
Flow -> Power Automate (only in Descriptions & Summaries)
PowerApps -> Power Apps
LogicApps -> Logic Apps