### PR TITLE
Renamed 'Text Analytics' connector to 'Language Service'

### DIFF
--- a/certified-connectors/CognitiveServicesTextAnalytics/Readme.md
+++ b/certified-connectors/CognitiveServicesTextAnalytics/Readme.md
@@ -1,5 +1,5 @@
 ## Text Analytics Connector
-The Text Analytics API is a cloud-based service that provides advanced natural language processing over raw text, and includes four main functions: sentiment analysis, key phrase extraction, language detection and entity recognition. This connector exposes these functions as operations in Microsoft Power Automate and Power Apps.
+The Language Service API is a cloud-based service that provides advanced natural language processing over raw text, and includes four main functions: sentiment analysis, key phrase extraction, language detection and entity recognition. This connector exposes these functions as operations in Microsoft Power Automate and Power Apps.
 
 ## Pre-requisites
 You will need the following to proceed:

--- a/certified-connectors/CognitiveServicesTextAnalytics/apiDefinition.swagger.json
+++ b/certified-connectors/CognitiveServicesTextAnalytics/apiDefinition.swagger.json
@@ -2,10 +2,10 @@
   "swagger": "2.0",
   "info": {
     "version": "v3.0",
-    "title": "Text Analytics",
-    "description": "Microsoft Cognitive Services Text Analytics detects language, sentiment and more of the text you provide.",
+    "title": "Language Service",
+    "description": "Azure Cognitive Service for Language detects language, sentiment and more of the text you provide.",
     "contact": {
-      "name": "Azure Cognitive Services Text Analytics",
+      "name": "Azure Cognitive Service for Language",
       "url": "https://azure.microsoft.com/en-us/services/cognitive-services/text-analytics/",
       "email": "mlapi@microsoft.com"
     },
@@ -179,7 +179,7 @@
     "/text/analytics/v3.0/entities/recognition/general": {
       "post": {
         "summary": "Named Entity Recognition (V3.0)",
-        "description": "The API returns a list of general named entities in a given document. For the list of supported entity types, check <a href=\"https://aka.ms/taner\">Supported Entity Types in Text Analytics API</a>. See the <a href=\"https://aka.ms/talangs\">Supported languages in Text Analytics API</a> for the list of enabled languages.",
+        "description": "The API returns a list of general named entities in a given document. For the list of supported entity types, check <a href=\"https://aka.ms/taner\">Supported Named Entity Recognition (NER) entity categories</a>.",
         "operationId": "EntitiesRecognitionGeneral",
         "consumes": [
           "application/json",
@@ -229,7 +229,7 @@
     "/text/analytics/v3.0/entities/linking": {
       "post": {
         "summary": "Entity Linking (V3.0)",
-        "description": "The API returns a list of recognized entities with links to a well-known knowledge base. See the <a href=\"https://aka.ms/talangs\">Supported languages in Text Analytics API</a> for the list of enabled languages.",
+        "description": "The API returns a list of recognized entities with links to a well-known knowledge base. See the <a href=\"https://aka.ms/talinking\">language support</a> for the list of supported languages.",
         "operationId": "EntitiesLinking",
         "consumes": [
           "application/json",
@@ -277,7 +277,7 @@
     "/text/analytics/v3.0/keyPhrases": {
       "post": {
         "summary": "Key Phrases (V3.0)",
-        "description": "The API returns a list of strings denoting the key phrases in the input text. See the <a href=\"https://aka.ms/talangs\">Supported languages in Text Analytics API</a> for the list of enabled languages.",
+        "description": "The API returns a list of strings denoting the key phrases in the input text. See the <a href=\"https://aka.ms/takeyphrases\">Language support for Key Phrase Extraction</a> for the list of supported languages.",
         "operationId": "KeyPhrases",
         "consumes": [
           "application/json",
@@ -325,7 +325,7 @@
     "/text/analytics/v3.0/languages": {
       "post": {
         "summary": "Detect Language (V3.0)",
-        "description": "The API returns the detected language and a numeric score between 0 and 1. Scores close to 1 indicate 100% certainty that the identified language is true. See the <a href=\"https://aka.ms/talangs\">Supported languages in Text Analytics API</a> for the list of enabled languages.",
+        "description": "The API returns the detected language and a numeric score between 0 and 1. Scores close to 1 indicate 100% certainty that the identified language is true. See the <a href=\"https://aka.ms/tadetectlanguage\">Language support for Language Detection</a> for the list of supported languages.",
         "operationId": "Languages",
         "consumes": [
           "application/json",
@@ -373,7 +373,7 @@
     "/text/analytics/v3.0/sentiment": {
       "post": {
         "summary": "Sentiment (V3.0)",
-        "description": "The API returns a sentiment prediction, as well as sentiment scores for each sentiment class (Positive, Negative, and Neutral) for the document and each sentence within it. See the <a href=\"https://aka.ms/talangs\">Supported languages in Text Analytics API</a> for the list of enabled languages.",
+        "description": "The API returns a sentiment prediction, as well as sentiment scores for each sentiment class (Positive, Negative, and Neutral) for the document and each sentence within it. See the <a href=\"https://aka.ms/tasentiment\">Sentiment Analysis and Opinion Mining language support</a> for the list of supported languages.",
         "operationId": "Sentiment",
         "consumes": [
           "application/json",


### PR DESCRIPTION
Following up "Text Analytics" service rename and renaming connector display name (and some descriptions) accordingly.