### PR TITLE
Update icon brand color for certification

### DIFF
--- a/certified-connectors/Flotiq/apiProperties.json
+++ b/certified-connectors/Flotiq/apiProperties.json
@@ -15,7 +15,7 @@
         }
       }
     },
-    "iconBrandColor": "#16A085",
+    "iconBrandColor": "#EBEBEB",
     "capabilities": [],
     "stackOwner": "Flotiq",
     "publisher": "CodeWave LLC"


### PR DESCRIPTION
Please accept the update for icon brand color, as required in the ISV step of the certification process.