### PR TITLE
More consistent download experience for overwrite

### DIFF
--- a/tools/paconn-cli/README.md
+++ b/tools/paconn-cli/README.md
@@ -171,14 +171,15 @@ When environment or connector ID is not specified the command will prompt for th
 
 ```
 Arguments
-   --cid -c      : The custom connector ID.
-   --dest -d     : Destination directory.
-   --env -e      : Power Platform environment ID.
-   --pau -u      : Power Platform URL.
-   --pav -v      : Power Platform API version.
-   --settings -s : A settings file containing required parameters.
-                   When a settings file is specified some command 
-                   line parameters are ignored.
+   --cid -c       : The custom connector ID.
+   --dest -d      : Destination directory.   
+   --env -e       : Power Platform environment ID.
+   --overwrite -w : Overwrite all the existing connector and settings files.
+   --pau -u       : Power Platform URL.
+   --pav -v       : Power Platform API version.
+   --settings -s  : A settings file containing required parameters.
+                    When a settings file is specified some command 
+                    line parameters are ignored.
 ```
 ### Create a New Custom Connector
 

--- a/tools/paconn-cli/paconn/operations/download.py
+++ b/tools/paconn-cli/paconn/operations/download.py
@@ -47,11 +47,9 @@ def _prepare_directory(destination, connector_id):
     # Create a sub-directory in the current directory
     # when a destination isn't provided
     else:
-        if os.path.isdir(connector_id):            
-            destination = connector_id
-        else:
+        if not os.path.isdir(connector_id):
             os.mkdir(connector_id)
-            destination = connector_id
+        destination = connector_id
 
     if os.path.isdir(destination):
         os.chdir(destination)
@@ -84,7 +82,7 @@ def download(powerapps_rp, settings, destination, overwrite):
     """
     # Prepare folders
     directory = _prepare_directory(
-        destination=destination,        
+        destination=destination,
         connector_id=settings.connector_id)
 
     # Check if files could be overwritten

--- a/tools/paconn-cli/paconn/operations/download.py
+++ b/tools/paconn-cli/paconn/operations/download.py
@@ -34,7 +34,7 @@ from paconn.operations.json_keys import (
 )
 
 
-def _prepare_directory(destination, overwrite, connector_id):
+def _prepare_directory(destination, connector_id):
     """
     Create directory for saving a connector.
     """
@@ -84,8 +84,7 @@ def download(powerapps_rp, settings, destination, overwrite):
     """
     # Prepare folders
     directory = _prepare_directory(
-        destination=destination,
-        overwrite=overwrite,
+        destination=destination,        
         connector_id=settings.connector_id)
 
     # Check if files could be overwritten

--- a/tools/paconn-cli/paconn/operations/download.py
+++ b/tools/paconn-cli/paconn/operations/download.py
@@ -34,7 +34,7 @@ from paconn.operations.json_keys import (
 )
 
 
-def _prepare_directory(destination, connector_id):
+def _prepare_directory(destination, overwrite, connector_id):
     """
     Create directory for saving a connector.
     """
@@ -47,9 +47,8 @@ def _prepare_directory(destination, connector_id):
     # Create a sub-directory in the current directory
     # when a destination isn't provided
     else:
-        if os.path.isdir(connector_id):
-            error = '{} directory already exists. Please remove the directory before continuing.'
-            raise CLIError(error.format(connector_id))
+        if os.path.isdir(connector_id):            
+            destination = connector_id
         else:
             os.mkdir(connector_id)
             destination = connector_id
@@ -86,6 +85,7 @@ def download(powerapps_rp, settings, destination, overwrite):
     # Prepare folders
     directory = _prepare_directory(
         destination=destination,
+        overwrite=overwrite,
         connector_id=settings.connector_id)
 
     # Check if files could be overwritten


### PR DESCRIPTION
Power Platform Connectors CLI Update

This pull request will allow for a more consistent download experience and allow for better ALM by ensuring that custom connectors can be downloaded even if the files already exist.  Also updates the documentation which had no mention of the overwrite argument.

Issue: User cannot download connector files with the --overwrite argument unless they also supply the --destination argument. If they attempt to download the connector without the --destination argument the following error always appears, "{connectorid} directory already exists. Please remove the directory before continuing."

New Experience
* paconn download; If directory is found user is provided option to overwrite files within connectionid directory.
* paconn download --overwrite;  If directory is found files are automatically overwritten
* paconn download --destination c:\code\dest; If directory is found user is provided option to overwrite files within destination directory.
* paconn download --destination c:\code\dest --overwrite; If directory is found files are automatically overwritten
