### PR TITLE
openFDA Drug (Independent Publisher)

### DIFF
--- a/independent-publisher-connectors/openFDA Drug/apiDefinition.swagger.json
+++ b/independent-publisher-connectors/openFDA Drug/apiDefinition.swagger.json
@@ -1057,8 +1057,8 @@
             }
           }
         },
-        "summary": "Drugs@FDA",
-        "description": "Drugs@FDA includes most of the drug products approved since 1939. The majority of patient information, labels, approval letters, reviews, and other information are available for drug products approved since 1998.",
+        "summary": "DrugsFDA",
+        "description": "DrugsFDA includes most of the drug products approved since 1939. The majority of patient information, labels, approval letters, reviews, and other information are available for drug products approved since 1998.",
         "operationId": "DrugsFDA",
         "parameters": [
           {

--- a/independent-publisher-connectors/openFDA Drug/apiDefinition.swagger.json
+++ b/independent-publisher-connectors/openFDA Drug/apiDefinition.swagger.json
@@ -1,0 +1,1104 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "openFDA Drug",
+    "description": "openFDA is an Elasticsearch-based API that serves public FDA data about nouns like drugs, devices, and foods. Each of these nouns has one or more categories, which serve unique data-such as data about recall enforcement reports, or about adverse events. Every query to the API must go through one endpoint for one kind of data.",
+    "version": "1.0",
+    "contact": {
+      "name": "Woong Choi",
+      "email": "Woong.Choi@sevensigma.com.au"
+    }
+  },
+  "host": "api.fda.gov",
+  "basePath": "/drug",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [],
+  "produces": [],
+  "paths": {
+    "/event.json": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "default",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "meta": {
+                  "type": "object",
+                  "properties": {
+                    "disclaimer": {
+                      "type": "string",
+                      "description": "Disclaimer"
+                    },
+                    "terms": {
+                      "type": "string",
+                      "description": "Terms of Service"
+                    },
+                    "license": {
+                      "type": "string",
+                      "description": "Data Licensing"
+                    },
+                    "last_updated": {
+                      "type": "string",
+                      "description": "Last Update Date"
+                    },
+                    "results": {
+                      "type": "object",
+                      "properties": {
+                        "skip": {
+                          "type": "integer",
+                          "format": "int32",
+                          "description": "Number of skipped records"
+                        },
+                        "limit": {
+                          "type": "integer",
+                          "format": "int32",
+                          "description": "Number of records to be returned"
+                        },
+                        "total": {
+                          "type": "integer",
+                          "format": "int32",
+                          "description": "Number of total records"
+                        }
+                      },
+                      "description": "Metadata result"
+                    }
+                  },
+                  "description": "Metadata"
+                },
+                "results": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "receiptdateformat": {
+                        "type": "string",
+                        "description": "Receipt date format"
+                      },
+                      "receiver": {
+                        "type": "string",
+                        "description": "Receiver"
+                      },
+                      "seriousnessdeath": {
+                        "type": "string",
+                        "description": "Adverse event resulted in death"
+                      },
+                      "companynumb": {
+                        "type": "string",
+                        "description": "Identifier for the company providing the report."
+                      },
+                      "receivedateformat": {
+                        "type": "string",
+                        "description": "Encoding format of the transmissiondate field"
+                      },
+                      "primarysource": {
+                        "type": "object",
+                        "properties": {
+                          "reportercountry": {
+                            "type": "string",
+                            "description": "Country from which the report was submitted."
+                          },
+                          "qualification": {
+                            "type": "string",
+                            "description": "Category of individual who submitted the report."
+                          }
+                        },
+                        "description": "Primary Source"
+                      },
+                      "transmissiondateformat": {
+                        "type": "string",
+                        "description": "Encoding format of the transmissiondate field."
+                      },
+                      "fulfillexpeditecriteria": {
+                        "type": "string",
+                        "description": "Identifies expedited reports (those that were processed within 15 days)."
+                      },
+                      "safetyreportid": {
+                        "type": "string",
+                        "description": "The 8-digit Safety Report ID number, also known as the case report number or case ID."
+                      },
+                      "sender": {
+                        "type": "object",
+                        "properties": {
+                          "senderorganization": {
+                            "type": "string",
+                            "description": "Name of the organization sending the report."
+                          }
+                        },
+                        "description": "Sender"
+                      },
+                      "receivedate": {
+                        "type": "string",
+                        "description": "Date that the report was first received by FDA."
+                      },
+                      "patient": {
+                        "type": "object",
+                        "properties": {
+                          "patientonsetage": {
+                            "type": "string",
+                            "description": "Age of the patient when the event first occured."
+                          },
+                          "patientonsetageunit": {
+                            "type": "string",
+                            "description": "The unit for the interval in the field patientonsetage."
+                          },
+                          "patientsex": {
+                            "type": "string",
+                            "description": "The sex of the patient."
+                          },
+                          "patientdeath": {
+                            "type": "object",
+                            "properties": {
+                              "patientdeathdateformat": {
+                                "type": "string",
+                                "description": "Encoding format of the field patientdeathdate."
+                              },
+                              "patientdeathdate": {
+                                "type": "string",
+                                "description": "If the patient died, the date that the patient died"
+                              }
+                            },
+                            "description": "Patient death"
+                          },
+                          "reaction": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "reactionmeddrapt": {
+                                  "type": "string",
+                                  "description": "Patient reaction, as a MedDRA term."
+                                }
+                              }
+                            },
+                            "description": "Reaction"
+                          },
+                          "drug": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "drugcharacterization": {
+                                  "type": "string",
+                                  "description": "Reported role of the drug in the adverse event report."
+                                },
+                                "medicinalproduct": {
+                                  "type": "string",
+                                  "description": "Drug name."
+                                },
+                                "drugauthorizationnumb": {
+                                  "type": "string",
+                                  "description": "Drug authorization or application number (NDA or ANDA), if provided."
+                                },
+                                "drugadministrationroute": {
+                                  "type": "string",
+                                  "description": "The drug's route of administration."
+                                },
+                                "drugindication": {
+                                  "type": "string",
+                                  "description": "Indication for the drug's use."
+                                }
+                              }
+                            },
+                            "description": "Drug"
+                          }
+                        },
+                        "description": "Patient"
+                      },
+                      "transmissiondate": {
+                        "type": "string",
+                        "description": "Date that the record was created."
+                      },
+                      "serious": {
+                        "type": "string",
+                        "description": "Seriousness of the adverse event."
+                      },
+                      "receiptdate": {
+                        "type": "string",
+                        "description": "Date that the most recent information in the report was received by FDA."
+                      }
+                    }
+                  },
+                  "description": "Results"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Drug Adverse Event",
+        "description": "The openFDA drug adverse event API returns data that has been collected from the FDA Adverse Event Reporting System (FAERS), a database that contains information on adverse event and medication error reports submitted to FDA.",
+        "operationId": "DrugAdverseEvent",
+        "parameters": [
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "x-ms-summary": "Search Query",
+            "description": "single"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "x-ms-summary": "Number of records to be returned",
+            "description": "single"
+          }
+        ]
+      }
+    },
+    "/label.json": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "default",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "meta": {
+                  "type": "object",
+                  "properties": {
+                    "disclaimer": {
+                      "type": "string",
+                      "description": "Disclaimer"
+                    },
+                    "terms": {
+                      "type": "string",
+                      "description": "Terms of Service"
+                    },
+                    "license": {
+                      "type": "string",
+                      "description": "Data Licensing"
+                    },
+                    "last_updated": {
+                      "type": "string",
+                      "description": "Last Update Date"
+                    },
+                    "results": {
+                      "type": "object",
+                      "properties": {
+                        "skip": {
+                          "type": "integer",
+                          "format": "int32",
+                          "description": "Number of skipped records"
+                        },
+                        "limit": {
+                          "type": "integer",
+                          "format": "int32",
+                          "description": "Number of records to be returned"
+                        },
+                        "total": {
+                          "type": "integer",
+                          "format": "int32",
+                          "description": "Number of total records"
+                        }
+                      },
+                      "description": "Metadata result"
+                    }
+                  },
+                  "description": "Metadata"
+                },
+                "results": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "effective_time": {
+                        "type": "string",
+                        "description": "Date reference to the particular version of the labeling document."
+                      },
+                      "inactive_ingredient": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "A list of inactive, non-medicinal ingredients in a drug product."
+                      },
+                      "references": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "This field may contain references when prescription drug labeling must summarize or otherwise relay on a recommendation by an authoritative scientific body, or on a standardized methodology, scale, or technique, because the information is important to prescribing decisions."
+                      },
+                      "purpose": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Information about the drug product's indications for use."
+                      },
+                      "keep_out_of_reach_of_children": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Information pertaining to whether the product should be kept out of the reach of children, and instructions about what to do in the case of accidental contact or ingestion, if appropriate."
+                      },
+                      "warnings": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Information about serious adverse reactions and potential safety hazards, including limitations in use imposed by those hazards and steps that should be taken if they occur."
+                      },
+                      "spl_product_data_elements": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Usually a list of ingredients in a drug product."
+                      },
+                      "other_safety_information": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Information about safe use and handling of the product that may not have been specified in another field."
+                      },
+                      "openfda": {
+                        "type": "object",
+                        "properties": {},
+                        "description": "OpenFDA"
+                      },
+                      "version": {
+                        "type": "string",
+                        "description": "A sequentially increasing number identifying the particular version of a document, starting with 1."
+                      },
+                      "dosage_and_administration": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Information about the drug product's dosage and administration recommendations, including starting dose, dose range, titration regimens, and any other clinically sigificant information that affects dosing recommendations."
+                      },
+                      "pregnancy_or_breast_feeding": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Documentation forthcoming."
+                      },
+                      "stop_use": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Information about when use of the drug product should be discontinued immediately and a doctor consulted. Includes information about any signs of toxicity or other reactions that would necessitate immediately discontinuing use of the product."
+                      },
+                      "package_label_principal_display_panel": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "The content of the principal display panel of the product package, usually including the product's name, dosage forms, and other key information about the drug product."
+                      },
+                      "indications_and_usage": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "A statement of each of the drug product's indications for use, such as for the treatment, prevention, mitigation, cure, or diagnosis of a disease or condition, or of a manifestation of a recognized disease or condition, or for the relief of symptoms associated with a recognized disease or condition. This field may also describe any relevant limitations of use."
+                      },
+                      "set_id": {
+                        "type": "string",
+                        "description": "The Set ID, A globally unique identifier (GUID) for the labeling, stable across all versions or revisions."
+                      },
+                      "id": {
+                        "type": "string",
+                        "description": "The document ID, A globally unique identifier (GUID) for the particular revision of a labeling document."
+                      },
+                      "active_ingredient": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "A list of the active, medicinal ingredients in the drug product."
+                      },
+                      "dosage_and_administration_table": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Information about the drug product's dosage and administration recommendations, including starting dose, dose range, titration regimens, and any other clinically sigificant information that affects dosing recommendations."
+                      }
+                    }
+                  },
+                  "description": "Results"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Drug Labeling",
+        "description": "Drug manufacturers and distributors submit documentation about their products to FDA in the Structured Product Labeling (SPL) format. The openFDA drug product labeling API returns data from this dataset.",
+        "operationId": "DrugLabeling",
+        "parameters": [
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "x-ms-summary": "Search Query",
+            "description": "single"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "x-ms-summary": "Number of records to be returned",
+            "description": "single"
+          }
+        ]
+      }
+    },
+    "/ndc.json": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "default",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "meta": {
+                  "type": "object",
+                  "properties": {
+                    "disclaimer": {
+                      "type": "string",
+                      "description": "Disclaimer"
+                    },
+                    "terms": {
+                      "type": "string",
+                      "description": "Terms of Service"
+                    },
+                    "license": {
+                      "type": "string",
+                      "description": "Data Licensing"
+                    },
+                    "last_updated": {
+                      "type": "string",
+                      "description": "Last Update Date"
+                    },
+                    "results": {
+                      "type": "object",
+                      "properties": {
+                        "skip": {
+                          "type": "integer",
+                          "format": "int32",
+                          "description": "Number of skipped records"
+                        },
+                        "limit": {
+                          "type": "integer",
+                          "format": "int32",
+                          "description": "Number of records to be returned"
+                        },
+                        "total": {
+                          "type": "integer",
+                          "format": "int32",
+                          "description": "Number of total records"
+                        }
+                      },
+                      "description": "Metadata result"
+                    }
+                  },
+                  "description": "Metadata"
+                },
+                "results": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "product_ndc": {
+                        "type": "string",
+                        "description": "The labeler manufacturer code and product code segments of the NDC number, separated by a hyphen."
+                      },
+                      "generic_name": {
+                        "type": "string",
+                        "description": "Generic name(s) of the drug product."
+                      },
+                      "labeler_name": {
+                        "type": "string",
+                        "description": "Labeler name of the drug product."
+                      },
+                      "brand_name": {
+                        "type": "string",
+                        "description": "Brand or trade name of the drug product."
+                      },
+                      "active_ingredients": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string",
+                              "description": "The names of the active, medicinal ingredients in the drug product."
+                            },
+                            "strength": {
+                              "type": "string",
+                              "description": "The strength of the active, medicinal ingredients in the drug product."
+                            }
+                          }
+                        },
+                        "description": "Active Ingredients"
+                      },
+                      "finished": {
+                        "type": "boolean",
+                        "description": "finished"
+                      },
+                      "packaging": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "package_ndc": {
+                              "type": "string",
+                              "description": "This number, known as the NDC, identifies the labeler, product, and trade package size. The first segment, the labeler code, is assigned by the FDA. A labeler is any firm that manufactures (including repackers or relabelers), or distributes (under its own name) the drug."
+                            },
+                            "description": {
+                              "type": "string",
+                              "description": "A description of the size and type of packaging in sentence form. Multilevel packages will have the descriptions concatenated together."
+                            },
+                            "marketing_start_date": {
+                              "type": "string",
+                              "description": "This is the date that the labeler indicates was the start of its marketing of the drug product."
+                            },
+                            "sample": {
+                              "type": "boolean",
+                              "description": "Indicates whether this is a sample packaging or not."
+                            }
+                          }
+                        },
+                        "description": "Packaging"
+                      },
+                      "listing_expiration_date": {
+                        "type": "string",
+                        "description": "This is the date when the listing record will expire if not updated or certified by the firm."
+                      },
+                      "openfda": {
+                        "type": "object",
+                        "properties": {
+                          "manufacturer_name": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "description": "Name of manufacturer or company that makes this drug product, corresponding to the labeler code segment of the NDC."
+                          },
+                          "rxcui": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "description": "The RxNorm Concept Unique Identifier. RxCUI is a unique number that describes a semantic concept about the drug product, including its ingredients, strength, and dose forms."
+                          },
+                          "spl_set_id": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "description": "Unique identifier for the Structured Product Label for a product, which is stable across versions of the label. Also referred to as the set ID."
+                          },
+                          "nui": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "description": "Unique identifier applied to a drug concept within the National Drug File Reference Terminology (NDF-RT)."
+                          },
+                          "pharm_class_epc": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "description": "Established pharmacologic class associated with an approved indication of an active moiety (generic drug) that the FDA has determined to be scientifically valid and clinically meaningful. Takes the form of the pharmacologic class, followed by [EPC] (such as Thiazide Diuretic [EPC] or Tumor Necrosis Factor Blocker [EPC]."
+                          },
+                          "pharm_class_pe": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "description": "Physiologic effect or pharmacodynamic effect—tissue, organ, or organ system level functional activity—of the drug's established pharmacologic class. Takes the form of the effect, followed by [PE] (such as Increased Diuresis [PE] or Decreased Cytokine Activity [PE]."
+                          },
+                          "unii": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "description": "Unique Ingredient Identifier, which is a non-proprietary, free, unique, unambiguous, non-semantic, alphanumeric identifier based on a substance's molecular structure and/or descriptive information."
+                          }
+                        },
+                        "description": "OpenFDA"
+                      },
+                      "marketing_category": {
+                        "type": "string",
+                        "description": "Product types are broken down into several potential Marketing Categories, such as NDA/ANDA/BLA, OTC Monograph, or Unapproved Drug."
+                      },
+                      "dosage_form": {
+                        "type": "string",
+                        "description": "The drug's dosage form. There is no standard, but values may include terms like tablet or solution for injection."
+                      },
+                      "spl_id": {
+                        "type": "string",
+                        "description": "Unique identifier for a particular version of a Structured Product Label for a product. Also referred to as the document ID."
+                      },
+                      "product_type": {
+                        "type": "string",
+                        "description": "Type of drug product"
+                      },
+                      "route": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "The route of administation of the drug product."
+                      },
+                      "marketing_start_date": {
+                        "type": "string",
+                        "description": "This is the date that the labeler indicates was the start of its marketing of the drug product."
+                      },
+                      "product_id": {
+                        "type": "string",
+                        "description": "ProductID is a concatenation of the NDC product code and SPL documentID."
+                      },
+                      "application_number": {
+                        "type": "string",
+                        "description": "This corresponds to the NDA, ANDA, or BLA number reported by the labeler for products which have the corresponding Marketing Category designated. If the designated Marketing Category is OTC Monograph Final or OTC Monograph Not Final, then the application number will be the CFR citation corresponding to the appropriate Monograph (e.g. “part 341”). For unapproved drugs, this field will be null."
+                      },
+                      "brand_name_base": {
+                        "type": "string",
+                        "description": "The base of the brand name excluding its suffix."
+                      },
+                      "pharm_class": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "These are the reported pharmacological class categories corresponding to the SubstanceNames listed above."
+                      }
+                    }
+                  },
+                  "description": "Results"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Drug NDC",
+        "description": "The openFDA drug NDC Directory endpoint returns data from the NDC Directory, a database that contains information on the National Drug Code (NDC). FDA publishes the listed NDC numbers and the information submitted as part of the listing information in the NDC Directory which is updated daily.",
+        "operationId": "DrugNDC",
+        "parameters": [
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "x-ms-summary": "Search Query",
+            "description": "single"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "x-ms-summary": "Number of records to be returned",
+            "description": "single"
+          }
+        ]
+      }
+    },
+    "/enforcement.json": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "default",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "meta": {
+                  "type": "object",
+                  "properties": {
+                    "disclaimer": {
+                      "type": "string",
+                      "description": "Disclaimer"
+                    },
+                    "terms": {
+                      "type": "string",
+                      "description": "Terms of Service"
+                    },
+                    "license": {
+                      "type": "string",
+                      "description": "Data Licensing"
+                    },
+                    "last_updated": {
+                      "type": "string",
+                      "description": "Last Update Date"
+                    },
+                    "results": {
+                      "type": "object",
+                      "properties": {
+                        "skip": {
+                          "type": "integer",
+                          "format": "int32",
+                          "description": "Number of skipped records"
+                        },
+                        "limit": {
+                          "type": "integer",
+                          "format": "int32",
+                          "description": "Number of records to be returned"
+                        },
+                        "total": {
+                          "type": "integer",
+                          "format": "int32",
+                          "description": "Number of total records"
+                        }
+                      },
+                      "description": "Metadata result"
+                    }
+                  },
+                  "description": "Metadata"
+                },
+                "results": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "country": {
+                        "type": "string",
+                        "description": "The country in which the recalling firm is located."
+                      },
+                      "city": {
+                        "type": "string",
+                        "description": "The city in which the recalling firm is located."
+                      },
+                      "address_1": {
+                        "type": "string",
+                        "description": "This is an .exact field. It has been indexed both as its exact string content, and also tokenized."
+                      },
+                      "reason_for_recall": {
+                        "type": "string",
+                        "description": "Information describing how the product is defective and violates the FD&C Act or related statutes."
+                      },
+                      "address_2": {
+                        "type": "string",
+                        "description": "This is an .exact field. It has been indexed both as its exact string content, and also tokenized."
+                      },
+                      "product_quantity": {
+                        "type": "string",
+                        "description": "The amount of defective product subject to recall."
+                      },
+                      "code_info": {
+                        "type": "string",
+                        "description": "A list of all lot and/or serial numbers, product numbers, packer or manufacturer numbers, sell or use by dates, etc., which appear on the product or its labeling."
+                      },
+                      "center_classification_date": {
+                        "type": "string",
+                        "description": "Center classification date"
+                      },
+                      "distribution_pattern": {
+                        "type": "string",
+                        "description": "General area of initial distribution such as, “Distributors in 6 states: NY, VA, TX, GA, FL and MA; the Virgin Islands; Canada and Japan”. The term “nationwide” is defined to mean the fifty states or a significant portion. Note that subsequent distribution by the consignees to other parties may not be included."
+                      },
+                      "state": {
+                        "type": "string",
+                        "description": "The U.S. state in which the recalling firm is located."
+                      },
+                      "product_description": {
+                        "type": "string",
+                        "description": "Brief description of the product being recalled."
+                      },
+                      "report_date": {
+                        "type": "string",
+                        "description": "Date that the FDA issued the enforcement report for the product recall."
+                      },
+                      "classification": {
+                        "type": "string",
+                        "description": "Numerical designation (I, II, or III) that is assigned by FDA to a particular product recall that indicates the relative degree of health hazard."
+                      },
+                      "openfda": {
+                        "type": "object",
+                        "properties": {},
+                        "description": "OpenFDA"
+                      },
+                      "recalling_firm": {
+                        "type": "string",
+                        "description": "The firm that initiates a recall or, in the case of an FDA requested recall or FDA mandated recall, the firm that has primary responsibility for the manufacture and (or) marketing of the product to be recalled."
+                      },
+                      "recall_number": {
+                        "type": "string",
+                        "description": "A numerical designation assigned by FDA to a specific recall event used for tracking purposes."
+                      },
+                      "initial_firm_notification": {
+                        "type": "string",
+                        "description": "The method(s) by which the firm initially notified the public or their consignees of a recall. A consignee is a person or firm named in a bill of lading to whom or to whose order the product has or will be delivered."
+                      },
+                      "product_type": {
+                        "type": "string",
+                        "description": "Product type"
+                      },
+                      "event_id": {
+                        "type": "string",
+                        "description": "A numerical designation assigned by FDA to a specific recall event used for tracking purposes."
+                      },
+                      "termination_date": {
+                        "type": "string",
+                        "description": "Termination date"
+                      },
+                      "more_code_info": {
+                        "type": "string",
+                        "description": "More code info"
+                      },
+                      "recall_initiation_date": {
+                        "type": "string",
+                        "description": "Date that the firm first began notifying the public or their consignees of the recall."
+                      },
+                      "postal_code": {
+                        "type": "string",
+                        "description": "Postal code"
+                      },
+                      "voluntary_mandated": {
+                        "type": "string",
+                        "description": "Describes who initiated the recall. Recalls are almost always voluntary, meaning initiated by a firm. A recall is deemed voluntary when the firm voluntarily removes or corrects marketed products or the FDA requests the marketed products be removed or corrected. A recall is mandated when the firm was ordered by the FDA to remove or correct the marketed products, under section 518(e) of the FD&C Act, National Childhood Vaccine Injury Act of 1986, 21 CFR 1271.440, Infant Formula Act of 1980 and its 1986 amendments, or the Food Safety Modernization Act (FSMA)."
+                      },
+                      "status": {
+                        "type": "string",
+                        "description": "This is an .exact field. It has been indexed both as its exact string content, and also tokenized."
+                      }
+                    }
+                  },
+                  "description": "Results"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "x-ms-summary": "Search Query",
+            "description": "single"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "x-ms-summary": "Number of records to be returned",
+            "description": "single"
+          }
+        ],
+        "summary": "Drug Enforcement",
+        "description": "The openFDA drug enforcement reports API returns data from the FDA Recall Enterprise System (RES), a database that contains information on recall event information submitted to FDA. Currently, this data covers publicly releasable records from 2004-present. The data is updated weekly.",
+        "operationId": "DrugEnforcement"
+      }
+    },
+    "/drugsfda.json": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "default",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "meta": {
+                  "type": "object",
+                  "properties": {
+                    "disclaimer": {
+                      "type": "string",
+                      "description": "Disclaimer"
+                    },
+                    "terms": {
+                      "type": "string",
+                      "description": "Terms of Service"
+                    },
+                    "license": {
+                      "type": "string",
+                      "description": "Data Licensing"
+                    },
+                    "last_updated": {
+                      "type": "string",
+                      "description": "Last Update Date"
+                    },
+                    "results": {
+                      "type": "object",
+                      "properties": {
+                        "skip": {
+                          "type": "integer",
+                          "format": "int32",
+                          "description": "Number of skipped records"
+                        },
+                        "limit": {
+                          "type": "integer",
+                          "format": "int32",
+                          "description": "Number of records to be returned"
+                        },
+                        "total": {
+                          "type": "integer",
+                          "format": "int32",
+                          "description": "Number of total records"
+                        }
+                      },
+                      "description": "Metadata result"
+                    }
+                  },
+                  "description": "Metadata"
+                },
+                "results": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "submissions": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "submission_type": {
+                              "type": "string",
+                              "description": "The type of the individual submission. Used in combination with submission_number."
+                            },
+                            "submission_number": {
+                              "type": "string",
+                              "description": "A unique identifier for each submission under that application."
+                            },
+                            "submission_status": {
+                              "type": "string",
+                              "description": "The current status of this submission."
+                            },
+                            "submission_status_date": {
+                              "type": "string",
+                              "description": "The date the status was applied to the submission."
+                            },
+                            "submission_class_code": {
+                              "type": "string",
+                              "description": "The Submission Classification Code, previously known as the Chemistry Classification Code, is assigned as a “Type” code."
+                            },
+                            "submission_class_code_description": {
+                              "type": "string",
+                              "description": "The Submission Classification Code, previously known as the Chemistry Classification Code, is assigned as a “Type” code. This is a full description of the classification code."
+                            }
+                          }
+                        },
+                        "description": "Submissions"
+                      },
+                      "application_number": {
+                        "type": "string",
+                        "description": "This corresponds to the NDA, ANDA, or BLA number reported by the labeler for products which have the corresponding Marketing Category designated. If the designated Marketing Category is OTC Monograph Final or OTC Monograph Not Final, then the application number will be the CFR citation corresponding to the appropriate Monograph (e.g. “part 341”). For unapproved drugs, this field will be null."
+                      },
+                      "sponsor_name": {
+                        "type": "string",
+                        "description": "The company that submitted an application to FDA for approval to market the drug product in the United States."
+                      },
+                      "products": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "product_number": {
+                              "type": "string",
+                              "description": "A product number is assigned to each drug product associated with an NDA (New Drug Application), ANDA (Abbreviated New Drug Application) and Biologic License Application (BLA) . If a drug product is available in multiple strengths, there are multiple product numbers."
+                            },
+                            "reference_drug": {
+                              "type": "string",
+                              "description": "Indicates whether the drug product is a reference drug."
+                            },
+                            "brand_name": {
+                              "type": "string",
+                              "description": "Brand or trade name of the drug product."
+                            },
+                            "active_ingredients": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string",
+                                    "description": "The names of the active, medicinal ingredients in the drug product."
+                                  },
+                                  "strength": {
+                                    "type": "string",
+                                    "description": "The strength of the active, medicinal ingredients in the drug product."
+                                  }
+                                }
+                              },
+                              "description": "Active ingredients"
+                            },
+                            "reference_standard": {
+                              "type": "string",
+                              "description": "Indicates whether the drug product is a reference standard."
+                            },
+                            "dosage_form": {
+                              "type": "string",
+                              "description": "The drug’s dosage form. There is no standard, but values may include terms like tablet or solution for injection."
+                            },
+                            "route": {
+                              "type": "string",
+                              "description": "The route of administation of the drug product."
+                            },
+                            "marketing_status": {
+                              "type": "string",
+                              "description": "Indicates how a drug product is sold in the United States."
+                            }
+                          }
+                        },
+                        "description": "Products"
+                      }
+                    }
+                  },
+                  "description": "Results"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Drugs@FDA",
+        "description": "Drugs@FDA includes most of the drug products approved since 1939. The majority of patient information, labels, approval letters, reviews, and other information are available for drug products approved since 1998.",
+        "operationId": "DrugsFDA",
+        "parameters": [
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "x-ms-summary": "Search Query",
+            "description": "single"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "x-ms-summary": "Number of records to be returned",
+            "description": "single"
+          }
+        ]
+      }
+    }
+  },
+  "definitions": {},
+  "parameters": {},
+  "responses": {},
+  "securityDefinitions": {},
+  "security": [],
+  "tags": [],
+  "x-ms-connector-metadata": [
+    {
+      "propertyName": "Website",
+      "propertyValue": "https://open.fda.gov"
+    },
+    {
+      "propertyName": "Privacy policy",
+      "propertyValue": "https://www.fda.gov/about-fda/about-website/website-policies#privacy"
+    },
+    {
+      "propertyName": "Categories",
+      "propertyValue": "Data"
+    }
+  ]
+}

--- a/independent-publisher-connectors/openFDA Drug/apiProperties.json
+++ b/independent-publisher-connectors/openFDA Drug/apiProperties.json
@@ -1,0 +1,10 @@
+{
+  "properties": {
+    "connectionParameters": {
+    },
+    "iconBrandColor": "#da3b01",
+    "capabilities": [],
+    "publisher": "Woong Choi",
+    "stackOwner": "Food and Drug Administration"
+  }
+}

--- a/independent-publisher-connectors/openFDA Drug/readme.md
+++ b/independent-publisher-connectors/openFDA Drug/readme.md
@@ -1,0 +1,23 @@
+# openFDA
+openFDA is an Elasticsearch-based API that serves public FDA data about nouns like drugs, devices, and foods. Each of these nouns has one or more categories, which serve unique data-such as data about recall enforcement reports, or about adverse events. Every query to the API must go through one endpoint for one kind of data.
+
+## Publisher: Woong Choi
+
+## Supported Operations
+### Drug Adverse Event
+The openFDA drug adverse event API returns data that has been collected from the FDA Adverse Event Reporting System (FAERS), a database that contains information on adverse event and medication error reports submitted to FDA.
+
+### Drug Labeling
+Drug manufacturers and distributors submit documentation about their products to FDA in the Structured Product Labeling (SPL) format. The openFDA drug product labeling API returns data from this dataset.
+ 
+### Drug NDC
+The openFDA drug NDC Directory endpoint returns data from the NDC Directory, a database that contains information on the National Drug Code (NDC). FDA publishes the listed NDC numbers and the information submitted as part of the listing information in the NDC Directory which is updated daily.
+
+### Drug Enforcement
+The openFDA drug enforcement reports API returns data from the FDA Recall Enterprise System (RES), a database that contains information on recall event information submitted to FDA. Currently, this data covers publicly releasable records from 2004-present. The data is updated weekly.
+
+### Drugs@FDA
+Drugs@FDA includes most of the drug products approved since 1939. The majority of patient information, labels, approval letters, reviews, and other information are available for drug products approved since 1998.
+
+## Getting Started
+Visit [openFDA](https://open.fda.gov/apis/drug/) documentations page for further details.


### PR DESCRIPTION
---
### When submitting a connector, please make sure that you follow the requirements below, otherwise your PR might be rejected. We want to make you have a well-built connector, a smooth certification experience, and your users are happy :) 

- [x] I attest that the connector works and I verified by deploying and testing all the operations. 
- [x] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [x] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [x] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [x] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.

If you are an Independent Publisher, you must also attest to the following to ensure a smooth publishing process:
- [x] I have named this PR after the pattern of "Connector Name (Independent Publisher)" ex: HubSpot Marketing (Independent Publisher)
- [x] Within this PR markdown file, I have pasted screenshots that show: 3 unique operations (actions/triggers) working within a Flow. This can be in one flow or part of multiple flows. For each one of those flows, I have pasted in screenshots of the Flow succeeding. 
![image](https://user-images.githubusercontent.com/30095306/145714634-48094a3a-a8d6-46b4-84c2-7e464ba5ba94.png)
![image](https://user-images.githubusercontent.com/30095306/145714655-f276fc76-9e28-4e03-bcf8-d74b4e2c0c3c.png)
- [x] Within this PR markdown file, I have pasted in a screenshot from the Test operations section within the Custom Connector UI.
![image](https://user-images.githubusercontent.com/30095306/145714705-60a89585-86f8-496a-b0b2-f09cb214ce9d.png)
- [x] If the connector uses OAuth, I have provided detailed steps on how to create an app in the readme.md. 


