### PR TITLE
[WayWeDo] Updating the outdated brand names

### DIFF
--- a/certified-connectors/Way We Do/apiDefinition.swagger.json
+++ b/certified-connectors/Way We Do/apiDefinition.swagger.json
@@ -389,7 +389,7 @@
             "schema": {
               "properties": {
                 "bot": {
-                  "default": "Microsoft Flow",
+                  "default": "Microsoft Power Automate",
                   "description": "The name of the bot creating the comment",
                   "type": "string",
                   "x-ms-summary": "Bot Name",
@@ -534,7 +534,7 @@
             "schema": {
               "properties": {
                 "bot": {
-                  "default": "Microsoft Flow",
+                  "default": "Microsoft Power Automate",
                   "description": "The name of the bot creating the instance",
                   "type": "string",
                   "x-ms-summary": "Bot Name",
@@ -861,7 +861,7 @@
             "schema": {
               "properties": {
                 "bot": {
-                  "default": "Microsoft Flow",
+                  "default": "Microsoft Power Automate",
                   "description": "The name of the bot that completed the checklist step",
                   "type": "string",
                   "x-ms-summary": "Bot Name",

--- a/certified-connectors/Way We Do/readme.md
+++ b/certified-connectors/Way We Do/readme.md
@@ -26,4 +26,4 @@ The connector supports the following operations:
 
 ## Deployment instructions
 
-Please use [these instructions](https://docs.microsoft.com/en-us/connectors/custom-connectors/paconn-cli) to deploy this connector as custom connector in Microsoft Flow and PowerApps.
+Please use [these instructions](https://docs.microsoft.com/en-us/connectors/custom-connectors/paconn-cli) to deploy this connector as custom connector in Microsoft Power Automate and Power Apps.


### PR DESCRIPTION
Updated brand names like below:

Microsoft Flow -> Microsoft Power Automate
Flow -> Power Automate (only in Descriptions & Summaries)
PowerApps -> Power Apps
LogicApps -> Logic Apps