### PR TITLE
Planner - add support for all 25 categories

### DIFF
--- a/certified-connectors/Planner/apiDefinition.swagger.json
+++ b/certified-connectors/Planner/apiDefinition.swagger.json
@@ -1513,6 +1513,101 @@
           "type": "boolean",
           "x-ms-summary": "Purple",
           "description": "True if the task has the Purple category."
+        },
+        "category7": {
+          "type": "boolean",
+          "x-ms-summary": "Bronze",
+          "description": "True if the task has the Bronze category."
+        },
+        "category8": {
+          "type": "boolean",
+          "x-ms-summary": "Lime",
+          "description": "True if the task has the Lime category."
+        },
+        "category9": {
+          "type": "boolean",
+          "x-ms-summary": "Aqua",
+          "description": "True if the task has the Aqua category."
+        },
+        "category10": {
+          "type": "boolean",
+          "x-ms-summary": "Gray",
+          "description": "True if the task has the Gray category."
+        },
+        "category11": {
+          "type": "boolean",
+          "x-ms-summary": "Silver",
+          "description": "True if the task has the Silver category."
+        },
+        "category12": {
+          "type": "boolean",
+          "x-ms-summary": "Brown",
+          "description": "True if the task has the Brown category."
+        },
+        "category13": {
+          "type": "boolean",
+          "x-ms-summary": "Cranberry",
+          "description": "True if the task has the Cranberry category."
+        },
+        "category14": {
+          "type": "boolean",
+          "x-ms-summary": "Orange",
+          "description": "True if the task has the Orange category."
+        },
+        "category15": {
+          "type": "boolean",
+          "x-ms-summary": "Peach",
+          "description": "True if the task has the Peach category."
+        },
+        "category16": {
+          "type": "boolean",
+          "x-ms-summary": "Marigold",
+          "description": "True if the task has the Marigold category."
+        },
+        "category17": {
+          "type": "boolean",
+          "x-ms-summary": "Light green",
+          "description": "True if the task has the Light green category."
+        },
+        "category18": {
+          "type": "boolean",
+          "x-ms-summary": "Dark green",
+          "description": "True if the task has the Dark green category."
+        },
+        "category19": {
+          "type": "boolean",
+          "x-ms-summary": "Teal",
+          "description": "True if the task has the Teal category."
+        },
+        "category20": {
+          "type": "boolean",
+          "x-ms-summary": "Light blue",
+          "description": "True if the task has the Light blue category."
+        },
+        "category21": {
+          "type": "boolean",
+          "x-ms-summary": "Dark blue",
+          "description": "True if the task has the Dark blue category."
+        },
+        "category22": {
+          "type": "boolean",
+          "x-ms-summary": "Lavender",
+          "description": "True if the task has the Lavender category."
+        },
+        "category23": {
+          "type": "boolean",
+          "x-ms-summary": "Plum",
+          "description": "True if the task has the Plum category."
+        },
+        "category24": {
+          "type": "boolean",
+          "x-ms-summary": "Light gray",
+          "description": "True if the task has the Light gray category."
+        },
+        "category25": {
+          "type": "boolean",
+          "x-ms-summary": "Dark gray",
+          "description": "True if the task has the Dark gray category."
         }
       }
     }


### PR DESCRIPTION
Planner now supports 25 labels in total. This change adds labels 7-25 to the AppliedCategories schema.
This will affect GetTask_Response_V2, UpdateTask_Request_V3 and CreateTask_Request_V3

---
Please check the following conditions for your PR.

- [x] `apiDefinition.swagger.json` is validated using `paconn validate` command.
- [x] `apiProperties.json` has a valid brand color. Invalid brand colors are `#007ee5` and `#ffffff`.
