### PR TITLE
[OutlookTasks] fix capabilities and timezone data types

### DIFF
--- a/certified-connectors/OutlookTasks/apiDefinition.swagger.json
+++ b/certified-connectors/OutlookTasks/apiDefinition.swagger.json
@@ -18,7 +18,7 @@
     "application/json"
   ],
   "paths": {
-    "/actions/GetAllTaskFolders/v2/me/taskfolders": {
+    "/v2/me/taskfolders": {
       "get": {
         "tags": [
           "Tasks"
@@ -47,9 +47,7 @@
           "revision": 2,
           "status": "Preview"
         }
-      }
-    },
-    "/actions/CreateTaskFolder/v2/me/taskfolders": {
+      },
       "post": {
         "tags": [
           "Tasks"
@@ -82,7 +80,7 @@
         }
       }
     },
-    "/actions/GetTaskFolder/v1/me/taskfolders('{folder_id}')": {
+    "/v1/me/taskfolders('{folder_id}')": {
       "get": {
         "tags": [
           "Tasks"
@@ -105,9 +103,7 @@
           "revision": 1,
           "status": "Preview"
         }
-      }
-    },
-    "/actions/UpdateTaskFolder/v1/me/taskfolders('{folder_id}')": {
+      },
       "patch": {
         "tags": [
           "Tasks"
@@ -143,7 +139,7 @@
         }
       }
     },
-    "/actions/GetAllTaskGroups/v2/me/taskgroups": {
+    "/v2/me/taskgroups": {
       "get": {
         "tags": [
           "Tasks"
@@ -172,9 +168,7 @@
           "revision": 2,
           "status": "Preview"
         }
-      }
-    },
-    "/actions/CreateTaskGroup/v2/me/taskgroups": {
+      },
       "post": {
         "tags": [
           "Tasks"
@@ -207,7 +201,7 @@
         }
       }
     },
-    "/actions/GetTaskGroup/v1/me/taskgroups('{group_id}')": {
+    "/v1/me/taskgroups('{group_id}')": {
       "get": {
         "tags": [
           "Tasks"
@@ -230,9 +224,7 @@
           "revision": 1,
           "status": "Preview"
         }
-      }
-    },
-    "/actions/UpdateTaskGroup/v1/me/taskgroups('{group_id}')": {
+      },
       "patch": {
         "tags": [
           "Tasks"
@@ -268,7 +260,7 @@
         }
       }
     },
-    "/actions/GetTaskFoldersInGroup/v2/me/taskgroups('{group_id}')/taskfolders": {
+    "/v2/me/taskgroups('{group_id}')/taskfolders": {
       "get": {
         "tags": [
           "Tasks"
@@ -300,9 +292,7 @@
           "revision": 2,
           "status": "Preview"
         }
-      }
-    },
-    "/actions/CreateTaskFolderInGroup/v2/me/taskgroups('{group_id}')/taskfolders": {
+      },
       "post": {
         "tags": [
           "Tasks"
@@ -338,7 +328,7 @@
         }
       }
     },
-    "/actions/GetAllTasks/v2/me/tasks": {
+    "/v2/me/tasks": {
       "get": {
         "tags": [
           "Tasks"
@@ -369,7 +359,7 @@
         }
       }
     },
-    "/actions/GetTasksInFolder/v2/me/taskfolders('{folder_id}')/tasks": {
+    "/v2/me/taskfolders('{folder_id}')/tasks": {
       "get": {
         "tags": [
           "Tasks"
@@ -403,7 +393,7 @@
         }
       }
     },
-    "/actions/CreateTask/v3/me/tasks": {
+    "/v3/me/tasks": {
       "post": {
         "tags": [
           "Tasks"
@@ -436,7 +426,7 @@
         }
       }
     },
-    "/actions/CreateTaskInFolder/v3/me/taskfolders('{folder_id}')/tasks": {
+    "/v3/me/taskfolders('{folder_id}')/tasks": {
       "post": {
         "tags": [
           "Tasks"
@@ -472,7 +462,7 @@
         }
       }
     },
-    "/actions/GetTask/v2/me/tasks('{task_id}')": {
+    "/v2/me/tasks('{task_id}')": {
       "get": {
         "tags": [
           "Tasks"
@@ -495,9 +485,7 @@
           "revision": 2,
           "status": "Preview"
         }
-      }
-    },
-    "/actions/UpdateTask/v2/me/tasks('{task_id}')": {
+      },
       "patch": {
         "tags": [
           "Tasks"
@@ -533,7 +521,7 @@
         }
       }
     },
-    "/actions/DeleteTask/v1/me/tasks('{task_id}')": {
+    "/v1/me/tasks('{task_id}')": {
       "delete": {
         "tags": [
           "Tasks"
@@ -558,7 +546,7 @@
         }
       }
     },
-    "/actions/CompleteTask/v2/me/tasks('{task_id}')/complete": {
+    "/v2/me/tasks('{task_id}')/complete": {
       "post": {
         "tags": [
           "Tasks"

--- a/certified-connectors/OutlookTasks/apiDefinition.swagger.json
+++ b/certified-connectors/OutlookTasks/apiDefinition.swagger.json
@@ -799,7 +799,7 @@
               "type": "string"
             },
             "TimeZone": {
-              "$ref": "#/definitions/TimeZone"
+              "$ref": "#/definitions/DateTimeTimeZone-TimeZone"
             }
           }
         },
@@ -815,7 +815,7 @@
               "type": "string"
             },
             "TimeZone": {
-              "$ref": "#/definitions/TimeZone"
+              "$ref": "#/definitions/DateTimeTimeZone-TimeZone"
             }
           }
         },
@@ -831,7 +831,7 @@
               "type": "string"
             },
             "TimeZone": {
-              "$ref": "#/definitions/TimeZone"
+              "$ref": "#/definitions/DateTimeTimeZone-TimeZone"
             }
           }
         },
@@ -850,7 +850,7 @@
               "type": "string"
             },
             "TimeZone": {
-              "$ref": "#/definitions/TimeZone"
+              "$ref": "#/definitions/DateTimeTimeZone-TimeZone"
             }
           }
         }
@@ -1101,7 +1101,7 @@
           "format": "date"
         },
         "TimeZone": {
-          "$ref": "#/definitions/TimeZone"
+          "$ref": "#/definitions/request-DateTimeTimeZone-TimeZone"
         }
       },
       "x-ms-visibility": "advanced"
@@ -1122,7 +1122,7 @@
           "format": "date"
         },
         "TimeZone": {
-          "$ref": "#/definitions/TimeZone"
+          "$ref": "#/definitions/request-DateTimeTimeZone-TimeZone"
         }
       },
       "x-ms-visibility": "advanced"
@@ -1143,7 +1143,7 @@
           "format": "date"
         },
         "TimeZone": {
-          "$ref": "#/definitions/TimeZone"
+          "$ref": "#/definitions/request-DateTimeTimeZone-TimeZone"
         }
       },
       "x-ms-visibility": "advanced"
@@ -1160,18 +1160,27 @@
           "type": "string"
         },
         "TimeZone": {
-          "$ref": "#/definitions/TimeZone"
+          "$ref": "#/definitions/request-DateTimeTimeZone-TimeZone"
         }
       }
     },
-    "TimeZone": {
+    "DateTimeTimeZone-TimeZone": {
       "title": "Time Zone",
-      "description": "",
+      "description": "The time zone in which the `DateTime` field is expressed.",
+      "type": "string",
+      "externalDocs": {
+        "url": "https://docs.microsoft.com/en-us/previous-versions/office/office-365-api/api/version-2.0/complex-types-for-mail-contacts-calendar#DateTimeTimeZoneV2"
+      }
+    },
+    "request-DateTimeTimeZone-TimeZone": {
+      "title": "Time Zone",
+      "description": "Time zone to use for the `DateTime` field.",
       "type": "string",
       "externalDocs": {
         "url": "https://docs.microsoft.com/en-us/previous-versions/office/office-365-api/api/version-2.0/complex-types-for-mail-contacts-calendar#DateTimeTimeZoneV2"
       },
       "enum": [
+        "UTC",
         "Dateline Standard Time",
         "Samoa Standard Time",
         "Hawaiian Standard Time",
@@ -1200,7 +1209,6 @@
         "Azores Standard Time",
         "GMT Standard Time",
         "Greenwich Standard Time",
-        "UTC",
         "W. Europe Standard Time",
         "Central Europe Standard Time",
         "Romance Standard Time",
@@ -1254,6 +1262,10 @@
         "Tonga Standard Time"
       ],
       "x-ms-enum-values": [
+        {
+          "value": "UTC",
+          "displayName": "(UTC) Coordinated Universal Time"
+        },
         {
           "value": "Dateline Standard Time",
           "displayName": "(GMT-12:00) International Date Line West"
@@ -1365,10 +1377,6 @@
         {
           "value": "Greenwich Standard Time",
           "displayName": "(GMT) Casablanca, Monrovia"
-        },
-        {
-          "value": "UTC",
-          "displayName": "(UTC) Coordinated Universal Time"
         },
         {
           "value": "W. Europe Standard Time",

--- a/certified-connectors/OutlookTasks/apiDefinition.swagger.json
+++ b/certified-connectors/OutlookTasks/apiDefinition.swagger.json
@@ -797,7 +797,7 @@
           "properties": {
             "DateTime": {
               "title": "Date",
-              "description": "YYYY-MM-DD",
+              "description": "Format: YYYY-MM-DD.",
               "type": "string"
             },
             "TimeZone": {
@@ -813,7 +813,7 @@
           "properties": {
             "DateTime": {
               "title": "Date",
-              "description": "YYYY-MM-DD",
+              "description": "Format: YYYY-MM-DD.",
               "type": "string"
             },
             "TimeZone": {
@@ -829,7 +829,7 @@
           "properties": {
             "DateTime": {
               "title": "Date & Time",
-              "description": "YYYY-MM-DDThh:mm:ssZ (UTC format)",
+              "description": "UTC Format: YYYY-MM-DDThh:mm:ssZ.",
               "type": "string"
             },
             "TimeZone": {
@@ -848,7 +848,7 @@
           "properties": {
             "DateTime": {
               "title": "Date & Time",
-              "description": "YYYY-MM-DDThh:mm:ssZ (UTC format)",
+              "description": "UTC Format: YYYY-MM-DDThh:mm:ssZ.",
               "type": "string"
             },
             "TimeZone": {
@@ -1060,7 +1060,7 @@
       "properties": {
         "ContentType": {
           "title": "Content Type",
-          "description": "Default to HTML when editing to mimic the format",
+          "description": "Default to HTML when editing to mimic the format.",
           "type": "string",
           "enum": [
             "Text",
@@ -1098,7 +1098,7 @@
       "properties": {
         "DateTime": {
           "title": "Date",
-          "description": "Format: YYYY-MM-DD",
+          "description": "Format: YYYY-MM-DD.",
           "type": "string",
           "format": "date"
         },
@@ -1119,7 +1119,7 @@
       "properties": {
         "DateTime": {
           "title": "Date",
-          "description": "Format: YYYY-MM-DD",
+          "description": "Format: YYYY-MM-DD.",
           "type": "string",
           "format": "date"
         },
@@ -1140,7 +1140,7 @@
       "properties": {
         "DateTime": {
           "title": "Date",
-          "description": "Format: YYYY-MM-DD",
+          "description": "Format: YYYY-MM-DD.",
           "type": "string",
           "format": "date"
         },
@@ -1158,7 +1158,7 @@
       "properties": {
         "DateTime": {
           "title": "Date & Time",
-          "description": "Format: YYYY-MM-DDThh:mm:ss",
+          "description": "Format: YYYY-MM-DDThh:mm:ss.",
           "type": "string"
         },
         "TimeZone": {

--- a/certified-connectors/OutlookTasks/apiDefinition.swagger.json
+++ b/certified-connectors/OutlookTasks/apiDefinition.swagger.json
@@ -560,8 +560,22 @@
           }
         ],
         "responses": {
-          "204": {
-            "$ref": "#/responses/204-NoContent"
+          "200": {
+            "description": "Operation Successful",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "value": {
+                  "title": "An array containing the single Task that was completed.",
+                  "type": "array",
+                  "minItems": 1,
+                  "maxItems": 1,
+                  "items": {
+                    "$ref": "#/definitions/TaskOS"
+                  }
+                }
+              }
+            }
           }
         },
         "x-ms-api-annotation": {

--- a/certified-connectors/OutlookTasks/apiProperties.json
+++ b/certified-connectors/OutlookTasks/apiProperties.json
@@ -2,8 +2,7 @@
   "properties": {
     "iconBrandColor": "#0072c6",
     "capabilities": [
-      "actions",
-      "triggers"
+      "actions"
     ],
     "connectionParameters": {
       "token": {


### PR DESCRIPTION
- Removes the 'triggers' from the 'capabilities' as it causes errors when used with paconn tool.
- Broke out TimeZone schema to be different when used in request and responses.
- Remove path prefixes "/actions/{family}/" to match with other connectors.
- Fix Open Api warnings
- Fix response of CompleteTask_V2
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).
