### PR TITLE
Poka - Make the language field mandatory. (Update apiDefinition.swagger)

### DIFF
--- a/certified-connectors/Poka/apiDefinition.swagger.json
+++ b/certified-connectors/Poka/apiDefinition.swagger.json
@@ -215,7 +215,8 @@
                 }
               },
               "required": [
-                "url"
+                "url",
+                "language"
               ]
             }
           },


### PR DESCRIPTION
---
Please check the following conditions for your PR.

- [x] `apiDefinition.swagger.json` is validated using `paconn validate` command.
- [x] `apiProperties.json` has a valid brand color. Invalid brand colors are `#007ee5` and `#ffffff`.
