### PR TITLE
Update Icon brand color

### DIFF
--- a/certified-connectors/Impexium/apiProperties.json
+++ b/certified-connectors/Impexium/apiProperties.json
@@ -1,7 +1,7 @@
 {
   "properties": {
     "connectionParameters": {},
-    "iconBrandColor": "#D7212F",
+    "iconBrandColor": "#D8212F",
     "capabilities": [],
     "publisher": "Impexium Corporation",
 	"stackOwner": "Impexium Corporation"


### PR DESCRIPTION
---
Please check the following conditions for your PR.

- [ ] `apiDefinition.swagger.json` is validated using `paconn validate` command.
- [ ] `apiProperties.json` has a valid brand color. Invalid brand colors are `#007ee5` and `#ffffff`.
