### PR TITLE
Rest Countries (Independent Publisher)

### DIFF
--- a/independent-publisher-connectors/RestCountries/apiDefinition.swagger.json
+++ b/independent-publisher-connectors/RestCountries/apiDefinition.swagger.json
@@ -1,0 +1,795 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "title": "REST Countries",
+        "description": "Get information about countries via a RESTful API",
+        "version": "1.0",
+        "contact": {
+            "name": "Siddharth Vaghasia",
+            "email": "siddh.vaghasia@gmail.com"
+        }
+    },
+    "host": "restcountries.com",
+    "basePath": "/v3.1/",
+    "schemes": [
+        "https"
+    ],
+    "consumes": [],
+    "produces": [
+        "application/json"
+    ],
+    "paths": {
+        "/all": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "200 OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "object",
+                                        "properties": {
+                                            "common": {
+                                                "type": "string",
+                                                "description": "common"
+                                            },
+                                            "official": {
+                                                "type": "string",
+                                                "description": "official"
+                                            },
+                                            "nativeName": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "ara": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "official": {
+                                                                "type": "string",
+                                                                "description": "official"
+                                                            },
+                                                            "common": {
+                                                                "type": "string",
+                                                                "description": "common"
+                                                            }
+                                                        },
+                                                        "description": "ara"
+                                                    },
+                                                    "sin": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "official": {
+                                                                "type": "string",
+                                                                "description": "official"
+                                                            },
+                                                            "common": {
+                                                                "type": "string",
+                                                                "description": "common"
+                                                            }
+                                                        },
+                                                        "description": "sin"
+                                                    },
+                                                    "tam": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "official": {
+                                                                "type": "string",
+                                                                "description": "official"
+                                                            },
+                                                            "common": {
+                                                                "type": "string",
+                                                                "description": "common"
+                                                            }
+                                                        },
+                                                        "description": "tam"
+                                                    },
+                                                    "pol": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "official": {
+                                                                "type": "string",
+                                                                "description": "official"
+                                                            },
+                                                            "common": {
+                                                                "type": "string",
+                                                                "description": "common"
+                                                            }
+                                                        },
+                                                        "description": "pol"
+                                                    }
+                                                },
+                                                "description": "nativeName"
+                                            }
+                                        },
+                                        "description": "name"
+                                    },
+                                    "tld": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "description": "tld"
+                                    },
+                                    "cca2": {
+                                        "type": "string",
+                                        "description": "cca2"
+                                    },
+                                    "ccn3": {
+                                        "type": "string",
+                                        "description": "ccn3"
+                                    },
+                                    "cca3": {
+                                        "type": "string",
+                                        "description": "cca3"
+                                    },
+                                    "cioc": {
+                                        "type": "string",
+                                        "description": "cioc"
+                                    },
+                                    "independent": {
+                                        "type": "boolean",
+                                        "description": "independent"
+                                    },
+                                    "status": {
+                                        "type": "string",
+                                        "description": "status"
+                                    },
+                                    "unMember": {
+                                        "type": "boolean",
+                                        "description": "unMember"
+                                    },
+                                    "currencies": {
+                                        "type": "object",
+                                        "properties": {
+                                            "MRU": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "name"
+                                                    },
+                                                    "symbol": {
+                                                        "type": "string",
+                                                        "description": "symbol"
+                                                    }
+                                                },
+                                                "description": "MRU"
+                                            },
+                                            "LKR": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "name"
+                                                    },
+                                                    "symbol": {
+                                                        "type": "string",
+                                                        "description": "symbol"
+                                                    }
+                                                },
+                                                "description": "LKR"
+                                            },
+                                            "PLN": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "name"
+                                                    },
+                                                    "symbol": {
+                                                        "type": "string",
+                                                        "description": "symbol"
+                                                    }
+                                                },
+                                                "description": "PLN"
+                                            }
+                                        },
+                                        "description": "currencies"
+                                    },
+                                    "idd": {
+                                        "type": "object",
+                                        "properties": {
+                                            "root": {
+                                                "type": "string",
+                                                "description": "root"
+                                            },
+                                            "suffixes": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "description": "suffixes"
+                                            }
+                                        },
+                                        "description": "idd"
+                                    },
+                                    "capital": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "description": "capital"
+                                    },
+                                    "altSpellings": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "description": "altSpellings"
+                                    },
+                                    "region": {
+                                        "type": "string",
+                                        "description": "region"
+                                    },
+                                    "subregion": {
+                                        "type": "string",
+                                        "description": "subregion"
+                                    },
+                                    "languages": {
+                                        "type": "object",
+                                        "properties": {
+                                            "ara": {
+                                                "type": "string",
+                                                "description": "ara"
+                                            },
+                                            "sin": {
+                                                "type": "string",
+                                                "description": "sin"
+                                            },
+                                            "tam": {
+                                                "type": "string",
+                                                "description": "tam"
+                                            },
+                                            "pol": {
+                                                "type": "string",
+                                                "description": "pol"
+                                            }
+                                        },
+                                        "description": "languages"
+                                    },
+                                    "translations": {
+                                        "type": "object",
+                                        "properties": {
+                                            "ara": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "official": {
+                                                        "type": "string",
+                                                        "description": "official"
+                                                    },
+                                                    "common": {
+                                                        "type": "string",
+                                                        "description": "common"
+                                                    }
+                                                },
+                                                "description": "ara"
+                                            },
+                                            "ces": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "official": {
+                                                        "type": "string",
+                                                        "description": "official"
+                                                    },
+                                                    "common": {
+                                                        "type": "string",
+                                                        "description": "common"
+                                                    }
+                                                },
+                                                "description": "ces"
+                                            },
+                                            "cym": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "official": {
+                                                        "type": "string",
+                                                        "description": "official"
+                                                    },
+                                                    "common": {
+                                                        "type": "string",
+                                                        "description": "common"
+                                                    }
+                                                },
+                                                "description": "cym"
+                                            },
+                                            "deu": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "official": {
+                                                        "type": "string",
+                                                        "description": "official"
+                                                    },
+                                                    "common": {
+                                                        "type": "string",
+                                                        "description": "common"
+                                                    }
+                                                },
+                                                "description": "deu"
+                                            },
+                                            "est": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "official": {
+                                                        "type": "string",
+                                                        "description": "official"
+                                                    },
+                                                    "common": {
+                                                        "type": "string",
+                                                        "description": "common"
+                                                    }
+                                                },
+                                                "description": "est"
+                                            },
+                                            "fin": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "official": {
+                                                        "type": "string",
+                                                        "description": "official"
+                                                    },
+                                                    "common": {
+                                                        "type": "string",
+                                                        "description": "common"
+                                                    }
+                                                },
+                                                "description": "fin"
+                                            },
+                                            "fra": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "official": {
+                                                        "type": "string",
+                                                        "description": "official"
+                                                    },
+                                                    "common": {
+                                                        "type": "string",
+                                                        "description": "common"
+                                                    }
+                                                },
+                                                "description": "fra"
+                                            },
+                                            "hrv": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "official": {
+                                                        "type": "string",
+                                                        "description": "official"
+                                                    },
+                                                    "common": {
+                                                        "type": "string",
+                                                        "description": "common"
+                                                    }
+                                                },
+                                                "description": "hrv"
+                                            },
+                                            "hun": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "official": {
+                                                        "type": "string",
+                                                        "description": "official"
+                                                    },
+                                                    "common": {
+                                                        "type": "string",
+                                                        "description": "common"
+                                                    }
+                                                },
+                                                "description": "hun"
+                                            },
+                                            "ita": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "official": {
+                                                        "type": "string",
+                                                        "description": "official"
+                                                    },
+                                                    "common": {
+                                                        "type": "string",
+                                                        "description": "common"
+                                                    }
+                                                },
+                                                "description": "ita"
+                                            },
+                                            "jpn": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "official": {
+                                                        "type": "string",
+                                                        "description": "official"
+                                                    },
+                                                    "common": {
+                                                        "type": "string",
+                                                        "description": "common"
+                                                    }
+                                                },
+                                                "description": "jpn"
+                                            },
+                                            "kor": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "official": {
+                                                        "type": "string",
+                                                        "description": "official"
+                                                    },
+                                                    "common": {
+                                                        "type": "string",
+                                                        "description": "common"
+                                                    }
+                                                },
+                                                "description": "kor"
+                                            },
+                                            "nld": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "official": {
+                                                        "type": "string",
+                                                        "description": "official"
+                                                    },
+                                                    "common": {
+                                                        "type": "string",
+                                                        "description": "common"
+                                                    }
+                                                },
+                                                "description": "nld"
+                                            },
+                                            "per": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "official": {
+                                                        "type": "string",
+                                                        "description": "official"
+                                                    },
+                                                    "common": {
+                                                        "type": "string",
+                                                        "description": "common"
+                                                    }
+                                                },
+                                                "description": "per"
+                                            },
+                                            "pol": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "official": {
+                                                        "type": "string",
+                                                        "description": "official"
+                                                    },
+                                                    "common": {
+                                                        "type": "string",
+                                                        "description": "common"
+                                                    }
+                                                },
+                                                "description": "pol"
+                                            },
+                                            "por": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "official": {
+                                                        "type": "string",
+                                                        "description": "official"
+                                                    },
+                                                    "common": {
+                                                        "type": "string",
+                                                        "description": "common"
+                                                    }
+                                                },
+                                                "description": "por"
+                                            },
+                                            "rus": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "official": {
+                                                        "type": "string",
+                                                        "description": "official"
+                                                    },
+                                                    "common": {
+                                                        "type": "string",
+                                                        "description": "common"
+                                                    }
+                                                },
+                                                "description": "rus"
+                                            },
+                                            "slk": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "official": {
+                                                        "type": "string",
+                                                        "description": "official"
+                                                    },
+                                                    "common": {
+                                                        "type": "string",
+                                                        "description": "common"
+                                                    }
+                                                },
+                                                "description": "slk"
+                                            },
+                                            "spa": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "official": {
+                                                        "type": "string",
+                                                        "description": "official"
+                                                    },
+                                                    "common": {
+                                                        "type": "string",
+                                                        "description": "common"
+                                                    }
+                                                },
+                                                "description": "spa"
+                                            },
+                                            "swe": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "official": {
+                                                        "type": "string",
+                                                        "description": "official"
+                                                    },
+                                                    "common": {
+                                                        "type": "string",
+                                                        "description": "common"
+                                                    }
+                                                },
+                                                "description": "swe"
+                                            },
+                                            "urd": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "official": {
+                                                        "type": "string",
+                                                        "description": "official"
+                                                    },
+                                                    "common": {
+                                                        "type": "string",
+                                                        "description": "common"
+                                                    }
+                                                },
+                                                "description": "urd"
+                                            },
+                                            "zho": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "official": {
+                                                        "type": "string",
+                                                        "description": "official"
+                                                    },
+                                                    "common": {
+                                                        "type": "string",
+                                                        "description": "common"
+                                                    }
+                                                },
+                                                "description": "zho"
+                                            }
+                                        },
+                                        "description": "translations"
+                                    },
+                                    "latlng": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "number",
+                                            "format": "float"
+                                        },
+                                        "description": "latlng"
+                                    },
+                                    "landlocked": {
+                                        "type": "boolean",
+                                        "description": "landlocked"
+                                    },
+                                    "borders": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "description": "borders"
+                                    },
+                                    "area": {
+                                        "type": "number",
+                                        "format": "float",
+                                        "description": "area"
+                                    },
+                                    "demonyms": {
+                                        "type": "object",
+                                        "properties": {
+                                            "eng": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "f": {
+                                                        "type": "string",
+                                                        "description": "f"
+                                                    },
+                                                    "m": {
+                                                        "type": "string",
+                                                        "description": "m"
+                                                    }
+                                                },
+                                                "description": "eng"
+                                            },
+                                            "fra": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "f": {
+                                                        "type": "string",
+                                                        "description": "f"
+                                                    },
+                                                    "m": {
+                                                        "type": "string",
+                                                        "description": "m"
+                                                    }
+                                                },
+                                                "description": "fra"
+                                            }
+                                        },
+                                        "description": "demonyms"
+                                    },
+                                    "flag": {
+                                        "type": "string",
+                                        "description": "flag"
+                                    },
+                                    "maps": {
+                                        "type": "object",
+                                        "properties": {
+                                            "googleMaps": {
+                                                "type": "string",
+                                                "description": "googleMaps"
+                                            },
+                                            "openStreetMaps": {
+                                                "type": "string",
+                                                "description": "openStreetMaps"
+                                            }
+                                        },
+                                        "description": "maps"
+                                    },
+                                    "population": {
+                                        "type": "number",
+                                        "format": "float",
+                                        "description": "population"
+                                    },
+                                    "gini": {
+                                        "type": "object",
+                                        "properties": {
+                                            "2014": {
+                                                "type": "number",
+                                                "format": "float",
+                                                "description": "2014"
+                                            },
+                                            "2016": {
+                                                "type": "number",
+                                                "format": "float",
+                                                "description": "2016"
+                                            },
+                                            "2018": {
+                                                "type": "number",
+                                                "format": "float",
+                                                "description": "2018"
+                                            }
+                                        },
+                                        "description": "gini"
+                                    },
+                                    "fifa": {
+                                        "type": "string",
+                                        "description": "fifa"
+                                    },
+                                    "car": {
+                                        "type": "object",
+                                        "properties": {
+                                            "signs": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "description": "signs"
+                                            },
+                                            "side": {
+                                                "type": "string",
+                                                "description": "side"
+                                            }
+                                        },
+                                        "description": "car"
+                                    },
+                                    "timezones": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "description": "timezones"
+                                    },
+                                    "continents": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "description": "continents"
+                                    },
+                                    "flags": {
+                                        "type": "object",
+                                        "properties": {
+                                            "png": {
+                                                "type": "string",
+                                                "description": "png"
+                                            },
+                                            "svg": {
+                                                "type": "string",
+                                                "description": "svg"
+                                            }
+                                        },
+                                        "description": "flags"
+                                    },
+                                    "coatOfArms": {
+                                        "type": "object",
+                                        "properties": {
+                                            "png": {
+                                                "type": "string",
+                                                "description": "png"
+                                            },
+                                            "svg": {
+                                                "type": "string",
+                                                "description": "svg"
+                                            }
+                                        },
+                                        "description": "coatOfArms"
+                                    },
+                                    "startOfWeek": {
+                                        "type": "string",
+                                        "description": "startOfWeek"
+                                    },
+                                    "capitalInfo": {
+                                        "type": "object",
+                                        "properties": {
+                                            "latlng": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "number",
+                                                    "format": "float"
+                                                },
+                                                "description": "latlng"
+                                            }
+                                        },
+                                        "description": "capitalInfo"
+                                    },
+                                    "postalCode": {
+                                        "type": "object",
+                                        "properties": {
+                                            "format": {
+                                                "type": "string",
+                                                "description": "format"
+                                            },
+                                            "regex": {
+                                                "type": "string",
+                                                "description": "regex"
+                                            }
+                                        },
+                                        "description": "postalCode"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "summary": "ALL",
+                "description": "ALL",
+                "operationId": "ALL",
+                "parameters": []
+            }
+        }
+    },
+    "definitions": {},
+    "parameters": {},
+    "responses": {},
+    "securityDefinitions": {},
+    "security": [],
+    "tags": [],
+    "x-ms-connector-metadata": [
+      {
+        "propertyName": "Website",
+        "propertyValue": "https://restcountries.com/"
+      },
+      {
+        "propertyName": "Privacy Policy",
+        "propertyValue": "https://restcountries.com/#license"
+      },
+      {
+        "propertyName": "Categories",
+        "propertyValue": "Data"
+      }
+    ]
+}

--- a/independent-publisher-connectors/RestCountries/apiDefinition.swagger.json
+++ b/independent-publisher-connectors/RestCountries/apiDefinition.swagger.json
@@ -1,795 +1,811 @@
 {
-    "swagger": "2.0",
-    "info": {
-        "title": "REST Countries",
-        "description": "Get information about countries via a RESTful API",
-        "version": "1.0",
-        "contact": {
-            "name": "Siddharth Vaghasia",
-            "email": "siddh.vaghasia@gmail.com"
-        }
-    },
-    "host": "restcountries.com",
-    "basePath": "/v3.1/",
-    "schemes": [
-        "https"
-    ],
-    "consumes": [],
-    "produces": [
-        "application/json"
-    ],
-    "paths": {
-        "/all": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "200 OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "name": {
-                                        "type": "object",
-                                        "properties": {
-                                            "common": {
-                                                "type": "string",
-                                                "description": "common"
-                                            },
-                                            "official": {
-                                                "type": "string",
-                                                "description": "official"
-                                            },
-                                            "nativeName": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "ara": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "official": {
-                                                                "type": "string",
-                                                                "description": "official"
-                                                            },
-                                                            "common": {
-                                                                "type": "string",
-                                                                "description": "common"
-                                                            }
-                                                        },
-                                                        "description": "ara"
-                                                    },
-                                                    "sin": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "official": {
-                                                                "type": "string",
-                                                                "description": "official"
-                                                            },
-                                                            "common": {
-                                                                "type": "string",
-                                                                "description": "common"
-                                                            }
-                                                        },
-                                                        "description": "sin"
-                                                    },
-                                                    "tam": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "official": {
-                                                                "type": "string",
-                                                                "description": "official"
-                                                            },
-                                                            "common": {
-                                                                "type": "string",
-                                                                "description": "common"
-                                                            }
-                                                        },
-                                                        "description": "tam"
-                                                    },
-                                                    "pol": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "official": {
-                                                                "type": "string",
-                                                                "description": "official"
-                                                            },
-                                                            "common": {
-                                                                "type": "string",
-                                                                "description": "common"
-                                                            }
-                                                        },
-                                                        "description": "pol"
-                                                    }
-                                                },
-                                                "description": "nativeName"
-                                            }
-                                        },
-                                        "description": "name"
-                                    },
-                                    "tld": {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "string"
-                                        },
-                                        "description": "tld"
-                                    },
-                                    "cca2": {
-                                        "type": "string",
-                                        "description": "cca2"
-                                    },
-                                    "ccn3": {
-                                        "type": "string",
-                                        "description": "ccn3"
-                                    },
-                                    "cca3": {
-                                        "type": "string",
-                                        "description": "cca3"
-                                    },
-                                    "cioc": {
-                                        "type": "string",
-                                        "description": "cioc"
-                                    },
-                                    "independent": {
-                                        "type": "boolean",
-                                        "description": "independent"
-                                    },
-                                    "status": {
-                                        "type": "string",
-                                        "description": "status"
-                                    },
-                                    "unMember": {
-                                        "type": "boolean",
-                                        "description": "unMember"
-                                    },
-                                    "currencies": {
-                                        "type": "object",
-                                        "properties": {
-                                            "MRU": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "name": {
-                                                        "type": "string",
-                                                        "description": "name"
-                                                    },
-                                                    "symbol": {
-                                                        "type": "string",
-                                                        "description": "symbol"
-                                                    }
-                                                },
-                                                "description": "MRU"
-                                            },
-                                            "LKR": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "name": {
-                                                        "type": "string",
-                                                        "description": "name"
-                                                    },
-                                                    "symbol": {
-                                                        "type": "string",
-                                                        "description": "symbol"
-                                                    }
-                                                },
-                                                "description": "LKR"
-                                            },
-                                            "PLN": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "name": {
-                                                        "type": "string",
-                                                        "description": "name"
-                                                    },
-                                                    "symbol": {
-                                                        "type": "string",
-                                                        "description": "symbol"
-                                                    }
-                                                },
-                                                "description": "PLN"
-                                            }
-                                        },
-                                        "description": "currencies"
-                                    },
-                                    "idd": {
-                                        "type": "object",
-                                        "properties": {
-                                            "root": {
-                                                "type": "string",
-                                                "description": "root"
-                                            },
-                                            "suffixes": {
-                                                "type": "array",
-                                                "items": {
-                                                    "type": "string"
-                                                },
-                                                "description": "suffixes"
-                                            }
-                                        },
-                                        "description": "idd"
-                                    },
-                                    "capital": {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "string"
-                                        },
-                                        "description": "capital"
-                                    },
-                                    "altSpellings": {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "string"
-                                        },
-                                        "description": "altSpellings"
-                                    },
-                                    "region": {
-                                        "type": "string",
-                                        "description": "region"
-                                    },
-                                    "subregion": {
-                                        "type": "string",
-                                        "description": "subregion"
-                                    },
-                                    "languages": {
-                                        "type": "object",
-                                        "properties": {
-                                            "ara": {
-                                                "type": "string",
-                                                "description": "ara"
-                                            },
-                                            "sin": {
-                                                "type": "string",
-                                                "description": "sin"
-                                            },
-                                            "tam": {
-                                                "type": "string",
-                                                "description": "tam"
-                                            },
-                                            "pol": {
-                                                "type": "string",
-                                                "description": "pol"
-                                            }
-                                        },
-                                        "description": "languages"
-                                    },
-                                    "translations": {
-                                        "type": "object",
-                                        "properties": {
-                                            "ara": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "official": {
-                                                        "type": "string",
-                                                        "description": "official"
-                                                    },
-                                                    "common": {
-                                                        "type": "string",
-                                                        "description": "common"
-                                                    }
-                                                },
-                                                "description": "ara"
-                                            },
-                                            "ces": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "official": {
-                                                        "type": "string",
-                                                        "description": "official"
-                                                    },
-                                                    "common": {
-                                                        "type": "string",
-                                                        "description": "common"
-                                                    }
-                                                },
-                                                "description": "ces"
-                                            },
-                                            "cym": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "official": {
-                                                        "type": "string",
-                                                        "description": "official"
-                                                    },
-                                                    "common": {
-                                                        "type": "string",
-                                                        "description": "common"
-                                                    }
-                                                },
-                                                "description": "cym"
-                                            },
-                                            "deu": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "official": {
-                                                        "type": "string",
-                                                        "description": "official"
-                                                    },
-                                                    "common": {
-                                                        "type": "string",
-                                                        "description": "common"
-                                                    }
-                                                },
-                                                "description": "deu"
-                                            },
-                                            "est": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "official": {
-                                                        "type": "string",
-                                                        "description": "official"
-                                                    },
-                                                    "common": {
-                                                        "type": "string",
-                                                        "description": "common"
-                                                    }
-                                                },
-                                                "description": "est"
-                                            },
-                                            "fin": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "official": {
-                                                        "type": "string",
-                                                        "description": "official"
-                                                    },
-                                                    "common": {
-                                                        "type": "string",
-                                                        "description": "common"
-                                                    }
-                                                },
-                                                "description": "fin"
-                                            },
-                                            "fra": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "official": {
-                                                        "type": "string",
-                                                        "description": "official"
-                                                    },
-                                                    "common": {
-                                                        "type": "string",
-                                                        "description": "common"
-                                                    }
-                                                },
-                                                "description": "fra"
-                                            },
-                                            "hrv": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "official": {
-                                                        "type": "string",
-                                                        "description": "official"
-                                                    },
-                                                    "common": {
-                                                        "type": "string",
-                                                        "description": "common"
-                                                    }
-                                                },
-                                                "description": "hrv"
-                                            },
-                                            "hun": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "official": {
-                                                        "type": "string",
-                                                        "description": "official"
-                                                    },
-                                                    "common": {
-                                                        "type": "string",
-                                                        "description": "common"
-                                                    }
-                                                },
-                                                "description": "hun"
-                                            },
-                                            "ita": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "official": {
-                                                        "type": "string",
-                                                        "description": "official"
-                                                    },
-                                                    "common": {
-                                                        "type": "string",
-                                                        "description": "common"
-                                                    }
-                                                },
-                                                "description": "ita"
-                                            },
-                                            "jpn": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "official": {
-                                                        "type": "string",
-                                                        "description": "official"
-                                                    },
-                                                    "common": {
-                                                        "type": "string",
-                                                        "description": "common"
-                                                    }
-                                                },
-                                                "description": "jpn"
-                                            },
-                                            "kor": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "official": {
-                                                        "type": "string",
-                                                        "description": "official"
-                                                    },
-                                                    "common": {
-                                                        "type": "string",
-                                                        "description": "common"
-                                                    }
-                                                },
-                                                "description": "kor"
-                                            },
-                                            "nld": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "official": {
-                                                        "type": "string",
-                                                        "description": "official"
-                                                    },
-                                                    "common": {
-                                                        "type": "string",
-                                                        "description": "common"
-                                                    }
-                                                },
-                                                "description": "nld"
-                                            },
-                                            "per": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "official": {
-                                                        "type": "string",
-                                                        "description": "official"
-                                                    },
-                                                    "common": {
-                                                        "type": "string",
-                                                        "description": "common"
-                                                    }
-                                                },
-                                                "description": "per"
-                                            },
-                                            "pol": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "official": {
-                                                        "type": "string",
-                                                        "description": "official"
-                                                    },
-                                                    "common": {
-                                                        "type": "string",
-                                                        "description": "common"
-                                                    }
-                                                },
-                                                "description": "pol"
-                                            },
-                                            "por": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "official": {
-                                                        "type": "string",
-                                                        "description": "official"
-                                                    },
-                                                    "common": {
-                                                        "type": "string",
-                                                        "description": "common"
-                                                    }
-                                                },
-                                                "description": "por"
-                                            },
-                                            "rus": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "official": {
-                                                        "type": "string",
-                                                        "description": "official"
-                                                    },
-                                                    "common": {
-                                                        "type": "string",
-                                                        "description": "common"
-                                                    }
-                                                },
-                                                "description": "rus"
-                                            },
-                                            "slk": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "official": {
-                                                        "type": "string",
-                                                        "description": "official"
-                                                    },
-                                                    "common": {
-                                                        "type": "string",
-                                                        "description": "common"
-                                                    }
-                                                },
-                                                "description": "slk"
-                                            },
-                                            "spa": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "official": {
-                                                        "type": "string",
-                                                        "description": "official"
-                                                    },
-                                                    "common": {
-                                                        "type": "string",
-                                                        "description": "common"
-                                                    }
-                                                },
-                                                "description": "spa"
-                                            },
-                                            "swe": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "official": {
-                                                        "type": "string",
-                                                        "description": "official"
-                                                    },
-                                                    "common": {
-                                                        "type": "string",
-                                                        "description": "common"
-                                                    }
-                                                },
-                                                "description": "swe"
-                                            },
-                                            "urd": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "official": {
-                                                        "type": "string",
-                                                        "description": "official"
-                                                    },
-                                                    "common": {
-                                                        "type": "string",
-                                                        "description": "common"
-                                                    }
-                                                },
-                                                "description": "urd"
-                                            },
-                                            "zho": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "official": {
-                                                        "type": "string",
-                                                        "description": "official"
-                                                    },
-                                                    "common": {
-                                                        "type": "string",
-                                                        "description": "common"
-                                                    }
-                                                },
-                                                "description": "zho"
-                                            }
-                                        },
-                                        "description": "translations"
-                                    },
-                                    "latlng": {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "number",
-                                            "format": "float"
-                                        },
-                                        "description": "latlng"
-                                    },
-                                    "landlocked": {
-                                        "type": "boolean",
-                                        "description": "landlocked"
-                                    },
-                                    "borders": {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "string"
-                                        },
-                                        "description": "borders"
-                                    },
-                                    "area": {
-                                        "type": "number",
-                                        "format": "float",
-                                        "description": "area"
-                                    },
-                                    "demonyms": {
-                                        "type": "object",
-                                        "properties": {
-                                            "eng": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "f": {
-                                                        "type": "string",
-                                                        "description": "f"
-                                                    },
-                                                    "m": {
-                                                        "type": "string",
-                                                        "description": "m"
-                                                    }
-                                                },
-                                                "description": "eng"
-                                            },
-                                            "fra": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "f": {
-                                                        "type": "string",
-                                                        "description": "f"
-                                                    },
-                                                    "m": {
-                                                        "type": "string",
-                                                        "description": "m"
-                                                    }
-                                                },
-                                                "description": "fra"
-                                            }
-                                        },
-                                        "description": "demonyms"
-                                    },
-                                    "flag": {
-                                        "type": "string",
-                                        "description": "flag"
-                                    },
-                                    "maps": {
-                                        "type": "object",
-                                        "properties": {
-                                            "googleMaps": {
-                                                "type": "string",
-                                                "description": "googleMaps"
-                                            },
-                                            "openStreetMaps": {
-                                                "type": "string",
-                                                "description": "openStreetMaps"
-                                            }
-                                        },
-                                        "description": "maps"
-                                    },
-                                    "population": {
-                                        "type": "number",
-                                        "format": "float",
-                                        "description": "population"
-                                    },
-                                    "gini": {
-                                        "type": "object",
-                                        "properties": {
-                                            "2014": {
-                                                "type": "number",
-                                                "format": "float",
-                                                "description": "2014"
-                                            },
-                                            "2016": {
-                                                "type": "number",
-                                                "format": "float",
-                                                "description": "2016"
-                                            },
-                                            "2018": {
-                                                "type": "number",
-                                                "format": "float",
-                                                "description": "2018"
-                                            }
-                                        },
-                                        "description": "gini"
-                                    },
-                                    "fifa": {
-                                        "type": "string",
-                                        "description": "fifa"
-                                    },
-                                    "car": {
-                                        "type": "object",
-                                        "properties": {
-                                            "signs": {
-                                                "type": "array",
-                                                "items": {
-                                                    "type": "string"
-                                                },
-                                                "description": "signs"
-                                            },
-                                            "side": {
-                                                "type": "string",
-                                                "description": "side"
-                                            }
-                                        },
-                                        "description": "car"
-                                    },
-                                    "timezones": {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "string"
-                                        },
-                                        "description": "timezones"
-                                    },
-                                    "continents": {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "string"
-                                        },
-                                        "description": "continents"
-                                    },
-                                    "flags": {
-                                        "type": "object",
-                                        "properties": {
-                                            "png": {
-                                                "type": "string",
-                                                "description": "png"
-                                            },
-                                            "svg": {
-                                                "type": "string",
-                                                "description": "svg"
-                                            }
-                                        },
-                                        "description": "flags"
-                                    },
-                                    "coatOfArms": {
-                                        "type": "object",
-                                        "properties": {
-                                            "png": {
-                                                "type": "string",
-                                                "description": "png"
-                                            },
-                                            "svg": {
-                                                "type": "string",
-                                                "description": "svg"
-                                            }
-                                        },
-                                        "description": "coatOfArms"
-                                    },
-                                    "startOfWeek": {
-                                        "type": "string",
-                                        "description": "startOfWeek"
-                                    },
-                                    "capitalInfo": {
-                                        "type": "object",
-                                        "properties": {
-                                            "latlng": {
-                                                "type": "array",
-                                                "items": {
-                                                    "type": "number",
-                                                    "format": "float"
-                                                },
-                                                "description": "latlng"
-                                            }
-                                        },
-                                        "description": "capitalInfo"
-                                    },
-                                    "postalCode": {
-                                        "type": "object",
-                                        "properties": {
-                                            "format": {
-                                                "type": "string",
-                                                "description": "format"
-                                            },
-                                            "regex": {
-                                                "type": "string",
-                                                "description": "regex"
-                                            }
-                                        },
-                                        "description": "postalCode"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "summary": "ALL",
-                "description": "ALL",
-                "operationId": "ALL",
-                "parameters": []
+  "swagger":"2.0",
+  "info":{
+    "title":"REST Countries",
+    "description":"Get information about countries via a RESTful API",
+    "version":"1.0",
+    "contact":{
+      "name":"Siddharth Vaghasia",
+      "email":"siddh.vaghasia@gmail.com"
+    }
+  },
+  "host":"restcountries.com",
+  "basePath":"/v3.1/",
+  "schemes":[
+    "https"
+  ],
+  "consumes":[
+
+  ],
+  "produces":[
+    "application/json"
+  ],
+  "paths":{
+    "/all":{
+      "get":{
+        "responses":{
+          "200":{
+            "description":"200",
+            "schema":{
+              "type":"array",
+              "items":{
+                "type":"object",
+                "properties":{
+                  "name":{
+                    "type":"object",
+                    "properties":{
+                      "common":{
+                        "type":"string",
+                        "description":"common"
+                      },
+                      "official":{
+                        "type":"string",
+                        "description":"official"
+                      },
+                      "nativeName":{
+                        "type":"object",
+                        "properties":{
+                          "ara":{
+                            "type":"object",
+                            "properties":{
+                              "official":{
+                                "type":"string",
+                                "description":"official"
+                              },
+                              "common":{
+                                "type":"string",
+                                "description":"common"
+                              }
+                            },
+                            "description":"ara"
+                          },
+                          "sin":{
+                            "type":"object",
+                            "properties":{
+                              "official":{
+                                "type":"string",
+                                "description":"official"
+                              },
+                              "common":{
+                                "type":"string",
+                                "description":"common"
+                              }
+                            },
+                            "description":"sin"
+                          },
+                          "tam":{
+                            "type":"object",
+                            "properties":{
+                              "official":{
+                                "type":"string",
+                                "description":"official"
+                              },
+                              "common":{
+                                "type":"string",
+                                "description":"common"
+                              }
+                            },
+                            "description":"tam"
+                          },
+                          "pol":{
+                            "type":"object",
+                            "properties":{
+                              "official":{
+                                "type":"string",
+                                "description":"official"
+                              },
+                              "common":{
+                                "type":"string",
+                                "description":"common"
+                              }
+                            },
+                            "description":"pol"
+                          }
+                        },
+                        "description":"nativeName"
+                      }
+                    },
+                    "description":"name"
+                  },
+                  "tld":{
+                    "type":"array",
+                    "items":{
+                      "type":"string"
+                    },
+                    "description":"tld"
+                  },
+                  "cca2":{
+                    "type":"string",
+                    "description":"cca2"
+                  },
+                  "ccn3":{
+                    "type":"string",
+                    "description":"ccn3"
+                  },
+                  "cca3":{
+                    "type":"string",
+                    "description":"cca3"
+                  },
+                  "cioc":{
+                    "type":"string",
+                    "description":"cioc"
+                  },
+                  "independent":{
+                    "type":"boolean",
+                    "description":"independent"
+                  },
+                  "status":{
+                    "type":"string",
+                    "description":"status"
+                  },
+                  "unMember":{
+                    "type":"boolean",
+                    "description":"unMember"
+                  },
+                  "currencies":{
+                    "type":"object",
+                    "properties":{
+                      "MRU":{
+                        "type":"object",
+                        "properties":{
+                          "name":{
+                            "type":"string",
+                            "description":"name"
+                          },
+                          "symbol":{
+                            "type":"string",
+                            "description":"symbol"
+                          }
+                        },
+                        "description":"MRU"
+                      },
+                      "LKR":{
+                        "type":"object",
+                        "properties":{
+                          "name":{
+                            "type":"string",
+                            "description":"name"
+                          },
+                          "symbol":{
+                            "type":"string",
+                            "description":"symbol"
+                          }
+                        },
+                        "description":"LKR"
+                      },
+                      "PLN":{
+                        "type":"object",
+                        "properties":{
+                          "name":{
+                            "type":"string",
+                            "description":"name"
+                          },
+                          "symbol":{
+                            "type":"string",
+                            "description":"symbol"
+                          }
+                        },
+                        "description":"PLN"
+                      }
+                    },
+                    "description":"currencies"
+                  },
+                  "idd":{
+                    "type":"object",
+                    "properties":{
+                      "root":{
+                        "type":"string",
+                        "description":"root"
+                      },
+                      "suffixes":{
+                        "type":"array",
+                        "items":{
+                          "type":"string"
+                        },
+                        "description":"suffixes"
+                      }
+                    },
+                    "description":"idd"
+                  },
+                  "capital":{
+                    "type":"array",
+                    "items":{
+                      "type":"string"
+                    },
+                    "description":"capital"
+                  },
+                  "altSpellings":{
+                    "type":"array",
+                    "items":{
+                      "type":"string"
+                    },
+                    "description":"altSpellings"
+                  },
+                  "region":{
+                    "type":"string",
+                    "description":"region"
+                  },
+                  "subregion":{
+                    "type":"string",
+                    "description":"subregion"
+                  },
+                  "languages":{
+                    "type":"object",
+                    "properties":{
+                      "ara":{
+                        "type":"string",
+                        "description":"ara"
+                      },
+                      "sin":{
+                        "type":"string",
+                        "description":"sin"
+                      },
+                      "tam":{
+                        "type":"string",
+                        "description":"tam"
+                      },
+                      "pol":{
+                        "type":"string",
+                        "description":"pol"
+                      }
+                    },
+                    "description":"languages"
+                  },
+                  "translations":{
+                    "type":"object",
+                    "properties":{
+                      "ara":{
+                        "type":"object",
+                        "properties":{
+                          "official":{
+                            "type":"string",
+                            "description":"official"
+                          },
+                          "common":{
+                            "type":"string",
+                            "description":"common"
+                          }
+                        },
+                        "description":"ara"
+                      },
+                      "ces":{
+                        "type":"object",
+                        "properties":{
+                          "official":{
+                            "type":"string",
+                            "description":"official"
+                          },
+                          "common":{
+                            "type":"string",
+                            "description":"common"
+                          }
+                        },
+                        "description":"ces"
+                      },
+                      "cym":{
+                        "type":"object",
+                        "properties":{
+                          "official":{
+                            "type":"string",
+                            "description":"official"
+                          },
+                          "common":{
+                            "type":"string",
+                            "description":"common"
+                          }
+                        },
+                        "description":"cym"
+                      },
+                      "deu":{
+                        "type":"object",
+                        "properties":{
+                          "official":{
+                            "type":"string",
+                            "description":"official"
+                          },
+                          "common":{
+                            "type":"string",
+                            "description":"common"
+                          }
+                        },
+                        "description":"deu"
+                      },
+                      "est":{
+                        "type":"object",
+                        "properties":{
+                          "official":{
+                            "type":"string",
+                            "description":"official"
+                          },
+                          "common":{
+                            "type":"string",
+                            "description":"common"
+                          }
+                        },
+                        "description":"est"
+                      },
+                      "fin":{
+                        "type":"object",
+                        "properties":{
+                          "official":{
+                            "type":"string",
+                            "description":"official"
+                          },
+                          "common":{
+                            "type":"string",
+                            "description":"common"
+                          }
+                        },
+                        "description":"fin"
+                      },
+                      "fra":{
+                        "type":"object",
+                        "properties":{
+                          "official":{
+                            "type":"string",
+                            "description":"official"
+                          },
+                          "common":{
+                            "type":"string",
+                            "description":"common"
+                          }
+                        },
+                        "description":"fra"
+                      },
+                      "hrv":{
+                        "type":"object",
+                        "properties":{
+                          "official":{
+                            "type":"string",
+                            "description":"official"
+                          },
+                          "common":{
+                            "type":"string",
+                            "description":"common"
+                          }
+                        },
+                        "description":"hrv"
+                      },
+                      "hun":{
+                        "type":"object",
+                        "properties":{
+                          "official":{
+                            "type":"string",
+                            "description":"official"
+                          },
+                          "common":{
+                            "type":"string",
+                            "description":"common"
+                          }
+                        },
+                        "description":"hun"
+                      },
+                      "ita":{
+                        "type":"object",
+                        "properties":{
+                          "official":{
+                            "type":"string",
+                            "description":"official"
+                          },
+                          "common":{
+                            "type":"string",
+                            "description":"common"
+                          }
+                        },
+                        "description":"ita"
+                      },
+                      "jpn":{
+                        "type":"object",
+                        "properties":{
+                          "official":{
+                            "type":"string",
+                            "description":"official"
+                          },
+                          "common":{
+                            "type":"string",
+                            "description":"common"
+                          }
+                        },
+                        "description":"jpn"
+                      },
+                      "kor":{
+                        "type":"object",
+                        "properties":{
+                          "official":{
+                            "type":"string",
+                            "description":"official"
+                          },
+                          "common":{
+                            "type":"string",
+                            "description":"common"
+                          }
+                        },
+                        "description":"kor"
+                      },
+                      "nld":{
+                        "type":"object",
+                        "properties":{
+                          "official":{
+                            "type":"string",
+                            "description":"official"
+                          },
+                          "common":{
+                            "type":"string",
+                            "description":"common"
+                          }
+                        },
+                        "description":"nld"
+                      },
+                      "per":{
+                        "type":"object",
+                        "properties":{
+                          "official":{
+                            "type":"string",
+                            "description":"official"
+                          },
+                          "common":{
+                            "type":"string",
+                            "description":"common"
+                          }
+                        },
+                        "description":"per"
+                      },
+                      "pol":{
+                        "type":"object",
+                        "properties":{
+                          "official":{
+                            "type":"string",
+                            "description":"official"
+                          },
+                          "common":{
+                            "type":"string",
+                            "description":"common"
+                          }
+                        },
+                        "description":"pol"
+                      },
+                      "por":{
+                        "type":"object",
+                        "properties":{
+                          "official":{
+                            "type":"string",
+                            "description":"official"
+                          },
+                          "common":{
+                            "type":"string",
+                            "description":"common"
+                          }
+                        },
+                        "description":"por"
+                      },
+                      "rus":{
+                        "type":"object",
+                        "properties":{
+                          "official":{
+                            "type":"string",
+                            "description":"official"
+                          },
+                          "common":{
+                            "type":"string",
+                            "description":"common"
+                          }
+                        },
+                        "description":"rus"
+                      },
+                      "slk":{
+                        "type":"object",
+                        "properties":{
+                          "official":{
+                            "type":"string",
+                            "description":"official"
+                          },
+                          "common":{
+                            "type":"string",
+                            "description":"common"
+                          }
+                        },
+                        "description":"slk"
+                      },
+                      "spa":{
+                        "type":"object",
+                        "properties":{
+                          "official":{
+                            "type":"string",
+                            "description":"official"
+                          },
+                          "common":{
+                            "type":"string",
+                            "description":"common"
+                          }
+                        },
+                        "description":"spa"
+                      },
+                      "swe":{
+                        "type":"object",
+                        "properties":{
+                          "official":{
+                            "type":"string",
+                            "description":"official"
+                          },
+                          "common":{
+                            "type":"string",
+                            "description":"common"
+                          }
+                        },
+                        "description":"swe"
+                      },
+                      "urd":{
+                        "type":"object",
+                        "properties":{
+                          "official":{
+                            "type":"string",
+                            "description":"official"
+                          },
+                          "common":{
+                            "type":"string",
+                            "description":"common"
+                          }
+                        },
+                        "description":"urd"
+                      },
+                      "zho":{
+                        "type":"object",
+                        "properties":{
+                          "official":{
+                            "type":"string",
+                            "description":"official"
+                          },
+                          "common":{
+                            "type":"string",
+                            "description":"common"
+                          }
+                        },
+                        "description":"zho"
+                      }
+                    },
+                    "description":"translations"
+                  },
+                  "latlng":{
+                    "type":"array",
+                    "items":{
+                      "type":"number",
+                      "format":"float"
+                    },
+                    "description":"latlng"
+                  },
+                  "landlocked":{
+                    "type":"boolean",
+                    "description":"landlocked"
+                  },
+                  "borders":{
+                    "type":"array",
+                    "items":{
+                      "type":"string"
+                    },
+                    "description":"borders"
+                  },
+                  "area":{
+                    "type":"number",
+                    "format":"float",
+                    "description":"area"
+                  },
+                  "demonyms":{
+                    "type":"object",
+                    "properties":{
+                      "eng":{
+                        "type":"object",
+                        "properties":{
+                          "f":{
+                            "type":"string",
+                            "description":"f"
+                          },
+                          "m":{
+                            "type":"string",
+                            "description":"m"
+                          }
+                        },
+                        "description":"eng"
+                      },
+                      "fra":{
+                        "type":"object",
+                        "properties":{
+                          "f":{
+                            "type":"string",
+                            "description":"f"
+                          },
+                          "m":{
+                            "type":"string",
+                            "description":"m"
+                          }
+                        },
+                        "description":"fra"
+                      }
+                    },
+                    "description":"demonyms"
+                  },
+                  "flag":{
+                    "type":"string",
+                    "description":"flag"
+                  },
+                  "maps":{
+                    "type":"object",
+                    "properties":{
+                      "googleMaps":{
+                        "type":"string",
+                        "description":"googleMaps"
+                      },
+                      "openStreetMaps":{
+                        "type":"string",
+                        "description":"openStreetMaps"
+                      }
+                    },
+                    "description":"maps"
+                  },
+                  "population":{
+                    "type":"number",
+                    "format":"float",
+                    "description":"population"
+                  },
+                  "gini":{
+                    "type":"object",
+                    "properties":{
+                      "2014":{
+                        "type":"number",
+                        "format":"float",
+                        "description":"2014"
+                      },
+                      "2016":{
+                        "type":"number",
+                        "format":"float",
+                        "description":"2016"
+                      },
+                      "2018":{
+                        "type":"number",
+                        "format":"float",
+                        "description":"2018"
+                      }
+                    },
+                    "description":"gini"
+                  },
+                  "fifa":{
+                    "type":"string",
+                    "description":"fifa"
+                  },
+                  "car":{
+                    "type":"object",
+                    "properties":{
+                      "signs":{
+                        "type":"array",
+                        "items":{
+                          "type":"string"
+                        },
+                        "description":"signs"
+                      },
+                      "side":{
+                        "type":"string",
+                        "description":"side"
+                      }
+                    },
+                    "description":"car"
+                  },
+                  "timezones":{
+                    "type":"array",
+                    "items":{
+                      "type":"string"
+                    },
+                    "description":"timezones"
+                  },
+                  "continents":{
+                    "type":"array",
+                    "items":{
+                      "type":"string"
+                    },
+                    "description":"continents"
+                  },
+                  "flags":{
+                    "type":"object",
+                    "properties":{
+                      "png":{
+                        "type":"string",
+                        "description":"png"
+                      },
+                      "svg":{
+                        "type":"string",
+                        "description":"svg"
+                      }
+                    },
+                    "description":"flags"
+                  },
+                  "coatOfArms":{
+                    "type":"object",
+                    "properties":{
+                      "png":{
+                        "type":"string",
+                        "description":"png"
+                      },
+                      "svg":{
+                        "type":"string",
+                        "description":"svg"
+                      }
+                    },
+                    "description":"coatOfArms"
+                  },
+                  "startOfWeek":{
+                    "type":"string",
+                    "description":"startOfWeek"
+                  },
+                  "capitalInfo":{
+                    "type":"object",
+                    "properties":{
+                      "latlng":{
+                        "type":"array",
+                        "items":{
+                          "type":"number",
+                          "format":"float"
+                        },
+                        "description":"latlng"
+                      }
+                    },
+                    "description":"capitalInfo"
+                  },
+                  "postalCode":{
+                    "type":"object",
+                    "properties":{
+                      "format":{
+                        "type":"string",
+                        "description":"format"
+                      },
+                      "regex":{
+                        "type":"string",
+                        "description":"regex"
+                      }
+                    },
+                    "description":"postalCode"
+                  }
+                }
+              }
             }
-        }
-    },
-    "definitions": {},
-    "parameters": {},
-    "responses": {},
-    "securityDefinitions": {},
-    "security": [],
-    "tags": [],
-    "x-ms-connector-metadata": [
-      {
-        "propertyName": "Website",
-        "propertyValue": "https://restcountries.com/"
-      },
-      {
-        "propertyName": "Privacy Policy",
-        "propertyValue": "https://restcountries.com/#license"
-      },
-      {
-        "propertyName": "Categories",
-        "propertyValue": "Data"
+          }
+        },
+        "summary":"ALL",
+        "description":"ALL",
+        "operationId":"ALL",
+        "parameters":[
+
+        ]
       }
-    ]
+    }
+  },
+  "definitions":{
+
+  },
+  "parameters":{
+
+  },
+  "responses":{
+
+  },
+  "securityDefinitions":{
+
+  },
+  "security":[
+
+  ],
+  "tags":[
+
+  ],
+  "x-ms-connector-metadata":[
+    {
+      "propertyName":"Website",
+      "propertyValue":"https://restcountries.com/"
+    },
+    {
+      "propertyName":"Privacy Policy",
+      "propertyValue":"https://restcountries.com/#license"
+    },
+    {
+      "propertyName":"Categories",
+      "propertyValue":"Data"
+    }
+  ]
 }

--- a/independent-publisher-connectors/RestCountries/apiProperties.json
+++ b/independent-publisher-connectors/RestCountries/apiProperties.json
@@ -1,0 +1,9 @@
+{
+    "properties": {
+        "connectionParameters": {},
+        "iconBrandColor": "#da3b01",
+        "capabilities": [],
+        "publisher": "Siddharth Vaghasia",
+        "stackOwner": "Rest Countries"
+    }
+}

--- a/independent-publisher-connectors/RestCountries/apiProperties.json
+++ b/independent-publisher-connectors/RestCountries/apiProperties.json
@@ -1,9 +1,11 @@
 {
-    "properties": {
-        "connectionParameters": {},
-        "iconBrandColor": "#da3b01",
-        "capabilities": [],
-        "publisher": "Siddharth Vaghasia",
-        "stackOwner": "Rest Countries"
-    }
+  "properties":{
+    "connectionParameters":{
+    },
+    "iconBrandColor":"#da3b01",
+    "capabilities":[
+    ],
+    "publisher":"Siddharth Vaghasia",
+    "stackOwner":"Rest Countries"
+  }
 }

--- a/independent-publisher-connectors/RestCountries/readme.md
+++ b/independent-publisher-connectors/RestCountries/readme.md
@@ -1,0 +1,25 @@
+# Rest Countries
+Rest Countries is a REST Based service that provides access to accurate all countries data and its relevant information.
+This connector will allow you to recieves countries information in your app, flow or report.
+
+## Publisher
+### Siddharth Vaghasia
+
+## Prerequisites
+NA
+
+## Supported Operations
+### [Locations Operations](https://restcountries.com/)
+#### Get All Countries List
+Returns list of all countries and its basic information like name, currency, languages, time zone etc
+
+
+## API Documentation
+Visit [Rest Countries APIs reference](https://restcountries.com/#api-endpoints-v3-all) page for further details.
+
+Please note that connector uses v3 endpoints
+
+## Known Issues and Limitations
+No issues and limitations are known at this time.
+
+#### Not all operations provided by Rest Countries are part of the first IP connector submission. I will keep adding/updating/supporting this connector based on your feedback/requests :)


### PR DESCRIPTION
---
This is a custom connector to get all the countries lists and its relevant information using an open-source API restcountries.com
This would be useful where we need to create a dropdown to select the country and get is currency, language, timezone, etc also. 

- [x] I attest that the connector works and I verified by deploying and testing all the operations. 
- [x] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [x] I attest that I have added response schemas to my actions unless the response schema is dynamic. 
- [x] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [x] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.

If you are an Independent Publisher, you must also attest to the following to ensure a smooth publishing process:
- [x] I have named this PR after the pattern of "Connector Name (Independent Publisher)" ex: HubSpot Marketing (Independent Publisher)
- [x] Within this PR markdown file, I have pasted screenshots that show: 3 unique operations (actions/triggers) working within a Flow. This can be in one flow or part of multiple flows. For each one of those flows, I have pasted in screenshots of the Flow succeeding. 
- [x] Within this PR markdown file, I have pasted in a screenshot from the Test operations section within the Custom Connector UI.
- [ ] If the connector uses OAuth, I have provided detailed steps on how to create an app in the readme.md. 

Screenshot of actions in Flow

![image](https://user-images.githubusercontent.com/9557557/145941270-6afb48b4-5f22-432b-ae39-7eb08c42c2d8.png)

Screenshot of  Test operations section within the Custom Connector UI

![image](https://user-images.githubusercontent.com/9557557/145941513-a088f42d-01a0-4ae0-b700-077911c1f483.png)


Let me know if any changes are required.