### PR TITLE
Replace default responses by expected status codes

### DIFF
--- a/certified-connectors/Ubiqod by Skiply/apiDefinition.swagger.json
+++ b/certified-connectors/Ubiqod by Skiply/apiDefinition.swagger.json
@@ -23,8 +23,8 @@
     "/key/unsubscribe/{routingId}": {
       "delete": {
         "responses": {
-          "default": {
-            "description": "default"
+          "200": {
+            "description": "Unsubscribe response"
           }
         },
         "operationId": "DeleteRouting",
@@ -113,8 +113,8 @@
       },
       "post": {
         "responses": {
-          "default": {
-            "description": "default"
+          "201": {
+            "description": "Subscribe response"
           }
         },
         "summary": "When data is received from devices",
@@ -188,8 +188,8 @@
     "/key/getGroupsByName": {
       "get": {
         "responses": {
-          "default": {
-            "description": "default",
+          "200": {
+            "description": "Group list response",
             "schema": {
               "type": "array",
               "items": {


### PR DESCRIPTION
Follow the recommandation of Srikanth: please replace the "default" responses with expected status codes, otherwise users may see errors about incorrect schema instead of real error responses from your service in OpenAPI mode.


---
Please check the following conditions for your PR.

- [x] `apiDefinition.swagger.json` is validated using `paconn validate` command.
- [x] `apiProperties.json` has a valid brand color. Invalid brand colors are `#007ee5` and `#ffffff`.
