### PR TITLE
Dokobit Portal: status signed_file type fix

### DIFF
--- a/certified-connectors/Dokobit Portal/apiDefinition.swagger.json
+++ b/certified-connectors/Dokobit Portal/apiDefinition.swagger.json
@@ -440,9 +440,16 @@
                   "x-ms-summary title": "Name of the file"
                 },
                 "signed_file": {
-                  "type": "string",
+                  "type": "object",
                   "description": "signed_file",
-                  "x-ms-summary title": "Signed file"
+                  "x-ms-summary title": "Signed file",
+                  "properties": {
+                    "url": {
+                      "type": "string",
+                      "description": "url",
+                      "x-ms-summary title": "url"
+                    }
+                  }
                 },
                 "signers": {
                   "type": "array",

--- a/certified-connectors/Dokobit Portal/readme.md
+++ b/certified-connectors/Dokobit Portal/readme.md
@@ -4,7 +4,7 @@ Use Dokobit portal with all the features that it has but make it automated so th
 
 ## Prerequisites
 
-Dokobit Portal Flow connector requires a valid Dokobit Portal account with API access token. 
+In order to use Dokobit Portal, a Business or Enterprise plan in Dokobit Portal is required. Register for free at https://app.dokobit.com to explore the benefits, and contact us at sales@dokobit.com about upgrading your plan.
 
 ## How to get credentials?
 


### PR DESCRIPTION
---
Checked:

- [x] `apiDefinition.swagger.json` is validated using `paconn validate` command.
- [x] `apiProperties.json` has a valid brand color. Invalid brand colors are `#007ee5` and `#ffffff`.
