### PR TITLE
(Azure CXP) Fixing the Facebook Swagger File

### DIFF
--- a/custom-connectors/Facebook/apiDefinition.swagger.json
+++ b/custom-connectors/Facebook/apiDefinition.swagger.json
@@ -1400,7 +1400,7 @@
   "security": [
     {
       "oauth2_auth": [
-        "user_posts publish_pages"
+        "user_posts"
       ]
     }
   ],
@@ -1409,7 +1409,7 @@
       "authorizationUrl": "https://graph.facebook.com/oauth/authorize",
       "flow": "accessCode",
       "scopes": {
-        "user_posts publish_pages": "user_posts publish_pages"
+        "user_posts": "user_posts"
       },
       "tokenUrl": "https://login.windows.net/common/oauth2/authorize",
       "type": "oauth2"


### PR DESCRIPTION
Publish_pages is deprecated from FB end
Reference: https://developers.facebook.com/docs/facebook-login/permissions



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).
