### PR TITLE
virtustotal - Change file name to file path

### DIFF
--- a/certified-connectors/VirusTotal/apiDefinition.swagger.json
+++ b/certified-connectors/VirusTotal/apiDefinition.swagger.json
@@ -143,7 +143,7 @@
 				"name": "file",
 				"description": "File to be scanned",
 				"required": true,
-				"x-ms-summary": "file name",
+				"x-ms-summary": "file path",
 				"type": "file"
 			  }
 			],


### PR DESCRIPTION
---
Please check the following conditions for your PR.

- [ ] `apiDefinition.swagger.json` is validated using `paconn validate` command.
- [ ] `apiProperties.json` has a valid brand color. Invalid brand colors are `#007ee5` and `#ffffff`.
