### PR TITLE
fix: settings filename

### DIFF
--- a/tools/paconn-cli/paconn/settings/util.py
+++ b/tools/paconn-cli/paconn/settings/util.py
@@ -16,8 +16,7 @@ from paconn.common.prompts import get_environment, get_connector_id
 from paconn.settings.settingsserializer import SettingsSerializer
 
 # Setting file name
-SETTINGS_FILE = 'settings.json'
-
+SETTINGS_FILE = 'paconn-settings.json'
 
 def prompt_for_environment(settings, flow_rp):
     # Select environment if not provided


### PR DESCRIPTION
Fixes #198 
---
Please check the following conditions for your PR.

- [x] `apiDefinition.swagger.json` is validated using `paconn validate` command.
- [x] `apiProperties.json` has a valid brand color. Invalid brand colors are `#007ee5` and `#ffffff`.
