### PR TITLE
line_1 in add_watermark is not longer required

### DIFF
--- a/certified-connectors/PDF Blocks/apiDefinition.swagger.json
+++ b/certified-connectors/PDF Blocks/apiDefinition.swagger.json
@@ -233,7 +233,7 @@
             "description": "The first line of text of the watermark",
             "x-ms-summary": "1st Line",
             "x-ms-visibility": "important",
-            "required": true
+            "required": false
           },
           {
             "in": "formData",


### PR DESCRIPTION
---
Please check the following conditions for your PR.

- [x] `apiDefinition.swagger.json` is validated using `paconn validate` command.
- [x] `apiProperties.json` has a valid brand color. Invalid brand colors are `#007ee5` and `#ffffff`.
