### PR TITLE
Update icon brand color

### DIFF
--- a/certified-connectors/Bitvore/apiProperties.json
+++ b/certified-connectors/Bitvore/apiProperties.json
@@ -15,7 +15,7 @@
         }
       }
     },
-    "iconBrandColor": "#6399dd",
+    "iconBrandColor": "#539AE3",
     "capabilities": [],
     "publisher": "Bitvore Corp.",
     "stackOwner":"Bitvore Corp."


### PR DESCRIPTION
---
Please check the following conditions for your PR.

- [x] `apiDefinition.swagger.json` is validated using `paconn validate` command.
- [x] `apiProperties.json` has a valid brand color. Invalid brand colors are `#007ee5` and `#ffffff`.
