### PR TITLE
Extend properties

### DIFF
--- a/certified-connectors/FORCAM FORCE Bridge/apiDefinition.swagger.json
+++ b/certified-connectors/FORCAM FORCE Bridge/apiDefinition.swagger.json
@@ -3548,6 +3548,7 @@
       "type": "object",
       "required": [
         "callbackID",
+        "objectID",
         "timestamp",
         "eventType",
         "eventName",
@@ -3557,6 +3558,9 @@
       ],
       "properties": {
         "callbackID": {
+          "type": "string"
+        },
+        "objectID": {
           "type": "string"
         },
         "timestamp": {


### PR DESCRIPTION
Added the property "objectID" to process data violation trigger to allow a further use case.

---
Please check the following conditions for your PR.

- [ ] `apiDefinition.swagger.json` is validated using `paconn validate` command.
- [ ] `apiProperties.json` has a valid brand color. Invalid brand colors are `#007ee5` and `#ffffff`.
