### PR TITLE
Missing hyperlink

### DIFF
--- a/independent-publisher-connectors/readme.md
+++ b/independent-publisher-connectors/readme.md
@@ -41,7 +41,7 @@ Click here to read through the Independent Publisher Connector Manifesto.
 
 5. If an end service owner reaches out to Microsoft or the Independent Publisher Connector Group and requests that they want ownership of the Independent Publisher connector that connects to their end service, Microsoft reserves the right to provide them with maintainer rights.
 
-Click here to read through the rest of the Independent Publisher Connector Manifesto.
+Click [here](https://github-wiki-see.page/m/microsoft/PowerPlatformConnectors/wiki/Independent-Publisher-Connector-Group-%22Manifesto%22) to read through the rest of the Independent Publisher Connector Manifesto.
 
 ## Top Connector Asks
 


### PR DESCRIPTION
Missing hyperlink to the manifesto.
https://github-wiki-see.page/m/microsoft/PowerPlatformConnectors/wiki/Independent-Publisher-Connector-Group-%22Manifesto%22


---
When submitting a connector, please check the following conditions for your PR.

- [ ] I attest that the connector works and I verified by deploying and testing all the operations.
- [ ] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [ ] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a logo.
