### PR TITLE
[Slascone] Updating the outdated brand names

### DIFF
--- a/certified-connectors/Slascone/apiDefinition.swagger.json
+++ b/certified-connectors/Slascone/apiDefinition.swagger.json
@@ -339,7 +339,7 @@
   },
   "host": "api.slascone.com",
   "info": {
-    "description": "Connect any third-party software to your Slascone Enviroment via this Flow Connector.",
+    "description": "Connect any third-party software to your Slascone Enviroment via this Power Automate Connector.",
     "title": "Slascone",
     "version": "1.0"
   },
@@ -532,7 +532,7 @@
                   "type": "array"
                 },
                 "name": {
-                  "default": "msflow",
+                  "default": "powerautomate",
                   "description": "name",
                   "title": "",
                   "type": "string",


### PR DESCRIPTION
Updated brand names like below:

Microsoft Flow -> Microsoft Power Automate
Flow -> Power Automate (only in Descriptions & Summaries)
PowerApps -> Power Apps
LogicApps -> Logic Apps