### PR TITLE
[Connect2All,HotProfile,PDF4me,Robolytix,ScriveESign,TRIGGERcmd,WebMerge,WorkSpan] Fix swaggers of various connectors

### DIFF
--- a/certified-connectors/Aquaforest PDF Connector/apiDefinition.swagger.json
+++ b/certified-connectors/Aquaforest PDF Connector/apiDefinition.swagger.json
@@ -1182,7 +1182,6 @@
     },
     "ocr_data": {
       "description": "Parameters for OCR operation",
-      "format": "ocr_data",
       "properties": {
         "aquaforestImageTimeout": {
           "default": 120000,
@@ -1347,7 +1346,6 @@
         },
         "jbig2EncFlags": {
           "description": "These are the flags that will be passed to the application used to generate JBIG2 versions of images used in PDF generation (assuming this compression is enabled). This option should generally only be used under guidance from technical support.",
-          "format": "string",
           "type": "string",
           "x-ms-summary": "Jbig2EncFlags",
           "x-ms-visibility": "advanced"
@@ -1381,7 +1379,6 @@
             "Estonian",
             "Turkish"
           ],
-          "format": "enum",
           "type": "string",
           "x-ms-summary": "Language"
         },
@@ -1416,7 +1413,6 @@
         },
         "morph": {
           "description": "Morphological options that will be applied to the binarized image before OCR. If set to empty none is applied. Common options include those listed below but for more options please contact support@aquaforest.com.",
-          "format": "string",
           "type": "string",
           "x-ms-summary": "Morph",
           "x-ms-visibility": "advanced"
@@ -1488,7 +1484,6 @@
             "Bpp_1",
             "Bpp_24"
           ],
-          "format": "enum",
           "type": "string",
           "x-ms-summary": "PdfToImageBpp",
           "x-ms-visibility": "advanced"
@@ -1499,7 +1494,6 @@
             "CCITT4",
             "LZW"
           ],
-          "format": "enum",
           "type": "string",
           "x-ms-summary": "PdfToImageCompression",
           "x-ms-visibility": "advanced"
@@ -1516,7 +1510,6 @@
             "DPI_500",
             "DPI_600"
           ],
-          "format": "enum",
           "type": "string",
           "x-ms-summary": "PdfToImageDpi",
           "x-ms-visibility": "advanced"
@@ -1558,7 +1551,6 @@
             "PDF_A2b",
             "PDF_A3b"
           ],
-          "format": "enum",
           "type": "string",
           "x-ms-summary": "PDF/A Version",
           "x-ms-visibility": "advanced"
@@ -1744,7 +1736,6 @@
     },
     "ocr_response": {
       "description": "Response data for OCR operation",
-      "format": "ocr_response",
       "properties": {
         "ErrorMessage": {
           "description": "If the value of Is Successful is false, we will return an Error Message",

--- a/certified-connectors/Connect2All/apiDefinition.swagger.json
+++ b/certified-connectors/Connect2All/apiDefinition.swagger.json
@@ -36,7 +36,7 @@
                 "description": "The value to set for this field",
                 "type": "string",
                 "x-ms-summary": "Value to set",
-                "x-ms-visbility": "advanced"
+                "x-ms-visibility": "advanced"
               }
             },
             "type": "object"
@@ -304,7 +304,7 @@
                 "description": "The value to set for this field",
                 "type": "string",
                 "x-ms-summary": "Value to set",
-                "x-ms-visbility": "advanced"
+                "x-ms-visibility": "advanced"
               }
             },
             "type": "object"

--- a/certified-connectors/HotProfile/apiDefinition.swagger.json
+++ b/certified-connectors/HotProfile/apiDefinition.swagger.json
@@ -2446,8 +2446,7 @@
                   "description": "ID",
                   "format": "int32",
                   "title": "ID",
-                  "type": "integer",
-                  "x-ms-visibility": ""
+                  "type": "integer"
                 }
               },
               "type": "object"
@@ -3786,8 +3785,7 @@
                   "description": "id",
                   "format": "int32",
                   "title": "ID",
-                  "type": "integer",
-                  "x-ms-visibility": ""
+                  "type": "integer"
                 }
               },
               "type": "object"

--- a/certified-connectors/PDF4me/apiDefinition.swagger.json
+++ b/certified-connectors/PDF4me/apiDefinition.swagger.json
@@ -520,8 +520,7 @@
                 "pageNumbers": {
                   "description": "PageNumbers to be extracted (e.g: 1,2)",
                   "title": "Page Numbers",
-                  "type": "string",
-                  "x-ms-visibility": ""
+                  "type": "string"
                 }
               },
               "required": [
@@ -1293,8 +1292,7 @@
                   "description": "Input file content from the source",
                   "format": "byte",
                   "title": "File Content",
-                  "type": "string",
-                  "x-ms-visibility": ""
+                  "type": "string"
                 },
                 "document": {
                   "description": "document",

--- a/certified-connectors/PDF4me/apiProperties.json
+++ b/certified-connectors/PDF4me/apiProperties.json
@@ -35,4 +35,3 @@
     "iconBrandColor": "#eeeeee"
   }
 }
-}

--- a/certified-connectors/Planner/apiProperties.json
+++ b/certified-connectors/Planner/apiProperties.json
@@ -18,13 +18,13 @@
             "IsFirstParty": "True"
           },
           "customParameters": {
-            "ResourceUri": {
+            "resourceUri": {
               "value": "https://graph.microsoft.com/"
             },
-            "LoginUri": {
+            "loginUri": {
               "value": "https://login.windows.net"
             },
-            "LoginUriAAD": {
+            "loginUriAAD": {
               "value": "https://login.windows.net"
             }
           }

--- a/certified-connectors/Robolytix/apiDefinition.swagger.json
+++ b/certified-connectors/Robolytix/apiDefinition.swagger.json
@@ -50,7 +50,6 @@
         },
         "type": {
           "description": "Every process should start at sonars type Start and end at sonars type End. The number of Continuous sonars is unlimited. Use Error sonars for handling errors.",
-          "format": "",
           "title": "Type",
           "type": "string",
           "x-ms-dynamic-values": {

--- a/certified-connectors/Scrive eSign/apiDefinition.swagger.json
+++ b/certified-connectors/Scrive eSign/apiDefinition.swagger.json
@@ -211,7 +211,6 @@
             "description": "Document Created",
             "schema": {
               "description": "ID of the created document",
-              "format": "",
               "title": "New document ID",
               "type": "string"
             }
@@ -534,7 +533,6 @@
             "description": "Webhook Pushed",
             "schema": {
               "description": "ID of the created document",
-              "format": "",
               "title": "Signed document ID",
               "type": "string"
             }
@@ -591,7 +589,6 @@
             "description": "Webhook Pushed",
             "schema": {
               "description": "ID of the created document",
-              "format": "",
               "title": "Signed document ID",
               "type": "string"
             }
@@ -656,7 +653,6 @@
             "description": "Webhook Pushed",
             "schema": {
               "description": "ID of the triggering document",
-              "format": "",
               "title": "Signed document ID",
               "type": "string"
             }

--- a/certified-connectors/TRIGGERcmd/apiDefinition.swagger.json
+++ b/certified-connectors/TRIGGERcmd/apiDefinition.swagger.json
@@ -49,8 +49,7 @@
                   "type": "string",
                   "description": "Command Parameters (optional)",
                   "x-ms-summary": "params",
-                  "title": "Parameters",
-                  "x-ms-visibility": ""
+                  "title": "Parameters"
                 }
               },
               "required": [

--- a/certified-connectors/WebMerge/apiDefinition.swagger.json
+++ b/certified-connectors/WebMerge/apiDefinition.swagger.json
@@ -142,11 +142,10 @@
                         "type": "number",
                         "x-ms-summary": "Pick Document",
                         "x-ms-dynamic-values": {
-                          "operationId": "GetDocuments",      
-                          "parameters": { },                              
-                          "value-collection": null,                   
-                          "value-path": "id",                           
-                          "value-title": "name"                    
+                          "operationId": "GetDocuments",
+                          "parameters": { },
+                          "value-path": "id",
+                          "value-title": "name"
                         }
                     },
                     {
@@ -323,11 +322,10 @@
                         "type": "number",
                         "x-ms-summary": "Pick Data Route",
                         "x-ms-dynamic-values": {
-                          "operationId": "GetRoutes",      
-                          "parameters": { },                              
-                          "value-collection": null,                   
-                          "value-path": "id",                           
-                          "value-title": "name"                    
+                          "operationId": "GetRoutes",
+                          "parameters": { },
+                          "value-path": "id",
+                          "value-title": "name"
                         }
                     },
                     {

--- a/certified-connectors/WorkSpan/apiDefinition.swagger.json
+++ b/certified-connectors/WorkSpan/apiDefinition.swagger.json
@@ -194,7 +194,6 @@
       "get": {
         "operationId": "GetEventList",
         "summary": "Get list of events",
-        "x-ms-summary": "Get list of events",
         "description": "Get a list of WorkSpan Collaboration events",
         "x-ms-visibility": "internal",
         "produces": [
@@ -510,7 +509,6 @@
         ],
         "summary": "Bulk Load Opportunities (data in body)",
         "description": "Upload integration input data as request body. Allowed formats are .csv and .json",
-        "x-ms-summary": "Bulk Load Opportunities (data in body)",
         "operationId": "BulkloadOpportunity",
         "parameters": [
           {
@@ -598,7 +596,6 @@
           "multipart/form-data"
         ],
         "summary": "Bulk Load Opportunities (attachment)",
-        "x-ms-summary": "Bulk Load Opportunities (attachment)",
         "description": "Upload integration input file. Allowed formats are .xlsx, .json and .csv",
         "operationId": "BulkloadOpportunityFileAttachment",
         "parameters": [

--- a/certified-connectors/WorkSpan/apiDefinition.swagger.json
+++ b/certified-connectors/WorkSpan/apiDefinition.swagger.json
@@ -242,7 +242,6 @@
         "produces": [
           "application/json"
         ],
-        "x-ms-url-encoding": "single",
         "x-ms-visibility": "internal",
         "parameters": [
           {


### PR DESCRIPTION
Based on new schema cleanup, these connectors have small fixes to clean them up so they comply with the supported and normalized schemas.