### PR TITLE
Connective eSignatures bug fixes

### DIFF
--- a/certified-connectors/Connective eSignatures/Readme.md
+++ b/certified-connectors/Connective eSignatures/Readme.md
@@ -32,6 +32,7 @@ The available actions can be grouped into different groups
 |                                     | [Get Package List](https://documentation-archive.connective.eu/en-us/eSignatures5.5/api/Packagelist.html) |
 | Miscellaneous actions               | [Skip Signers](https://documentation-archive.connective.eu/en-us/eSignatures5.5/api/SkipSigners.html) |
 |                                     | [Download Package](https://documentation-archive.connective.eu/en-us/eSignatures5.5/api/DownloadPackage.html) |
+|                                     | [Download Document from Package](https://documentation-archive.connective.eu/en-us/eSignatures5.5/api/DownloadDocumentfromPackage.html) |
 |                                     | [Package Expiry Extension](https://documentation-archive.connective.eu/en-us/eSignatures5.5/api/PackageExpiryExtension.html) |
 |                                     | [Send Package Reminder](https://documentation-archive.connective.eu/en-us/eSignatures5.5/api/SendPackageReminders.html) |
 |                                     | [Delete Package](https://documentation-archive.connective.eu/en-us/eSignatures5.5/api/SendPackageReminders.html) |

--- a/certified-connectors/Connective eSignatures/apiDefinition.swagger.json
+++ b/certified-connectors/Connective eSignatures/apiDefinition.swagger.json
@@ -631,6 +631,14 @@
                   "type": "boolean",
                   "description": "This parameter determines whether packages can be downloaded from the WYSIWYS before signing"
                 },
+                "ReassignEnabled": {
+                  "type": "boolean",
+                  "description": "This parameter determines whether packages can be reassigned from the WYSIWYS to another approver/signer."
+                },
+                "ActionUrlExpirationPeriodInDays": {
+                  "type": "integer",
+                  "description": "This parameter determines after how many days the action URLs must expire when they are not used."
+                },
                 "ExpiryTimestamp": {
                   "type": "string",
                   "description": "Reference given by the calling application. This parameter will not be used by the eSignatures Portal"
@@ -908,6 +916,14 @@
                   "type": "boolean",
                   "description": "This parameter determines whether packages can be downloaded from the WYSIWYS before signing."
                 },
+                "ReassignEnabled": {
+                  "type": "boolean",
+                  "description": "This parameter determines whether packages can be reassigned from the WYSIWYS to another approver/signer."
+                },
+                "ActionUrlExpirationPeriodInDays": {
+                  "type": "integer",
+                  "description": "This parameter determines after how many days the action URLs must expire when they are not used."
+                },
                 "ExpiryTimestamp": {
                   "type": "string",
                   "description": "The date and time when this package expires and can no longer be signed."
@@ -1081,7 +1097,7 @@
                         "description": "Detected or specified label"
                       },
                       "PageNumber": {
-                        "type": "boolean",
+                        "type": "integer",
                         "description": "The page on which the location was found."
                       }
                     }
@@ -1342,11 +1358,53 @@
           "200": {
             "description": "The package gets downloaded successfully.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "binary"
             }
           },
           "404": {
             "description": "The package cannot be found."
+          },
+          "409": {
+            "description": "The package hasn't been fully signed."
+          }
+        },
+        "x-ms-visibility": "advanced"
+      }
+    },
+    "/packages/{id}/download/{documentId}": {
+      "get": {
+        "summary": "Download Document from Package",
+        "description": "The signed documents in a package can be downloaded one by one by an external system using this call. Each document will be downloaded as a PDF, or as an XML file stream, depending on the value of the DocumentType parameter.",
+        "operationId": "DownloadDocumentFromPackage",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "type": "string",
+            "required": true,
+            "description": "Unique id for the signing package",
+            "x-ms-summary": "Unique id for the signing package"
+          },
+          {
+            "name": "documentId",
+            "in": "path",
+            "type": "string",
+            "required": true,
+            "description": "Unique id of the document contained in the package",
+            "x-ms-summary": "Unique id of the document contained in the package"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The document gets downloaded successfully.",
+            "schema": {
+              "type": "string",
+              "format": "binary"
+            }
+          },
+          "404": {
+            "description": "The document cannot be found or is not part of the specified package."
           },
           "409": {
             "description": "The package hasn't been fully signed."


### PR DESCRIPTION
- added missing properties `reassignEnabled` & `actionUrlExpirationPeriodInDays` to two methods
- fixed return property type from `boolean` to `integer` for `pageNumber`
- fixed return schema for `DownloadPackage`
- added missing method `DownloadDocumentFromPackage`

---
### When submitting a connector, please make sure that you follow the requirements below, otherwise your PR might be rejected. We want to make you have a well-built connector, a smooth certification experience, and your users are happy :) 

- [x] I attest that the connector works and I verified by deploying and testing all the operations. 
- [x] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [x] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [x] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [x] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.