### PR TITLE
Added additional fields to SendMessage methods

### DIFF
--- a/certified-connectors/SmartDialog/apiDefinition.swagger.json
+++ b/certified-connectors/SmartDialog/apiDefinition.swagger.json
@@ -205,6 +205,23 @@
                   "type": "string",
                   "description": "Attachment Uri to be used when sending WhatsApp message that contains an attachment.",
                   "title": "Attachment Uri"
+                },
+                "CustomerData": {
+                  "type": "string",
+                  "maxLength": 255,
+                  "description": "Billing/grouping data for this message, optional",
+                  "title": "Customer Data"
+                },
+                "AdMessage": {
+                  "type": "boolean",
+                  "description": "Optional overriding flag for marking the message as an ad message",
+                  "title": "Ad Message"
+                },
+                "DlrUrl": {
+                  "type": "string",
+                  "description": "Url for Delivery status callback via http-get. You may add querystring values to url, they will be preserved.",
+                  "example": "https://api.company.com/Dlr",
+                  "title": "Dlr Url"
                 }
               },
               "required": [
@@ -733,6 +750,12 @@
                   "type": "string",
                   "description": "Delivery report Url that will recieve a callback when the sendprocess completes.",
                   "title": "Dlr Url"
+                },
+                "CustomerData": {
+                  "type": "string",
+                  "maxLength": 255,
+                  "description": "Billing/grouping data for this message, optional",
+                  "title": "Customer Data"
                 }
               },
               "required": [


### PR DESCRIPTION
---
### When submitting a connector, please make sure that you follow the requirements below, otherwise your PR might be rejected. We want to make you have a well-built connector, a smooth certification experience, and your users are happy :) 

- [X] I attest that the connector works and I verified by deploying and testing all the operations. 
- [X] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [X] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [X] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [X] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.

If you are an Independent Publisher, you must also attest to the following to ensure a smooth publishing process:
- [ ] I have named this PR after the pattern of "Connector Name (Independent Publisher)" ex: HubSpot Marketing (Independent Publisher)
- [ ] Within this PR markdown file, I have pasted screenshots that show: 3 unique operations (actions/triggers) working within a Flow. This can be in one flow or part of multiple flows. For each one of those flows, I have pasted in screenshots of the Flow succeeding. 
- [ ] Within this PR markdown file, I have pasted in a screenshot from the Test operations section within the Custom Connector UI.
- [ ] If the connector uses OAuth, I have provided detailed steps on how to create an app in the readme.md. 


