### PR TITLE
README.md polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ More information on each of the properties are given below:
 
 * `connectionParameters`: Defines the connection parameter for the service.
 
-* `iconBrandColor`: The icon brand color in HTML hex code for the custom connector. Independent Publisher connectors must set the color to "#da3b01".
+* `iconBrandColor`: The icon brand color in HTML hex code for the custom connector. Independent Publisher connectors must set the color to `"#da3b01"`.
 
 * `capabilities`: Describes the capabilities for the connector, e.g. cloud only, on-prem gateway etc.
 
@@ -88,7 +88,7 @@ For further details, see the [apiProperties.json](schemas/paconn-apiProperties.s
 
 ### README.md
 
-README.md file for your connector includes a description for your connector, any prerequisite a developer or contributor may need to build your connector. It includes instructions on how to use your connector and api, how to get credentials, supported operations, known issues and limitations, etc. This file is meant to be a standalone guide for deploying and using your connector by other users and developers. A good example is the [Azure Key Vault](custom-connectors/AzureKeyVault/readme.md) custom connector.
+README.md file for your connector includes a description for your connector, any prerequisite a developer or contributor may need to build your connector. It includes instructions on how to use your connector and api, how to get credentials, supported operations, known issues and limitations, etc. This file is meant to be a standalone guide for deploying and using your connector by other users and developers. A good example is the [Azure Key Vault](custom-connectors/AzureKeyVault/Readme.md) custom connector.
 A readme.md template for [Certified Connectors](templates/certified-connectors/readme.md) and [Independent Publisher Connectors](templates/Independent%20Publisher/readme.md) is also included for your reference. If you are submitting an Independent Publisher connector that requires OAuth, please make sure to explain how to create the OAuth app. The Microsoft Certification Team will use those instructions to create the app, so please make sure they are detailed and accurate.
 
 ### Creating a Fork
@@ -157,7 +157,7 @@ Updates to an existing custom connector can be made through a simple pull reques
 #### Independent Publisher Connectors
 
 Follow the same instructions as above on submitting for certification, create a directory under the "independent-publisher-connectors" directory and place the connector files in the sub-folder.
-The `"iconBrandColor":` in the API properties file must be set to `#da3b01`.
+The `"iconBrandColor":` in the API properties file must be set to `"#da3b01"`.
 Set your pull request title to "Connector Name (Independent Publisher)."
 Paste in screenshots from the Test operations section and 3 unique operations (actions/triggers) working within a Flow. This can be in one flow or part of multiple flows. For each one of those flows, I have pasted in screenshots of the Flow succeeding.
 Add a tag by selecting the labels option to "independent-publisher-connector."

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ To keep your fork up to date with this repository's updates, run these commands:
 
 ```git fetch upstream```
 
-```git checkout origin/master```
+```git checkout master```
 
 ```git merge upstream/master```
 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ Welcome to the Microsoft Power Platform Connectors open source repository. This 
 
 ## Custom Connectors
 
-The ```custom-connectors``` folder contains fully functional connector samples which can be deployed to the Power Platform for extension and use. If you are looking to publish a connector to the Power Platform, please explore Certified Connectors and Independent Publisher Connectors. 
+The ```custom-connectors``` folder contains fully functional connector samples which can be deployed to the Power Platform for extension and use. If you are looking to publish a connector to the Power Platform, please explore Certified Connectors and Independent Publisher Connectors.
 
 ## Certified Connectors
 
-The ```certified-connectors``` folder contains certified connectors which are built by partners who own the end service of their connector. These connectors are deployed and available out-of-box within the Power Platform for use. 
-One requirement of our [connector certification program](https://docs.microsoft.com/connectors/custom-connectors/submit-certification) is that new certified connectors be open sourced for community contributions. 
-The ```certified-connectors``` folder is managed by the Microsoft Connector Certification Team to ensure that within the ```master``` branch, the connector version is identical to that deployed in the Power Platform. 
-The ```dev``` branch is maintained by the connector owner and the Microsoft Connector Certification Team to allow community development of the connector prior to certification and deployment of a version. 
+The ```certified-connectors``` folder contains certified connectors which are built by partners who own the end service of their connector. These connectors are deployed and available out-of-box within the Power Platform for use.
+One requirement of our [connector certification program](https://docs.microsoft.com/connectors/custom-connectors/submit-certification) is that new certified connectors be open sourced for community contributions.
+The ```certified-connectors``` folder is managed by the Microsoft Connector Certification Team to ensure that within the ```master``` branch, the connector version is identical to that deployed in the Power Platform.
+The ```dev``` branch is maintained by the connector owner and the Microsoft Connector Certification Team to allow community development of the connector prior to certification and deployment of a version.
 
 ## Independent Publisher Connectors
 
@@ -24,11 +24,14 @@ Contributor License Agreement (CLA), which declares that you have the right to, 
 the rights to use your contribution. For details, visit https://cla.microsoft.com.
 
 ### Files to Include
+
 Please submit the following files: An Open API 2.0 swagger definition, an API properties file, and a README.md.
 
 ### API Definition (Swagger) File
 
 The API definition, also known as the swagger, describes the API for the custom connector using the OpenAPI specification.
+
+For further details, see the [apiDefinition.swagger.json](schemas/apiDefinition.swagger.schema.json) JSON schema.
 
 ### API Properties File
 
@@ -69,7 +72,7 @@ The API properties file contains some properties for the custom connector. These
 }
 ```
 
-More information on the each of the properties are given below:
+More information on each of the properties are given below:
 
 * `properties`: The container for the information.
 
@@ -81,13 +84,16 @@ More information on the each of the properties are given below:
 
 * `policyTemplateInstances`: An optional list of policy template instances and values used in the custom connector.
 
+For further details, see the [apiProperties.json](schemas/paconn-apiProperties.schema.json) JSON schema.
+
 ### README.md
 
-README.md file for your connector includes a description for your connector, any prerequisite a developer or contributor may need to build your connector. It includes instructions on how to use your connector and api, how to get credentials, supported operations, known issues and limitations, etc. This file is meant to be a standalone guide for deploying and using your connector by other users and developers. A [template](https://github.com/microsoft/PowerPlatformConnectors/blob/dev/templates/readme.md) and a [sample](https://github.com/microsoft/PowerPlatformConnectors/blob/dev/custom-connectors/AzureKeyVault/Readme.md) is included for reference. If you are submitting an Independent Publisher connector that requires OAuth, please make sure to explain how to create the OAuth app. The Microsoft Certification Team will use those instructions to create the app, so please make sure they are detailed and accurate.
+README.md file for your connector includes a description for your connector, any prerequisite a developer or contributor may need to build your connector. It includes instructions on how to use your connector and api, how to get credentials, supported operations, known issues and limitations, etc. This file is meant to be a standalone guide for deploying and using your connector by other users and developers. A good example is the [Azure Key Vault](custom-connectors/AzureKeyVault/readme.md) custom connector.
+A readme.md template for [Certified Connectors](templates/certified-connectors/readme.md) and [Independent Publisher Connectors](templates/Independent%20Publisher/readme.md) is also included for your reference. If you are submitting an Independent Publisher connector that requires OAuth, please make sure to explain how to create the OAuth app. The Microsoft Certification Team will use those instructions to create the app, so please make sure they are detailed and accurate.
 
 ### Creating a Fork
 
-To contibute to this open source repository, start by creating a fork on this repository. To do so, select the "fork" button on the upper right corner, and create your own copy of the repository. Next, sync your fork with the remote repository and clone your forked repository to your local machine.
+To contribute to this open source repository, start by creating a fork on this repository. To do so, select the "fork" button in the upper right corner, and create your own copy of the repository. Next, sync your fork with the remote repository and clone your forked repository to your local machine.
 
 ```git clone https://github.com/YOUR-USERNAME/PowerPlatformConnectors.git```
 
@@ -119,7 +125,7 @@ To keep your fork up to date with this repository's updates, run these commands:
 
 ```git fetch upstream```
 
-```git checkout master```
+```git checkout origin/master```
 
 ```git merge upstream/master```
 
@@ -127,38 +133,37 @@ You are now ready to develop your connector in your own branch.
 
 ### Submitting to the Open Source Repository
 
-Contributions to the open source repository are made through pull requests. 
-Prior to submitting a pull request, ensure that 1) you have thoroughly tested the connector 2) you have provided response schemas unless the responses are dynamic, and 3) that your pull request does not contain any sensitive or specific information, for example client ids or client secrets. 
-Any sensitive values can be replaced with fake or dummy values for the purposes of submission as long as it is clearly indicated. 
-Also, ensure that the readme.md of the connector is updated with the latest information, or created for new connector submissions. 
-An example of a clear, structured, readme.md can be found in the [Azure Key Vault](https://github.com/microsoft/PowerPlatformConnectors/blob/dev/custom-connectors/AzureKeyVault/Readme.md) connector repository. 
-A [README template](https://github.com/microsoft/PowerPlatformConnectors/blob/dev/templates/README.template.md) is also included for your reference.
-Include this completed `readme.md` in same connector directory which contains the artifacts. 
+Contributions to the open source repository are made through pull requests.
+Prior to submitting a pull request, ensure that 1) you have thoroughly tested the connector 2) you have provided response schemas unless the responses are dynamic, and 3) that your pull request does not contain any sensitive or specific information, for example client ids or client secrets.
+Any sensitive values can be replaced with fake or dummy values for the purposes of submission as long as it is clearly indicated.
+Also, ensure that the readme.md of the connector is updated with the latest information, or created for new connector submissions.
+An example of a clear, structured, readme.md can be found for the [Azure Key Vault](custom-connectors/AzureKeyVault/Readme.md) connector.
+A readme.md template for [Certified Connectors](templates/certified-connectors/readme.md) and [Independent Publisher Connectors](templates/Independent%20Publisher/readme.md) is also included for your reference.
+Put the `readme.md` in the same directory as the other connector files.
 Add tags indicating which connector type you are submitting. Connector type name should match the folder name you are submitting to: custom-connector, certified-connector, or independent-publisher-connector.
 
 #### Certified Connectors
 
-For new connectors which will be submitted for certification, create a directory under the ```certified-connectors``` directory, place the connector files in the sub-folder, and submit a pull request to the ```dev``` branch. Ensure that a clear, structured, readme.md is included. 
+For new connectors which will be submitted for certification, create a directory under the ```certified-connectors``` directory, place the connector files in the sub-folder, and submit a pull request to the ```dev``` branch. Ensure that a clear, structured, readme.md is included.
 
 Add a tag by selecting the labels option to "certified-connector"
 
-Updates to certified connectors must first be made through a pull request to the ```dev``` branch for review by the connector owner. 
+Updates to certified connectors must first be made through a pull request to the ```dev``` branch for review by the connector owner.
 
-Once a pull request has been merged to the ```dev``` branch, the connector owner can submit the connector for certification through the Connector certification tab in [ISV Studio](https://isvstudio.powerapps.com). Once certified, the Microsoft Certification team will handle merging the updates from ```dev``` to ```master```. 
+Once a pull request has been merged to the ```dev``` branch, the connector owner can submit the connector for certification through the Connector certification tab in [ISV Studio](https://isvstudio.powerapps.com). Once certified, the Microsoft Certification team will handle merging the updates from ```dev``` to ```master```.
 
 Updates to an existing custom connector can be made through a simple pull request to the ```dev``` branch to update the custom connector files.
 
-#### Independent Publisher
+#### Independent Publisher Connectors
 
-Follow the same instructions as above on submitting for certification, create a directory under the "independent-publisher-connectors" directory and place the connector files in the sub-folder. 
-Your icon color in the API properties file must be set to `#da3b01`, as in `"iconBrandColor": "#da3b01"`. [A sample icon for Independent Publisher connector](https://github.com/microsoft/PowerPlatformConnectors/blob/dev/templates/independent-publisher-icon.png) is included for your reference. 
+Follow the same instructions as above on submitting for certification, create a directory under the "independent-publisher-connectors" directory and place the connector files in the sub-folder.
+The `"iconBrandColor":` in the API properties file must be set to `#da3b01`.
 Set your pull request title to "Connector Name (Independent Publisher)."
-Paste in screenshots from the Test operations section and 3 unique operations (actions/triggers) working within a Flow. This can be in one flow or part of multiple flows. For each one of those flows, I have pasted in screenshots of the Flow succeeding. 
+Paste in screenshots from the Test operations section and 3 unique operations (actions/triggers) working within a Flow. This can be in one flow or part of multiple flows. For each one of those flows, I have pasted in screenshots of the Flow succeeding.
 Add a tag by selecting the labels option to "independent-publisher-connector."
 If the connector uses OAuth, I have provided detailed steps on how to create an app in the readme.md.
 
-
-#### Custom Connector
+#### Custom Connectors
 
 Follow the same instructions on submitting for certification, create a directory under the custom-connectors directory and place the connector files in the sub-folder. Add a tag by selecting the labels option to "custom-connector".
 
@@ -177,7 +182,7 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
 #### Swagger Validation
 
-A submitted pull request will also be validated against our Swagger Validator tool, which checks the connector files to ensure it is a proper Swagger file and adheres to our connector requirements and guidelines. Any errors or warnings will be added to the PR for both the submitter and the reviewer to understand. We do not accept pull requests with outstanding unresolved Swagger Validator issues. 
+A submitted pull request will also be validated against our Swagger Validator tool, which checks the connector files to ensure it is a proper Swagger file and adheres to our connector requirements and guidelines. Any errors or warnings will be added to the PR for both the submitter and the reviewer to understand. We do not accept pull requests with outstanding unresolved Swagger Validator issues.
 
 #### Breaking Change Detector
 


### PR DESCRIPTION
I gave the `README.md` a bit of polish since it contained dead links, typos, unnecessary whitespace, and other hiccups. However, there is still lots of room for improvement.
—Sebastian