### PR TITLE
[Stormboard] Updating the updated brand names

### DIFF
--- a/certified-connectors/Stormboard/apiDefinition.swagger.json
+++ b/certified-connectors/Stormboard/apiDefinition.swagger.json
@@ -3,7 +3,7 @@
   "info": {
     "version": "1.0",
     "title": "Stormboard",
-    "description": "Stormboard Flow Connector"
+    "description": "Stormboard Connector"
   },
   "host": "api.stormboard.com",
   "basePath": "/",
@@ -216,7 +216,7 @@
                 "service": {
                   "title": "params.service",
                   "description": "Service",
-                  "default": "MicrosoftFlow",
+                  "default": "MicrosoftPowerAutomate",
                   "type": "string",
                   "x-ms-summary": "service",
                   "x-ms-visibility": "internal"
@@ -393,7 +393,7 @@
                 "service": {
                   "title": "service",
                   "description": "service",
-                  "default": "MicrosoftFlow",
+                  "default": "MicrosoftPowerAutomate",
                   "type": "string",
                   "x-ms-summary": "service",
                   "x-ms-visibility": "internal"
@@ -577,7 +577,7 @@
                 "service": {
                   "title": "service",
                   "description": "service",
-                  "default": "MicrosoftFlow",
+                  "default": "MicrosoftPowerAutomate",
                   "type": "string",
                   "x-ms-summary": "service",
                   "x-ms-visibility": "internal"
@@ -743,7 +743,7 @@
                 "service": {
                   "title": "service",
                   "description": "service",
-                  "default": "MicrosoftFlow",
+                  "default": "MicrosoftPowerAutomate",
                   "type": "string",
                   "x-ms-summary": "service",
                   "x-ms-visibility": "internal"
@@ -909,7 +909,7 @@
                 "service": {
                   "title": "service",
                   "description": "service",
-                  "default": "MicrosoftFlow",
+                  "default": "MicrosoftPowerAutomate",
                   "type": "string",
                   "x-ms-summary": "service",
                   "x-ms-visibility": "internal"


### PR DESCRIPTION
Updated brand names like below:

Microsoft Flow -> Microsoft Power Automate
Flow -> Power Automate (only in Descriptions & Summaries)
PowerApps -> Power Apps
LogicApps -> Logic Apps