### PR TITLE
Formstack Documents iconBrandColor change

### DIFF
--- a/certified-connectors/Formstack Documents/apiProperties.json
+++ b/certified-connectors/Formstack Documents/apiProperties.json
@@ -28,7 +28,7 @@
         }
       }
     },
-    "iconBrandColor": "#007ee5",
+    "iconBrandColor": "#D1E0F2",
     "capabilities": [],
     "publisher": "Formstack LLC",
     "stackOwner": "Formstack LLC"


### PR DESCRIPTION
---
Please check the following conditions for your PR.

- [x] `apiDefinition.swagger.json` is validated using `paconn validate` command.
- [x] `apiProperties.json` has a valid brand color. Invalid brand colors are `#007ee5` and `#ffffff`.
