### PR TITLE
[IMPROVEMENT] Connective, use urlTemplate for configurable url

### DIFF
--- a/certified-connectors/Connective eSignatures/apiDefinition.swagger.json
+++ b/certified-connectors/Connective eSignatures/apiDefinition.swagger.json
@@ -4,7 +4,7 @@
     "description": "Connective eSignatures is a renowned digital signature solution offering a vast amount of signature methods & compliance to the most stringent (inter)national regulations. eSignatures allows you to transform any paper-based process into an end-to-end digital flow with an unparalleled user experience. Streamline the signing process exactly how you want it to and send, sign & track all types of documents directly from your favorite business applications. Join more than 500 satisfied customers.",
     "version": "0.1",
     "title": "Connective eSignatures",
-	"contact": {
+	  "contact": {
       "name": "Connective Support",
       "url": "https://connective.eu/contact-support/",
       "email": "service@connective.eu"

--- a/certified-connectors/Connective eSignatures/apiProperties.json
+++ b/certified-connectors/Connective eSignatures/apiProperties.json
@@ -1,6 +1,19 @@
 {
   "properties": {
     "connectionParameters": {
+      "connectiveHost": {
+        "type": "string",
+        "uiDefinition": {
+          "displayName": "Connective eSignatures environment url",
+          "description": "URL to your Connective eSignatures environment, eg. esignatures.connective.eu",
+          "tooltip": "Please provide the environment url",
+          "constraints": {
+            "tabIndex": 3,
+            "clearText": true,
+            "required": "true"
+          }
+        }
+      },
       "username": {
         "type": "securestring",
         "uiDefinition": {
@@ -8,7 +21,7 @@
           "description": "API username to access the API",
           "tooltip": "Please provide the API username",
           "constraints": {
-            "tabIndex": 2,
+            "tabIndex": 4,
             "clearText": true,
             "required": "true"
           }
@@ -21,16 +34,27 @@
           "description": "API password to access the API",
           "tooltip": "Please provide the API password",
           "constraints": {
-            "tabIndex": 3,
+            "tabIndex": 5,
             "clearText": false,
             "required": "true"
           }
         }
       }
     },
+    "policyTemplateInstances": [
+      {
+        "parameters": {
+          "x-ms-apimTemplateParameter.urlTemplate": "https://@connectionParameters('connectiveHost')/webportalapi/v3"
+        },
+        "templateId": "dynamichosturl",
+        "title": "Route to Connective eSignatures environment"
+      }
+    ],
     "iconBrandColor": "#07155b",
-    "capabilities": [],
-	"publisher": "Connective",
+    "capabilities": [
+      "actions"
+    ],
+    "publisher": "Connective",
     "stackOwner": "Connective"
   }
 }


### PR DESCRIPTION
Add the ability to use a configurable host url so customers can connect to their own Connective eSignatures environment

---
Please check the following conditions for your PR.

- [x] `apiDefinition.swagger.json` is validated using `paconn validate` command.
- [x] `apiProperties.json` has a valid brand color. Invalid brand colors are `#007ee5` and `#ffffff`.
