### PR TITLE
Revert "Add support for $skip in the List group members"

### DIFF
--- a/certified-connectors/AzureAD/apiDefinition.swagger.json
+++ b/certified-connectors/AzureAD/apiDefinition.swagger.json
@@ -314,16 +314,6 @@
             "x-ms-visibility": "advanced",
             "type": "integer",
             "format": "int32"
-          },
-          {
-            "name": "$skip",
-            "in": "query",
-            "description": "Skip the number of results to return",
-            "required": false,
-            "x-ms-summary": "Skip",
-            "x-ms-visibility": "advanced",
-            "type": "integer",
-            "format": "int32"
           }
         ],
         "responses": {


### PR DESCRIPTION
Reverts microsoft/PowerPlatformConnectors#207

The $skip parameter doesn't work for Graph group endpoints.