### PR TITLE
add the v3.0 GA endpoint to the Text Analytics connector

### DIFF
--- a/certified-connectors/CognitiveServicesTextAnalytics/apiDefinition.swagger.json
+++ b/certified-connectors/CognitiveServicesTextAnalytics/apiDefinition.swagger.json
@@ -1,16 +1,16 @@
 {
   "swagger": "2.0",
   "info": {
-    "version": "v2.0",
+    "version": "v3.0",
     "title": "Text Analytics",
     "description": "Microsoft Cognitive Services Text Analytics detects language, sentiment and more of the text you provide.",
     "contact": {
-      "name": "Azure Machine Learning",
-      "url": "https://gallery.cortanaanalytics.com/MachineLearningAPI/Text-Analytics-2",
+      "name": "Azure Cognitive Services Text Analytics",
+      "url": "https://azure.microsoft.com/en-us/services/cognitive-services/text-analytics/",
       "email": "mlapi@microsoft.com"
     },
     "x-ms-api-annotation": {
-      "status": "Production"
+      "status": "Preview"
     }
   },
   "host": "westus.api.cognitive.microsoft.com",
@@ -175,9 +175,1031 @@
           "revision": 2
         }
       }
+    },
+    "/text/analytics/v3.0/entities/recognition/general": {
+      "post": {
+        "summary": "Named Entity Recognition (V3)",
+        "description": "The API returns a list of general named entities in a given document. For the list of supported entity types, check <a href=\"https://aka.ms/taner\">Supported Entity Types in Text Analytics API</a>. See the <a href=\"https://aka.ms/talangs\">Supported languages in Text Analytics API</a> for the list of enabled languages.",
+        "operationId": "EntitiesRecognitionGeneral",
+        "consumes": [
+          "application/json",
+          "text/json"
+        ],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "name": "model-version",
+            "in": "query",
+            "description": "(Optional) This value indicates which model will be used for scoring. If a model-version is not specified, the API should default to the latest, non-preview version. ",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "showStats",
+            "in": "query",
+            "description": "(Optional) if set to true, response will contain input and document level statistics.",
+            "type": "boolean",
+            "required": false
+          },
+          {
+            "in": "body",
+            "name": "input",
+            "description": "Collection of documents to analyze.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/MultiLanguageBatchInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful call results in a list of recognized entities returned for each valid document.",
+            "schema": {
+              "$ref": "#/definitions/EntitiesResult"
+            }
+          },
+          "default": {
+            "description": "Error Response",
+            "schema": {
+              "$ref": "#/definitions/TextAnalyticsError"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/text/analytics/v3.0/entities/linking": {
+      "post": {
+        "summary": "Entity Linking (V3)",
+        "description": "The API returns a list of recognized entities with links to a well-known knowledge base. See the <a href=\"https://aka.ms/talangs\">Supported languages in Text Analytics API</a> for the list of enabled languages.",
+        "operationId": "EntitiesLinking",
+        "consumes": [
+          "application/json",
+          "text/json"
+        ],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "name": "model-version",
+            "in": "query",
+            "description": "(Optional) This value indicates which model will be used for scoring. If a model-version is not specified, the API should default to the latest, non-preview version. ",
+            "type": "string"
+          },
+          {
+            "name": "showStats",
+            "in": "query",
+            "description": "(Optional) if set to true, response will contain input and document level statistics.",
+            "type": "boolean"
+          },
+          {
+            "in": "body",
+            "name": "input",
+            "description": "Collection of documents to analyze.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/MultiLanguageBatchInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful call results in a list of recognized entities with links to a well-known knowledge base returned for each valid document",
+            "schema": {
+              "$ref": "#/definitions/EntityLinkingResult"
+            }
+          },
+          "default": {
+            "description": "Error Response",
+            "schema": {
+              "$ref": "#/definitions/TextAnalyticsError"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/text/analytics/v3.0/keyPhrases": {
+      "post": {
+        "summary": "Key Phrases (V3)",
+        "description": "The API returns a list of strings denoting the key phrases in the input text. See the <a href=\"https://aka.ms/talangs\">Supported languages in Text Analytics API</a> for the list of enabled languages.",
+        "operationId": "KeyPhrases",
+        "consumes": [
+          "application/json",
+          "text/json"
+        ],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "name": "model-version",
+            "in": "query",
+            "description": "(Optional) This value indicates which model will be used for scoring. If a model-version is not specified, the API should default to the latest, non-preview version. ",
+            "type": "string"
+          },
+          {
+            "name": "showStats",
+            "in": "query",
+            "description": "(Optional) if set to true, response will contain input and document level statistics.",
+            "type": "boolean"
+          },
+          {
+            "in": "body",
+            "name": "input",
+            "description": "Collection of documents to analyze. Documents can now contain a language field to indicate the text language",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/MultiLanguageBatchInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response results in 0 or more key phrases identified in each valid document",
+            "schema": {
+              "$ref": "#/definitions/KeyPhraseResult"
+            }
+          },
+          "default": {
+            "description": "Error Response",
+            "schema": {
+              "$ref": "#/definitions/TextAnalyticsError"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/text/analytics/v3.0/languages": {
+      "post": {
+        "summary": "Detect Language (V3)",
+        "description": "The API returns the detected language and a numeric score between 0 and 1. Scores close to 1 indicate 100% certainty that the identified language is true. See the <a href=\"https://aka.ms/talangs\">Supported languages in Text Analytics API</a> for the list of enabled languages.",
+        "operationId": "Languages",
+        "consumes": [
+          "application/json",
+          "text/json"
+        ],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "name": "model-version",
+            "in": "query",
+            "description": "(Optional) This value indicates which model will be used for scoring. If a model-version is not specified, the API should default to the latest, non-preview version. ",
+            "type": "string"
+          },
+          {
+            "name": "showStats",
+            "in": "query",
+            "description": "(Optional) if set to true, response will contain input and document level statistics.",
+            "type": "boolean"
+          },
+          {
+            "in": "body",
+            "name": "input",
+            "description": "Collection of documents to analyze.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/LanguageBatchInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful call results in the detected language with the highest probability for each valid document",
+            "schema": {
+              "$ref": "#/definitions/LanguageResult"
+            }
+          },
+          "default": {
+            "description": "Error Response",
+            "schema": {
+              "$ref": "#/definitions/TextAnalyticsError"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/text/analytics/v3.0/sentiment": {
+      "post": {
+        "summary": "Sentiment (V3)",
+        "description": "The API returns a sentiment prediction, as well as sentiment scores for each sentiment class (Positive, Negative, and Neutral) for the document and each sentence within it. See the <a href=\"https://aka.ms/talangs\">Supported languages in Text Analytics API</a> for the list of enabled languages.",
+        "operationId": "Sentiment",
+        "consumes": [
+          "application/json",
+          "text/json"
+        ],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "name": "model-version",
+            "in": "query",
+            "description": "(Optional) This value indicates which model will be used for scoring. If a model-version is not specified, the API should default to the latest, non-preview version. ",
+            "type": "string"
+          },
+          {
+            "name": "showStats",
+            "in": "query",
+            "description": "(Optional) if set to true, response will contain input and document level statistics.",
+            "type": "boolean"
+          },
+          {
+            "in": "body",
+            "name": "input",
+            "description": "Collection of documents to analyze.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/MultiLanguageBatchInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful call results in a document sentiment prediction, as well as sentiment scores for each sentiment class (Positive, Negative, and Neutral)",
+            "schema": {
+              "$ref": "#/definitions/SentimentResponse"
+            }
+          },
+          "default": {
+            "description": "Error Response",
+            "schema": {
+              "$ref": "#/definitions/TextAnalyticsError"
+            }
+          }
+        },
+        "deprecated": false
+      }
     }
   },
   "definitions": {
+    "MultiLanguageBatchInput": {
+      "type": "object",
+      "required": [
+        "documents"
+      ],
+      "properties": {
+        "documents": {
+          "type": "array",
+          "description": "The set of documents to process as part of this batch.",
+          "items": {
+            "$ref": "#/definitions/MultiLanguageInput"
+          }
+        }
+      },
+      "description": "Contains a set of input documents to be analyzed by the service."
+    },
+    "MultiLanguageInput": {
+      "type": "object",
+      "required": [
+        "id",
+        "text"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "A unique, non-empty document identifier."
+        },
+        "text": {
+          "type": "string",
+          "description": "The input text to process."
+        },
+        "language": {
+          "type": "string",
+          "description": "(Optional) This is the 2 letter ISO 639-1 representation of a language. For example, use \"en\" for English; \"es\" for Spanish etc. If not set, use \"en\" for English as default."
+        }
+      },
+      "description": "Contains an input document to be analyzed by the service."
+    },
+    "DocumentError": {
+      "type": "object",
+      "required": [
+        "id",
+        "error"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Document Id."
+        },
+        "error": {
+          "type": "object",
+          "description": "Document Error.",
+          "$ref": "#/definitions/TextAnalyticsError"
+        }
+      }
+    },
+    "TextAnalyticsError": {
+      "type": "object",
+      "required": [
+        "code",
+        "message"
+      ],
+      "properties": {
+        "code": {
+          "type": "string",
+          "enum": [
+            "invalidRequest",
+            "invalidArgument",
+            "internalServerError",
+            "serviceUnavailable"
+          ],
+          "x-ms-enum": {
+            "name": "ErrorCodeValue",
+            "modelAsString": false
+          },
+          "description": "Error code."
+        },
+        "message": {
+          "type": "string",
+          "description": "Error message."
+        },
+        "target": {
+          "type": "string",
+          "description": "Error target."
+        },
+        "innererror": {
+          "$ref": "#/definitions/InnerError",
+          "description": "Inner error contains more specific information."
+        },
+        "details": {
+          "type": "array",
+          "description": "Details about specific errors that led to this reported error.",
+          "items": {
+            "$ref": "#/definitions/TextAnalyticsError"
+          }
+        }
+      }
+    },
+    "TextAnalyticsWarning": {
+      "type": "object",
+      "required": [
+        "code",
+        "message"
+      ],
+      "properties": {
+        "code": {
+          "type": "string",
+          "enum": [
+            "LongWordsInDocument",
+            "DocumentTruncated"
+          ],
+          "x-ms-enum": {
+            "name": "WarningCodeValue",
+            "modelAsString": false
+          },
+          "description": "Error code."
+        },
+        "message": {
+          "type": "string",
+          "description": "Warning message."
+        },
+        "targetRef": {
+          "type": "string",
+          "description": "A JSON pointer reference indicating the target object."
+        }
+      }
+    },
+    "InnerError": {
+      "type": "object",
+      "required": [
+        "code",
+        "message"
+      ],
+      "properties": {
+        "code": {
+          "type": "string",
+          "enum": [
+            "invalidParameterValue",
+            "invalidRequestBodyFormat",
+            "emptyRequest",
+            "missingInputRecords",
+            "invalidDocument",
+            "modelVersionIncorrect",
+            "invalidDocumentBatch",
+            "unsupportedLanguageCode",
+            "invalidCountryHint"
+          ],
+          "x-ms-enum": {
+            "name": "InnerErrorCodeValue",
+            "modelAsString": false
+          },
+          "description": "Error code."
+        },
+        "message": {
+          "type": "string",
+          "description": "Error message."
+        },
+        "details": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Error details."
+        },
+        "target": {
+          "type": "string",
+          "description": "Error target."
+        },
+        "innererror": {
+          "$ref": "#/definitions/InnerError",
+          "description": "Inner error contains more specific information."
+        }
+      }
+    },
+    "SentimentResponse": {
+      "type": "object",
+      "required": [
+        "documents",
+        "errors",
+        "modelVersion"
+      ],
+      "properties": {
+        "documents": {
+          "type": "array",
+          "description": "Sentiment analysis per document.",
+          "items": {
+            "$ref": "#/definitions/DocumentSentiment"
+          }
+        },
+        "errors": {
+          "type": "array",
+          "description": "Errors by document id.",
+          "items": {
+            "$ref": "#/definitions/DocumentError"
+          }
+        },
+        "statistics": {
+          "$ref": "#/definitions/RequestStatistics"
+        },
+        "modelVersion": {
+          "type": "string",
+          "description": "This field indicates which model is used for scoring."
+        }
+      }
+    },
+    "DocumentSentiment": {
+      "type": "object",
+      "required": [
+        "id",
+        "sentiment",
+        "confidenceScores",
+        "sentences",
+        "warnings"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique, non-empty document identifier."
+        },
+        "sentiment": {
+          "type": "string",
+          "description": "Predicted sentiment for document (Negative, Neutral, Positive, or Mixed).",
+          "enum": [
+            "positive",
+            "neutral",
+            "negative",
+            "mixed"
+          ],
+          "x-ms-enum": {
+            "name": "DocumentSentimentValue",
+            "modelAsString": false
+          }
+        },
+        "statistics": {
+          "$ref": "#/definitions/DocumentStatistics"
+        },
+        "confidenceScores": {
+          "description": "Document level sentiment confidence scores between 0 and 1 for each sentiment class.",
+          "$ref": "#/definitions/SentimentConfidenceScorePerLabel"
+        },
+        "sentences": {
+          "type": "array",
+          "description": "Sentence level sentiment analysis.",
+          "items": {
+            "$ref": "#/definitions/SentenceSentiment"
+          }
+        },
+        "warnings": {
+          "type": "array",
+          "description": "Warnings encountered while processing document.",
+          "items": {
+            "$ref": "#/definitions/TextAnalyticsWarning"
+          }
+        }
+      }
+    },
+    "RequestStatistics": {
+      "type": "object",
+      "required": [
+        "documentsCount",
+        "validDocumentsCount",
+        "erroneousDocumentsCount",
+        "transactionsCount"
+      ],
+      "properties": {
+        "documentsCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of documents submitted in the request."
+        },
+        "validDocumentsCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of valid documents. This excludes empty, over-size limit or non-supported languages documents."
+        },
+        "erroneousDocumentsCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of invalid documents. This includes empty, over-size limit or non-supported languages documents."
+        },
+        "transactionsCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Number of transactions for the request."
+        }
+      },
+      "description": "if showStats=true was specified in the request this field will contain information about the request payload."
+    },
+    "DocumentStatistics": {
+      "type": "object",
+      "required": [
+        "charactersCount",
+        "transactionsCount"
+      ],
+      "properties": {
+        "charactersCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of text elements recognized in the document."
+        },
+        "transactionsCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of transactions for the document."
+        }
+      },
+      "description": "if showStats=true was specified in the request this field will contain information about the document payload."
+    },
+    "SentimentConfidenceScorePerLabel": {
+      "type": "object",
+      "required": [
+        "positive",
+        "neutral",
+        "negative"
+      ],
+      "properties": {
+        "positive": {
+          "type": "number",
+          "format": "double"
+        },
+        "neutral": {
+          "type": "number",
+          "format": "double"
+        },
+        "negative": {
+          "type": "number",
+          "format": "double"
+        }
+      },
+      "description": "Represents the confidence scores between 0 and 1 across all sentiment classes: positive, neutral, negative."
+    },
+    "SentenceSentiment": {
+      "type": "object",
+      "required": [
+        "sentiment",
+        "confidenceScores",
+        "offset",
+        "length"
+      ],
+      "properties": {
+        "text": {
+          "type": "string",
+          "description": "The sentence text."
+        },
+        "sentiment": {
+          "type": "string",
+          "description": "The predicted Sentiment for the sentence.",
+          "enum": [
+            "positive",
+            "neutral",
+            "negative"
+          ],
+          "x-ms-enum": {
+            "name": "SentenceSentimentValue",
+            "modelAsString": false
+          }
+        },
+        "confidenceScores": {
+          "description": "The sentiment confidence score between 0 and 1 for the sentence for all classes.",
+          "$ref": "#/definitions/SentimentConfidenceScorePerLabel"
+        },
+        "offset": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The sentence offset from the start of the document."
+        },
+        "length": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The length of the sentence by Unicode standard."
+        }
+      }
+    },
+    "DocumentEntities": {
+      "type": "object",
+      "required": [
+        "id",
+        "entities",
+        "warnings"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique, non-empty document identifier."
+        },
+        "entities": {
+          "type": "array",
+          "description": "Recognized entities in the document.",
+          "items": {
+            "$ref": "#/definitions/Entity"
+          }
+        },
+        "warnings": {
+          "type": "array",
+          "description": "Warnings encountered while processing document.",
+          "items": {
+            "$ref": "#/definitions/TextAnalyticsWarning"
+          }
+        },
+        "statistics": {
+          "description": "if showStats=true was specified in the request this field will contain information about the document payload.",
+          "$ref": "#/definitions/DocumentStatistics"
+        }
+      }
+    },
+    "Entity": {
+      "type": "object",
+      "required": [
+        "text",
+        "category",
+        "offset",
+        "length",
+        "confidenceScore"
+      ],
+      "properties": {
+        "text": {
+          "type": "string",
+          "description": "Entity text as appears in the request."
+        },
+        "category": {
+          "type": "string",
+          "description": "Entity type, such as Person/Location/Org/SSN etc"
+        },
+        "subcategory": {
+          "type": "string",
+          "description": "Entity sub type, such as Age/Year/TimeRange etc"
+        },
+        "offset": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Start position (in Unicode characters) for the entity text."
+        },
+        "length": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Length (in Unicode characters) for the entity text."
+        },
+        "confidenceScore": {
+          "type": "number",
+          "format": "double",
+          "description": "Confidence score between 0 and 1 of the extracted entity."
+        }
+      }
+    },
+    "EntityLinkingResult": {
+      "type": "object",
+      "required": [
+        "documents",
+        "errors",
+        "modelVersion"
+      ],
+      "properties": {
+        "documents": {
+          "type": "array",
+          "description": "Response by document",
+          "items": {
+            "$ref": "#/definitions/DocumentLinkedEntities"
+          }
+        },
+        "errors": {
+          "type": "array",
+          "description": "Errors by document id.",
+          "items": {
+            "$ref": "#/definitions/DocumentError"
+          }
+        },
+        "statistics": {
+          "$ref": "#/definitions/RequestStatistics"
+        },
+        "modelVersion": {
+          "type": "string",
+          "description": "This field indicates which model is used for scoring."
+        }
+      }
+    },
+    "DocumentLinkedEntities": {
+      "type": "object",
+      "required": [
+        "id",
+        "entities",
+        "warnings"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique, non-empty document identifier."
+        },
+        "entities": {
+          "type": "array",
+          "description": "Recognized well-known entities in the document.",
+          "items": {
+            "$ref": "#/definitions/LinkedEntity"
+          }
+        },
+        "warnings": {
+          "type": "array",
+          "description": "Warnings encountered while processing document.",
+          "items": {
+            "$ref": "#/definitions/TextAnalyticsWarning"
+          }
+        },
+        "statistics": {
+          "description": "if showStats=true was specified in the request this field will contain information about the document payload.",
+          "$ref": "#/definitions/DocumentStatistics"
+        }
+      }
+    },
+    "LinkedEntity": {
+      "type": "object",
+      "required": [
+        "name",
+        "matches",
+        "language",
+        "url",
+        "dataSource"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Entity Linking formal name."
+        },
+        "matches": {
+          "type": "array",
+          "description": "List of instances this entity appears in the text.",
+          "items": {
+            "$ref": "#/definitions/Match"
+          }
+        },
+        "language": {
+          "type": "string",
+          "description": "Language used in the data source."
+        },
+        "id": {
+          "type": "string",
+          "description": "Unique identifier of the recognized entity from the data source."
+        },
+        "url": {
+          "type": "string",
+          "description": "URL for the entity's page from the data source."
+        },
+        "dataSource": {
+          "type": "string",
+          "description": "Data source used to extract entity linking, such as Wiki/Bing etc."
+        }
+      }
+    },
+    "Match": {
+      "type": "object",
+      "required": [
+        "confidenceScore",
+        "text",
+        "offset",
+        "length"
+      ],
+      "properties": {
+        "confidenceScore": {
+          "type": "number",
+          "format": "double",
+          "description": "If a well-known item is recognized, a decimal number denoting the confidence level between 0 and 1 will be returned."
+        },
+        "text": {
+          "type": "string",
+          "description": "Entity text as appears in the request."
+        },
+        "offset": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Start position (in Unicode characters) for the entity match text."
+        },
+        "length": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Length (in Unicode characters) for the entity match text."
+        }
+      }
+    },
+    "DocumentKeyPhrases": {
+      "type": "object",
+      "required": [
+        "id",
+        "keyPhrases",
+        "warnings"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique, non-empty document identifier."
+        },
+        "keyPhrases": {
+          "type": "array",
+          "description": "A list of representative words or phrases. The number of key phrases returned is proportional to the number of words in the input document.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "warnings": {
+          "type": "array",
+          "description": "Warnings encountered while processing document.",
+          "items": {
+            "$ref": "#/definitions/TextAnalyticsWarning"
+          }
+        },
+        "statistics": {
+          "description": "if showStats=true was specified in the request this field will contain information about the document payload.",
+          "$ref": "#/definitions/DocumentStatistics"
+        }
+      }
+    },
+    "LanguageBatchInput": {
+      "type": "object",
+      "required": [
+        "documents"
+      ],
+      "properties": {
+        "documents": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LanguageInput"
+          }
+        }
+      }
+    },
+    "LanguageInput": {
+      "type": "object",
+      "required": [
+        "id",
+        "text"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique, non-empty document identifier."
+        },
+        "text": {
+          "type": "string"
+        },
+        "countryHint": {
+          "type": "string"
+        }
+      }
+    },
+    "DocumentLanguage": {
+      "type": "object",
+      "required": [
+        "id",
+        "detectedLanguage",
+        "warnings"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique, non-empty document identifier."
+        },
+        "detectedLanguage": {
+          "description": "Detected Language.",
+          "$ref": "#/definitions/DetectedLanguage"
+        },
+        "warnings": {
+          "type": "array",
+          "description": "Warnings encountered while processing document.",
+          "items": {
+            "$ref": "#/definitions/TextAnalyticsWarning"
+          }
+        },
+        "statistics": {
+          "description": "if showStats=true was specified in the request this field will contain information about the document payload.",
+          "$ref": "#/definitions/DocumentStatistics"
+        }
+      }
+    },
+    "DetectedLanguage": {
+      "type": "object",
+      "required": [
+        "name",
+        "iso6391Name",
+        "confidenceScore"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Long name of a detected language (e.g. English, French)."
+        },
+        "iso6391Name": {
+          "type": "string",
+          "description": "A two letter representation of the detected language according to the ISO 639-1 standard (e.g. en, fr)."
+        },
+        "confidenceScore": {
+          "type": "number",
+          "format": "double",
+          "description": "A confidence score between 0 and 1. Scores close to 1 indicate 100% certainty that the identified language is true."
+        }
+      }
+    },
+    "KeyPhraseResult": {
+      "type": "object",
+      "required": [
+        "documents",
+        "errors",
+        "modelVersion"
+      ],
+      "properties": {
+        "documents": {
+          "type": "array",
+          "description": "Response by document",
+          "items": {
+            "$ref": "#/definitions/DocumentKeyPhrases"
+          }
+        },
+        "errors": {
+          "type": "array",
+          "description": "Errors by document id.",
+          "items": {
+            "$ref": "#/definitions/DocumentError"
+          }
+        },
+        "statistics": {
+          "$ref": "#/definitions/RequestStatistics"
+        },
+        "modelVersion": {
+          "type": "string",
+          "description": "This field indicates which model is used for scoring."
+        }
+      }
+    },
+    "EntitiesResult": {
+      "type": "object",
+      "required": [
+        "documents",
+        "errors",
+        "modelVersion"
+      ],
+      "properties": {
+        "documents": {
+          "type": "array",
+          "description": "Response by document",
+          "items": {
+            "$ref": "#/definitions/DocumentEntities"
+          }
+        },
+        "errors": {
+          "type": "array",
+          "description": "Errors by document id.",
+          "items": {
+            "$ref": "#/definitions/DocumentError"
+          }
+        },
+        "statistics": {
+          "$ref": "#/definitions/RequestStatistics"
+        },
+        "modelVersion": {
+          "type": "string",
+          "description": "This field indicates which model is used for scoring."
+        }
+      }
+    },
     "LanguageInputs": {
       "type": "object",
       "properties": {
@@ -206,7 +1228,7 @@
         "documents": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/KeyPhraseResult"
+            "$ref": "#/definitions/KeyPhraseResultV2"
           }
         }
       }
@@ -217,7 +1239,7 @@
         "documents": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/EntitiesResult"
+            "$ref": "#/definitions/EntitiesResultV2"
           }
         }
       }
@@ -228,7 +1250,7 @@
         "documents": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/LanguageResult"
+            "$ref": "#/definitions/LanguageResultV2"
           }
         }
       }
@@ -305,7 +1327,7 @@
         }
       }
     },
-    "KeyPhraseResult": {
+    "KeyPhraseResultV2": {
       "type": "object",
       "properties": {
         "keyPhrases": {
@@ -323,7 +1345,7 @@
         }
       }
     },
-    "EntitiesResult": {
+    "EntitiesResultV2": {
       "type": "object",
       "properties": {
         "entities": {
@@ -388,6 +1410,37 @@
     },
     "LanguageResult": {
       "type": "object",
+      "required": [
+        "documents",
+        "errors",
+        "modelVersion"
+      ],
+      "properties": {
+        "documents": {
+          "type": "array",
+          "description": "Response by document",
+          "items": {
+            "$ref": "#/definitions/DocumentLanguage"
+          }
+        },
+        "errors": {
+          "type": "array",
+          "description": "Errors by document id.",
+          "items": {
+            "$ref": "#/definitions/DocumentError"
+          }
+        },
+        "statistics": {
+          "$ref": "#/definitions/RequestStatistics"
+        },
+        "modelVersion": {
+          "type": "string",
+          "description": "This field indicates which model is used for scoring."
+        }
+      }
+    },
+    "LanguageResultV2": {
+      "type": "object",
       "properties": {
         "id": {
           "description": "The unique document identifier.",
@@ -440,5 +1493,30 @@
         }
       }
     }
-  }
+  },
+  "parameters": {
+    "Endpoint": {
+      "name": "Endpoint",
+      "description": "Supported Cognitive Services endpoints (protocol and hostname, for example: https://westus.api.cognitive.microsoft.com).",
+      "x-ms-parameter-location": "client",
+      "required": true,
+      "type": "string",
+      "in": "path",
+      "x-ms-skip-url-encoding": true
+    }
+  },
+  "responses": {},
+  "securityDefinitions": {
+    "api_key": {
+      "type": "apiKey",
+      "in": "header",
+      "name": "Ocp-Apim-Subscription-Key"
+    }
+  },
+  "security": [
+    {
+      "apim_key": []
+    }
+  ],
+  "tags": []
 }

--- a/certified-connectors/CognitiveServicesTextAnalytics/apiDefinition.swagger.json
+++ b/certified-connectors/CognitiveServicesTextAnalytics/apiDefinition.swagger.json
@@ -178,7 +178,7 @@
     },
     "/text/analytics/v3.0/entities/recognition/general": {
       "post": {
-        "summary": "Named Entity Recognition (V3)",
+        "summary": "Named Entity Recognition (V3.0)",
         "description": "The API returns a list of general named entities in a given document. For the list of supported entity types, check <a href=\"https://aka.ms/taner\">Supported Entity Types in Text Analytics API</a>. See the <a href=\"https://aka.ms/talangs\">Supported languages in Text Analytics API</a> for the list of enabled languages.",
         "operationId": "EntitiesRecognitionGeneral",
         "consumes": [
@@ -233,7 +233,7 @@
     },
     "/text/analytics/v3.0/entities/linking": {
       "post": {
-        "summary": "Entity Linking (V3)",
+        "summary": "Entity Linking (V3.0)",
         "description": "The API returns a list of recognized entities with links to a well-known knowledge base. See the <a href=\"https://aka.ms/talangs\">Supported languages in Text Analytics API</a> for the list of enabled languages.",
         "operationId": "EntitiesLinking",
         "consumes": [
@@ -286,7 +286,7 @@
     },
     "/text/analytics/v3.0/keyPhrases": {
       "post": {
-        "summary": "Key Phrases (V3)",
+        "summary": "Key Phrases (V3.0)",
         "description": "The API returns a list of strings denoting the key phrases in the input text. See the <a href=\"https://aka.ms/talangs\">Supported languages in Text Analytics API</a> for the list of enabled languages.",
         "operationId": "KeyPhrases",
         "consumes": [
@@ -339,7 +339,7 @@
     },
     "/text/analytics/v3.0/languages": {
       "post": {
-        "summary": "Detect Language (V3)",
+        "summary": "Detect Language (V3.0)",
         "description": "The API returns the detected language and a numeric score between 0 and 1. Scores close to 1 indicate 100% certainty that the identified language is true. See the <a href=\"https://aka.ms/talangs\">Supported languages in Text Analytics API</a> for the list of enabled languages.",
         "operationId": "Languages",
         "consumes": [
@@ -392,7 +392,7 @@
     },
     "/text/analytics/v3.0/sentiment": {
       "post": {
-        "summary": "Sentiment (V3)",
+        "summary": "Sentiment (V3.0)",
         "description": "The API returns a sentiment prediction, as well as sentiment scores for each sentiment class (Positive, Negative, and Neutral) for the document and each sentence within it. See the <a href=\"https://aka.ms/talangs\">Supported languages in Text Analytics API</a> for the list of enabled languages.",
         "operationId": "Sentiment",
         "consumes": [

--- a/certified-connectors/CognitiveServicesTextAnalytics/apiProperties.json
+++ b/certified-connectors/CognitiveServicesTextAnalytics/apiProperties.json
@@ -35,7 +35,9 @@
             "KeyPhrasesV3",
             "DetectLanguageV3",
             "DetectSentimentV3",
-            "DetectEntitiesV2"
+            "DetectEntitiesV3",
+            "DetectEntitiesPIIV3",
+            "EntityLinkingV3"
           ],
           "x-ms-apimTemplateParameter.urlTemplate": "@connectionParameters('siteUrl','https://westus.api.cognitive.microsoft.com')"
         },
@@ -66,7 +68,7 @@
             "KeyPhrasesV3"
           ],
           "x-ms-apimTemplateParameter.httpMethod": "@Request.OriginalHTTPMethod",
-          "x-ms-apimTemplateParameter.newPath": "/text/analytics/v2.1/keyPhrases"
+          "x-ms-apimTemplateParameter.newPath": "/text/analytics/v3.0/keyPhrases"
         },
         "templateId": "routerequesttoendpoint",
         "title": "Redirect to KeyPhrases API"
@@ -77,7 +79,7 @@
             "DetectLanguageV3"
           ],
           "x-ms-apimTemplateParameter.httpMethod": "@Request.OriginalHTTPMethod",
-          "x-ms-apimTemplateParameter.newPath": "/text/analytics/v2.1/languages"
+          "x-ms-apimTemplateParameter.newPath": "/text/analytics/v3.0/languages"
         },
         "templateId": "routerequesttoendpoint",
         "title": "Redirect to DetectLanguages API"
@@ -88,7 +90,7 @@
             "DetectSentimentV3"
           ],
           "x-ms-apimTemplateParameter.httpMethod": "@Request.OriginalHTTPMethod",
-          "x-ms-apimTemplateParameter.newPath": "/text/analytics/v2.1/sentiment"
+          "x-ms-apimTemplateParameter.newPath": "/text/analytics/v3.0/sentiment"
         },
         "templateId": "routerequesttoendpoint",
         "title": "Redirect to DetectSentiment API"
@@ -96,13 +98,35 @@
       {
         "parameters": {
           "x-ms-apimTemplate-operationName": [
-            "DetectEntitiesV2"
+            "DetectEntitiesV3"
           ],
           "x-ms-apimTemplateParameter.httpMethod": "@Request.OriginalHTTPMethod",
-          "x-ms-apimTemplateParameter.newPath": "/text/analytics/v2.1/entities"
+          "x-ms-apimTemplateParameter.newPath": "/text/analytics/v3.0/entities/recognition/general"
         },
         "templateId": "routerequesttoendpoint",
         "title": "Redirect to DetectEntities API"
+      },
+      {
+        "parameters": {
+          "x-ms-apimTemplate-operationName": [
+            "DetectEntitiesPIIV3"
+          ],
+          "x-ms-apimTemplateParameter.httpMethod": "@Request.OriginalHTTPMethod",
+          "x-ms-apimTemplateParameter.newPath": "/text/analytics/v3.0/entities/recognition/pii"
+        },
+        "templateId": "routerequesttoendpoint",
+        "title": "Redirect to DetectEntitiesPII API"
+      },
+      {
+        "parameters": {
+          "x-ms-apimTemplate-operationName": [
+            "EntityLinkingV3"
+          ],
+          "x-ms-apimTemplateParameter.httpMethod": "@Request.OriginalHTTPMethod",
+          "x-ms-apimTemplateParameter.newPath": "/text/analytics/v3.0/entities/linking"
+        },
+        "templateId": "routerequesttoendpoint",
+        "title": "Redirect to EntityLinking API"
       }
     ]
   }


### PR DESCRIPTION
Now that Text Analytics v3.0 is available for GA, we can add the new endpoints and their corresponding functionality into the power platform connector - this does so, and has been tested locally as a custom connector (Text Analytics Preview V3). It maintains all the old endpoints as well, describing them as V2 endpoints, and the new endpoints are labeled as V3
