### PR TITLE
{VS Code} Update schemas

### DIFF
--- a/schemas/apiDefinition.swagger.schema.json
+++ b/schemas/apiDefinition.swagger.schema.json
@@ -1,7 +1,7 @@
 {
-  "title": "A JSON Schema for Swagger 2.0 API.",
-  "id": "http://swagger.io/v2/schema.json#",
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://swagger.io/v2/schema.json#",
+  "title": "A JSON Schema for Swagger 2.0 API.",
   "type": "object",
   "required": [
     "swagger",
@@ -90,6 +90,21 @@
     }
   },
   "definitions": {
+    "$ref": {
+      "description": "Swagger $ref's should only point to objects immediatly under #/definitions, #/parameters, and #/responses.",
+      "type": "string",
+      "defaultSnippets": [
+        {
+          "body": "#/definitions/$0"
+        },
+        {
+          "body": "#/parameters/$0"
+        },
+        {
+          "body": "#/responses/$0"
+        }
+      ]
+    },
     "info": {
       "type": "object",
       "description": "General information about the API.",
@@ -337,6 +352,9 @@
         "x-ms-no-generic-test": {
           "$ref": "#/definitions/x-ms-no-generic-test"
         },
+        "x-ms-pageable": {
+          "$ref": "#/definitions/x-ms-pageable"
+        },
         "x-ms-visibility": {
           "$ref": "#/definitions/x-ms-visibility"
         }
@@ -355,7 +373,7 @@
       },
       "properties": {
         "$ref": {
-          "type": "string"
+          "$ref": "#/definitions/$ref"
         },
         "get": {
           "$ref": "#/definitions/operation"
@@ -1089,10 +1107,25 @@
       },
       "properties": {
         "$ref": {
-          "type": "string"
+          "$ref": "#/definitions/$ref"
         },
         "format": {
-          "type": "string"
+          "description": "Swagger data types plus some Power Platform extensions:\n- `date-no-tz` - Represents an date-time that has no time-offset (ABNF: `full-date 'T' partial-time`).\n- `html` - Tells clients to emit html editor when editing and html viewer when viewing.",
+          "type": "string",
+          "enum": [
+            "int32",
+            "int64",
+            "float",
+            "double",
+            "byte",
+            "binary",
+            "date",
+            "date-time",
+            "password",
+            "date-no-tz",
+            "html",
+            "uri"
+          ]
         },
         "title": {
           "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
@@ -1211,6 +1244,9 @@
         "x-ms-dynamic-values": {
           "$ref": "#/definitions/x-ms-dynamic-values"
         },
+        "x-ms-enum-values": {
+          "$ref": "#/definitions/x-ms-enum-values"
+        },
         "x-ms-summary": {
           "$ref": "#/definitions/x-ms-summary"
         },
@@ -1236,7 +1272,7 @@
       },
       "properties": {
         "$ref": {
-          "type": "string"
+          "$ref": "#/definitions/$ref"
         },
         "format": {
           "$ref": "#/definitions/schema/properties/format"
@@ -1330,6 +1366,9 @@
         },
         "x-ms-dynamic-values": {
           "$ref": "#/definitions/schema/properties/x-ms-dynamic-values"
+        },
+        "x-ms-enum-values": {
+          "$ref": "#/definitions/x-ms-enum-values"
         },
         "x-ms-summary": {
           "$ref": "#/definitions/schema/properties/x-ms-summary"
@@ -1917,7 +1956,7 @@
       "additionalProperties": false,
       "properties": {
         "$ref": {
-          "type": "string"
+          "$ref": "#/definitions/$ref"
         }
       }
     },
@@ -1944,10 +1983,6 @@
     "x-ms-api-annotation<operation>": {
       "description": "Used for versioning and life cycle management of an operation.",
       "type": "object",
-      "required": [
-        "family",
-        "revision"
-      ],
       "additionalProperties": false,
       "properties": {
         "family": {
@@ -1977,7 +2012,7 @@
       },
       "defaultSnippets": [
         {
-          "label": "",
+          "label": "family-revision",
           "body": {
             "family": "${1:OperationId}",
             "revision": "^${2:1}"
@@ -2179,6 +2214,71 @@
         ]
       }
     },
+    "x-ms-no-generic-test": {
+      "type": "boolean"
+    },
+    "x-ms-pageable": {
+      "type": "object",
+      "description": "This extension configures an operation to be pageable.",
+      "required": [
+        "nextLinkName"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "nextLinkName": {
+          "description": "The name of the property at the root of the response that has the next link url.\nUsage: Be sure to use the policy template (id: `updatenextlink`) to enable the correct routing of this link.",
+          "type": "string",
+          "examples": [
+            "@odata.nextLink"
+          ]
+        }
+      },
+      "defaultSnippets": [
+        {
+          "label": "@odata.nextLink",
+          "body": {
+            "nextLinkName": "@odata.nextLink"
+          }
+        }
+      ]
+    },
+    "x-ms-enum-values": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "value",
+          "displayName"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "value": {
+            "title": "The value in the /enum array of the parent schema object for this enum value item."
+          },
+          "displayName": {
+            "title": "The text to display in user interfaces for this enum value. This text is localizable.",
+            "type": "string"
+          }
+        },
+        "defaultSnippets": [
+          {
+            "label": "new item",
+            "body": {
+              "value": "$1",
+              "displayName": "${2:$1}"
+            }
+          }
+        ]
+      },
+      "defaultSnippets": [
+        {
+          "label": "[...]",
+          "body": [
+            "^{\n    \"value\": \"$1\",\n    \"displayName\": \"${2:$1}\"\n  }$0"
+          ]
+        }
+      ]
+    },
     "x-ms-summary": {
       "title": "Specifies the title for an entity.",
       "description": "Recommended: Use title case for `x-ms-summary`.",
@@ -2187,9 +2287,6 @@
     "x-ms-test-value": {
       "title": "A sample value to use when running a test.",
       "description": "The value should be a valid value for this entity.\nDO NOT include any secrets, keys, or personally identifiable data."
-    },
-    "x-ms-no-generic-test": {
-      "type": "boolean"
     },
     "x-ms-visibility": {
       "title": "Specifies the user-facing visibility for an entity.",

--- a/schemas/paconn-apiProperties.schema.json
+++ b/schemas/paconn-apiProperties.schema.json
@@ -1,12 +1,19 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "id": "https://github.com/microsoft/PowerPlatformConnectors/blob/master/schemas/paconn-apiProperties.schema.json#",
+  "id": "https://raw.githubusercontent.com/microsoft/PowerPlatformConnectors/master/schemas/paconn-apiProperties.schema.json#",
+  "title": "The JSON schema for the apiProperties.json files managed by the paconn tool.",
   "type": "object",
   "required": [
     "properties"
   ],
   "additionalProperties": false,
   "properties": {
+    "$schema": {
+      "type": "string",
+      "examples": [
+        "https://raw.githubusercontent.com/microsoft/PowerPlatformConnectors/master/schemas/paconn-apiProperties.schema.json#"
+      ]
+    },
     "properties": {
       "type": "object",
       "required": [
@@ -43,46 +50,94 @@
       "type": "object"
     },
     "PolicyTemplateInstance": {
-      "anyOf": [
+      "oneOf": [
         {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/PolicyTemplateInstance-convertarraytoobject"
-            },
-            {
-              "$ref": "#/definitions/PolicyTemplateInstance-convertobjecttoarray"
-            },
-            {
-              "$ref": "#/definitions/PolicyTemplateInstance-dynamichosturl"
-            },
-            {
-              "$ref": "#/definitions/PolicyTemplateInstance-encodepropertyvalue"
-            },
-            {
-              "$ref": "#/definitions/PolicyTemplateInstance-pollingtrigger"
-            },
-            {
-              "$ref": "#/definitions/PolicyTemplateInstance-routerequesttoendpoint"
-            },
-            {
-              "$ref": "#/definitions/PolicyTemplateInstance-setheader"
-            },
-            {
-              "$ref": "#/definitions/PolicyTemplateInstance-setproperty"
-            },
-            {
-              "$ref": "#/definitions/PolicyTemplateInstance-setqueryparameter"
-            },
-            {
-              "$ref": "#/definitions/PolicyTemplateInstance-setvaluefromurl"
-            },
-            {
-              "$ref": "#/definitions/PolicyTemplateInstance-stringreplace"
-            },
-            {
-              "$ref": "#/definitions/PolicyTemplateInstance-stringtoarray"
+          "$ref": "#/definitions/PolicyTemplateInstance-convertarraytoobject"
+        },
+        {
+          "$ref": "#/definitions/PolicyTemplateInstance-convertobjecttoarray"
+        },
+        {
+          "$ref": "#/definitions/PolicyTemplateInstance-dynamichosturl"
+        },
+        {
+          "$ref": "#/definitions/PolicyTemplateInstance-encodepropertyvalue"
+        },
+        {
+          "$ref": "#/definitions/PolicyTemplateInstance-pollingtrigger"
+        },
+        {
+          "$ref": "#/definitions/PolicyTemplateInstance-routerequesttoendpoint"
+        },
+        {
+          "$ref": "#/definitions/PolicyTemplateInstance-setheader"
+        },
+        {
+          "$ref": "#/definitions/PolicyTemplateInstance-setproperty"
+        },
+        {
+          "$ref": "#/definitions/PolicyTemplateInstance-setqueryparameter"
+        },
+        {
+          "$ref": "#/definitions/PolicyTemplateInstance-setvaluefromurl"
+        },
+        {
+          "$ref": "#/definitions/PolicyTemplateInstance-stringreplace"
+        },
+        {
+          "$ref": "#/definitions/PolicyTemplateInstance-stringtoarray"
+        },
+        {
+          "$ref": "#/definitions/PolicyTemplateInstance-updatenextlink"
+        }
+      ],
+      "defaultSnippets": [
+        {
+          "label": "add new instance",
+          "body": {
+            "templateId": "$0"
+          }
+        },
+        {
+          "label": "Route request to endpoint",
+          "body": {
+            "templateId": "routerequesttoendpoint",
+            "title": "Route to '${1}'",
+            "parameters": {
+              "x-ms-apimTemplate-operationName": [
+                "${2:operationId}$0"
+              ],
+              "x-ms-apimTemplateParameter.newPath": "${1:/new/backend/path}"
             }
-          ]
+          }
+        },
+        {
+          "label": "Update pagination nextLink",
+          "body": {
+            "templateId": "updatenextlink",
+            "title": "Update ${1} property to make paging work",
+            "parameters": {
+              "x-ms-apimTemplate-operationName": [
+                "^\"${2:operationId}\"$0"
+              ],
+              "x-ms-apimTemplateParameter.nextLinkPropertyName": "${1:@odata.nextLink}"
+            }
+          }
+        },
+        {
+          "label": "Set query parameter - default value",
+          "body": {
+            "templateId": "setqueryparameter",
+            "title": "Default value for ${1}",
+            "parameters": {
+              "x-ms-apimTemplate-operationName": [
+                "^\"${4:operationId}\"$0"
+              ],
+              "x-ms-apimTemplateParameter.name": "^\"${1:\\$top}\"",
+              "x-ms-apimTemplateParameter.value": "${2:50}",
+              "x-ms-apimTemplateParameter.existsAction": "${3:skip}"
+            }
+          }
         }
       ]
     },
@@ -114,11 +169,7 @@
               }
             },
             "x-ms-apimTemplate-policySection": {
-              "type": "string",
-              "enum": [
-                "Request",
-                "Response"
-              ]
+              "$ref": "#/definitions/Parameter<x-ms-apimTemplate-policySection>-Request-Response"
             }
           },
           "patternProperties": {
@@ -128,6 +179,21 @@
           }
         }
       }
+    },
+    "Parameter<x-ms-apimTemplate-policySection>-Request-Response": {
+      "type": "string",
+      "enum": [
+        "Request",
+        "Response"
+      ]
+    },
+    "Parameter<x-ms-apimTemplate-policySection>-Request-Response-Failure": {
+      "type": "string",
+      "enum": [
+        "Request",
+        "Response",
+        "Failure"
+      ]
     },
     "PolicyTemplateInstance-convertarraytoobject": {
       "type": "object",
@@ -159,7 +225,7 @@
               "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-operationName"
             },
             "x-ms-apimTemplate-policySection": {
-              "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-policySection"
+              "$ref": "#/definitions/Parameter<x-ms-apimTemplate-policySection>-Request-Response"
             },
             "x-ms-apimTemplateParameter.propertyParentPath": {
               "type": "string"
@@ -215,7 +281,7 @@
               "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-operationName"
             },
             "x-ms-apimTemplate-policySection": {
-              "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-policySection"
+              "$ref": "#/definitions/Parameter<x-ms-apimTemplate-policySection>-Request-Response"
             },
             "x-ms-apimTemplateParameter.propertyParentPath": {
               "type": "string"
@@ -267,9 +333,6 @@
             "x-ms-apimTemplate-operationName": {
               "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-operationName"
             },
-            "x-ms-apimTemplate-policySection": {
-              "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-policySection"
-            },
             "x-ms-apimTemplateParameter.urlTemplate": {
               "type": "string"
             }
@@ -306,7 +369,7 @@
               "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-operationName"
             },
             "x-ms-apimTemplate-policySection": {
-              "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-policySection"
+              "$ref": "#/definitions/Parameter<x-ms-apimTemplate-policySection>-Request-Response"
             },
             "x-ms-apimTemplateParameter.propertyParentPath": {
               "type": "string"
@@ -355,9 +418,6 @@
             "x-ms-apimTemplate-operationName": {
               "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-operationName"
             },
-            "x-ms-apimTemplate-policySection": {
-              "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-policySection"
-            },
             "x-ms-apimTemplateParameter.triggerConfig": {
               "type": "object",
               "description": "A dictionary where each key is a query param name and value is a value expression.\nNote: the key 'x-ms-triggerConfig-nextLink' is a special setting.",
@@ -405,9 +465,6 @@
           "properties": {
             "x-ms-apimTemplate-operationName": {
               "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-operationName"
-            },
-            "x-ms-apimTemplate-policySection": {
-              "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-policySection"
             },
             "x-ms-apimTemplateParameter.newPath": {
               "type": "string"
@@ -459,7 +516,7 @@
               "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-operationName"
             },
             "x-ms-apimTemplate-policySection": {
-              "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-policySection"
+              "$ref": "#/definitions/Parameter<x-ms-apimTemplate-policySection>-Request-Response-Failure"
             },
             "x-ms-apimTemplateParameter.name": {
               "type": "string"
@@ -510,7 +567,7 @@
               "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-operationName"
             },
             "x-ms-apimTemplate-policySection": {
-              "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-policySection"
+              "$ref": "#/definitions/Parameter<x-ms-apimTemplate-policySection>-Request-Response"
             },
             "x-ms-apimTemplateParameter.newPropertyParentPathTemplate": {
               "type": "string"
@@ -553,9 +610,6 @@
           "properties": {
             "x-ms-apimTemplate-operationName": {
               "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-operationName"
-            },
-            "x-ms-apimTemplate-policySection": {
-              "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-policySection"
             },
             "x-ms-apimTemplateParameter.name": {
               "type": "string"
@@ -606,7 +660,7 @@
               "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-operationName"
             },
             "x-ms-apimTemplate-policySection": {
-              "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-policySection"
+              "$ref": "#/definitions/Parameter<x-ms-apimTemplate-policySection>-Request-Response"
             },
             "x-ms-apimTemplateParameter.parameterTemplate": {
               "type": "string"
@@ -661,7 +715,7 @@
               "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-operationName"
             },
             "x-ms-apimTemplate-policySection": {
-              "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-policySection"
+              "$ref": "#/definitions/Parameter<x-ms-apimTemplate-policySection>-Request-Response"
             },
             "x-ms-apimTemplateParameter.propertyParentPath": {
               "type": "string"
@@ -714,7 +768,7 @@
               "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-operationName"
             },
             "x-ms-apimTemplate-policySection": {
-              "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-policySection"
+              "$ref": "#/definitions/Parameter<x-ms-apimTemplate-policySection>-Request-Response"
             },
             "x-ms-apimTemplateParameter.propertyParentPath": {
               "type": "string"
@@ -730,6 +784,42 @@
               "type": "string"
             },
             "x-ms-apimTemplateParameter.newPropertyPath": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "PolicyTemplateInstance-updatenextlink": {
+      "type": "object",
+      "required": [
+        "templateId"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "templateId": {
+          "type": "string",
+          "enum": [
+            "updatenextlink"
+          ]
+        },
+        "title": {
+          "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/title"
+        },
+        "parameters": {
+          "type": "object",
+          "required": [
+            "x-ms-apimTemplateParameter.nextLinkPropertyName"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "x-ms-apimTemplate-operationName": {
+              "$ref": "#/definitions/PolicyTemplateInstanceBase/properties/parameters/properties/x-ms-apimTemplate-operationName"
+            },
+            "x-ms-apimTemplateParameter.nextLinkPropertyName": {
+              "type": "string"
+            },
+            "x-ms-apimTemplateParameter.nextLinkParentPropertyPath": {
               "type": "string"
             }
           }

--- a/schemas/paconn-settings.schema.json
+++ b/schemas/paconn-settings.schema.json
@@ -1,10 +1,17 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "id": "https://github.com/microsoft/PowerPlatformConnectors/blob/master/schemas/paconn-settings.schema.json#",
+  "id": "https://raw.githubusercontent.com/microsoft/PowerPlatformConnectors/master/schemas/paconn-settings.schema.json#",
+  "title": "The JSON schema for the settings.json files managed by the paconn tool.",
   "type": "object",
   "required": [],
   "additionalProperties": false,
   "properties": {
+    "$schema": {
+      "type": "string",
+      "examples": [
+        "https://raw.githubusercontent.com/microsoft/PowerPlatformConnectors/master/schemas/paconn-settings.schema.json#"
+      ]
+    },
     "connectorId": {
       "type": "string"
     },


### PR DESCRIPTION
- Set our custom schemas so their ids point to the raw schema file.
  The initial ids were to an html page. The new ids point to the raw file download.
- added support for the optional "$schema" property so loose files can still get intellisense.

Swagger schema updates:
- Added snippets for swagger $ref properties.
- Added support for `x-ms-pageable`
- Added support for `x-ms-enum-values`
- Added enum for `format`

apiProperties schema
- Added policy template `updatenextlink`
- Added some snippets for policy templates
- Remove erroneous definitions of `x-ms-apimTemplate-policySection`



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).
