### PR TITLE
Plumsail Forms: added Delete submission action

### DIFF
--- a/certified-connectors/Plumsail Forms/Readme.md
+++ b/certified-connectors/Plumsail Forms/Readme.md
@@ -16,3 +16,6 @@ paconn create --api-def apiDefinition.swagger.json --api-prop apiProperties.json
 
 ## Supported Operations
 * `Form is submitted`: a trigger that fires when the specified form is submitted
+* `Delete submission`: an action that deletes the specified submission
+* `Download attachment`: an action that downloads the specified attachment
+* `Delete attachment`: an action that deletes the specified attachment

--- a/certified-connectors/Plumsail Forms/apiDefinition.swagger.json
+++ b/certified-connectors/Plumsail Forms/apiDefinition.swagger.json
@@ -138,6 +138,51 @@
         "description": "Returns an array of public forms"
       }
     },
+    "/api/forms/{formId}/submissions/{submissionId}": {
+      "delete": {
+        "tags": [
+          "FormSubmissions"
+        ],
+        "operationId": "DeleteSubmission",
+        "consumes": [],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "formId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-dynamic-values": {
+              "operationId": "GetPublicForms",
+              "value-path": "id",
+              "value-title": "name",
+              "parameters": {
+                "version": "2"
+              }
+            },
+            "x-ms-summary": "Form",
+            "description": "The form which submission you want to delete."
+          },
+          {
+            "name": "submissionId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "x-ms-summary": "Submission ID",
+            "description": "Submission ID"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          }
+        },
+        "x-ms-visibility": "important",
+        "summary": "Delete submission",
+        "description": "Deletes an form submission by its ID"
+      }
+    },
     "/api/flow/schema/form": {
       "get": {
         "tags": [


### PR DESCRIPTION
---
### When submitting a connector, please make sure that you follow the requirements below, otherwise your PR might be rejected. We want to make you have a well-built connector, a smooth certification experience, and your users are happy :) 

- [x] I attest that the connector works and I verified by deploying and testing all the operations. 
- [x] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [x] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [x] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [x] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.

If you are an Independent Publisher, you must also attest to the following to ensure a smooth publishing process:
- [x] I have named this PR after the pattern of "Connector Name (Independent Publisher)" ex: HubSpot Marketing (Independent Publisher)
- [x] Within this PR markdown file, I have pasted screenshots that show: 3 unique operations (actions/triggers) working within a Flow. This can be in one flow or part of multiple flows. For each one of those flows, I have pasted in screenshots of the Flow succeeding. 
- [x] Within this PR markdown file, I have pasted in a screenshot from the Test operations section within the Custom Connector UI.
- [x] If the connector uses OAuth, I have provided detailed steps on how to create an app in the readme.md. 


