### PR TITLE
Nederlandse Spoorwegen connector added

### DIFF
--- a/independent-publisher-connectors/Nederlandse Spoorwegen/Readme.md
+++ b/independent-publisher-connectors/Nederlandse Spoorwegen/Readme.md
@@ -1,0 +1,34 @@
+# Nederlandse Spoorwegen
+
+Nederlandse Spoorwegen (NS) is the main railway operator within the Netherlands.
+
+## Publisher: Miguel Verweij
+
+## Prerequisites
+
+You need a Nederlandse Spoorwegen account. You can get one for free [here](https://apiportal.ns.nl/signin).
+
+## Obtaining Credentials
+
+For authorization an API key is required. How to get this is described in NS's developer [Starter's Guide](https://apiportal.ns.nl/startersguide).
+The product to choose for this connection is [Ns-App](https://apiportal.ns.nl/products/NsApp).
+
+## Supported Operations
+
+The connector supports the following operations:
+- `Departures`: List of departures for a specific station
+- `Arrivals`: List of arrivals for a specific station
+- `Journey details`: Returns information about a specific journey
+- `Single trip`: Returns a single trip, based on the given parameters
+- `Calamities`: List of calamities. This operation is deprecated. Use /api/v3/disruptions instead
+- `International prices`: Returns price information for international trips
+- `Domestic prices`: Returns price information for domestic trips
+- `Stations`: List of stations
+- `Trips`: Returns a travel advice for the given parameters
+- `Station disruptions`: List of disruptions relevant for the current station
+- `Single disruption`: Returns information on a single disruption/maintenance/calamity
+- `Disruptions`: List of calamities/disruptions/maintenance
+
+## Known Issues and Limitations
+
+Although the API service is free, the number of calls is limited. NS always has the option to adjust the limit if desired.

--- a/independent-publisher-connectors/Nederlandse Spoorwegen/apiDefinition.swagger.json
+++ b/independent-publisher-connectors/Nederlandse Spoorwegen/apiDefinition.swagger.json
@@ -1,0 +1,6615 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Nederlandse Spoorwegen",
+    "version": "1.0",
+    "description": "Retrieve information from the main Dutch railway operator.",
+    "contact": {
+      "email": "miguel.verweij@sogeti.com",
+      "name": "Miguel Verweij",
+      "url": "https://www.PowerPlatformChallenge.com"
+    }
+  },
+  "x-ms-connector-metadata": [
+    {
+      "propertyName": "Website",
+      "propertyValue": "https://apiportal.ns.nl/"
+    },
+    {
+      "propertyName": "Privacy policy",
+      "propertyValue": "https://www.ns.nl/en/privacy"
+    },
+    {
+      "propertyName": "Categories",
+      "propertyValue": "Communication"
+    }
+  ],
+  "host": "gateway.apiportal.ns.nl",
+  "basePath": "/reisinformatie-api",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [],
+  "produces": [],
+  "paths": {
+    "/api/v2/departures": {
+      "get": {
+        "description": "List of departures for a specific station",
+        "operationId": "getDepartures",
+        "summary": "Departures",
+        "tags": [
+          "Departures"
+        ],
+        "parameters": [
+          {
+            "name": "lang",
+            "in": "query",
+            "description": "Language to use for localizing the departures list. Only a small subset of text is translated, mainly notes. Defaults to Dutch",
+            "type": "string"
+          },
+          {
+            "name": "station",
+            "in": "query",
+            "description": "NS Station code for the station to return departures for. Can be left empty if uicCode parameter is provided.",
+            "type": "string"
+          },
+          {
+            "name": "uicCode",
+            "in": "query",
+            "description": "UIC code for the station to return departures for. Can be left empty if station parameter is provided.",
+            "type": "string"
+          },
+          {
+            "name": "dateTime",
+            "in": "query",
+            "description": "Format - date-time (as date-time in RFC3339). Departure date to show departures from. Only supported for departures at foreign stations. Defaults to server time (Europe/Amsterdam)",
+            "type": "string"
+          },
+          {
+            "name": "maxJourneys",
+            "in": "query",
+            "description": "Number of departures or departures to return. Defaults to 40",
+            "type": "integer"
+          }
+        ],
+        "produces": [
+          "*/*",
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of departures",
+            "schema": {
+              "$ref": "#/definitions/RepresentationResponseDeparturesPayload"
+            }
+          },
+          "400": {
+            "description": "Bad request. One or more parameters are invalid",
+            "schema": {
+              "$ref": "#/definitions/APIError"
+            },
+            "examples": {
+              "application/json": {
+                "timestamp": "string",
+                "code": 0,
+                "message": "string",
+                "path": "string",
+                "exception": "string",
+                "errors": [
+                  {
+                    "message": "string",
+                    "type": "string",
+                    "lang": "string"
+                  }
+                ],
+                "requestId": "string"
+              }
+            }
+          },
+          "404": {
+            "description": "Station name or uiccode provided in the parameters could not be found",
+            "schema": {
+              "$ref": "#/definitions/APIError"
+            },
+            "examples": {
+              "application/json": {
+                "timestamp": "string",
+                "code": 0,
+                "message": "string",
+                "path": "string",
+                "exception": "string",
+                "errors": [
+                  {
+                    "message": "string",
+                    "type": "string",
+                    "lang": "string"
+                  }
+                ],
+                "requestId": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/arrivals": {
+      "get": {
+        "description": "List of arrivals for a specific station",
+        "operationId": "getArrivals",
+        "summary": "Arrivals",
+        "tags": [
+          "Arrivals"
+        ],
+        "parameters": [
+          {
+            "name": "lang",
+            "in": "query",
+            "description": "Language to use for localizing the arrivals list. Only a small subset of text is translated, mainly notes. Defaults to Dutch",
+            "type": "string"
+          },
+          {
+            "name": "station",
+            "in": "query",
+            "description": "NS Station code for the station to return arrivals for. Can be left empty if uicCode parameter is provided.",
+            "type": "string"
+          },
+          {
+            "name": "uicCode",
+            "in": "query",
+            "description": "UIC code for the station to return arrivals for. Can be left empty if station parameter is provided.",
+            "type": "string"
+          },
+          {
+            "name": "dateTime",
+            "in": "query",
+            "description": "Format - date-time (as date-time in RFC3339). Departure date to show arrivals from.  Only supported for arrivals at foreign stations. Defaults to server time (Europe/Amsterdam)",
+            "type": "string"
+          },
+          {
+            "name": "maxJourneys",
+            "in": "query",
+            "description": "Number of departures or arrivals to return. Defaults to 40",
+            "type": "integer"
+          }
+        ],
+        "produces": [
+          "*/*",
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of arrivals",
+            "schema": {
+              "$ref": "#/definitions/RepresentationResponseArrivalsPayload"
+            }
+          },
+          "400": {
+            "description": "Bad request. One or more parameters are invalid",
+            "schema": {
+              "$ref": "#/definitions/APIError"
+            },
+            "examples": {
+              "application/json": {
+                "timestamp": "string",
+                "code": 0,
+                "message": "string",
+                "path": "string",
+                "exception": "string",
+                "errors": [
+                  {
+                    "message": "string",
+                    "type": "string",
+                    "lang": "string"
+                  }
+                ],
+                "requestId": "string"
+              }
+            }
+          },
+          "404": {
+            "description": "Station name or uiccode provided in the parameters could not be found",
+            "schema": {
+              "$ref": "#/definitions/APIError"
+            },
+            "examples": {
+              "application/json": {
+                "timestamp": "string",
+                "code": 0,
+                "message": "string",
+                "path": "string",
+                "exception": "string",
+                "errors": [
+                  {
+                    "message": "string",
+                    "type": "string",
+                    "lang": "string"
+                  }
+                ],
+                "requestId": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/journey": {
+      "get": {
+        "description": "Returns information about a specific journey",
+        "operationId": "getJourneyDetail",
+        "summary": "Journey details",
+        "tags": [
+          "Journey"
+        ],
+        "parameters": [
+          {
+            "name": "train",
+            "in": "query",
+            "description": "Format - int32. Train number to return details for. Either the train number or journey identifier must be given",
+            "type": "integer"
+          },
+          {
+            "name": "id",
+            "in": "query",
+            "description": "Journey identifier. Can be found in as journeyDetailRef in the /api/v3/trips output. Either the train number of journey identifier must be given",
+            "type": "string"
+          },
+          {
+            "name": "dateTime",
+            "in": "query",
+            "description": "Format - date-time (as date-time in RFC3339). Date for this journey. Defaults to server time (Europe/Amsterdam)",
+            "type": "string"
+          },
+          {
+            "name": "departureUicCode",
+            "in": "query",
+            "description": "UIC code of the station that will be indicated as kind = DEPARTURE in the output.",
+            "type": "string"
+          },
+          {
+            "name": "transferUicCode",
+            "in": "query",
+            "description": "UIC code of the station that will be indicated as kind = TRANSFER in the output.",
+            "type": "string"
+          },
+          {
+            "name": "arrivalUicCode",
+            "in": "query",
+            "description": "UIC code of the station that will be indicated as kind = ARRIVAL in the output.",
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "*/*",
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Information about the journey",
+            "schema": {
+              "$ref": "#/definitions/RepresentationResponseJourney"
+            }
+          },
+          "400": {
+            "description": "Bad request. One or more parameters are invalid",
+            "schema": {
+              "$ref": "#/definitions/APIError"
+            },
+            "examples": {
+              "application/json": {
+                "timestamp": "string",
+                "code": 0,
+                "message": "string",
+                "path": "string",
+                "exception": "string",
+                "errors": [
+                  {
+                    "message": "string",
+                    "type": "string",
+                    "lang": "string"
+                  }
+                ],
+                "requestId": "string"
+              }
+            }
+          },
+          "404": {
+            "description": "Information about this journey could  not be found",
+            "schema": {
+              "$ref": "#/definitions/APIError"
+            },
+            "examples": {
+              "application/json": {
+                "timestamp": "string",
+                "code": 0,
+                "message": "string",
+                "path": "string",
+                "exception": "string",
+                "errors": [
+                  {
+                    "message": "string",
+                    "type": "string",
+                    "lang": "string"
+                  }
+                ],
+                "requestId": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/trips/trip": {
+      "get": {
+        "description": "Returns a single trip, based on the given parameters",
+        "operationId": "getTrip",
+        "summary": "Single trip",
+        "tags": [
+          "Trips"
+        ],
+        "parameters": [
+          {
+            "name": "ctxRecon",
+            "in": "query",
+            "description": "Reconstruction context to use as basis for finding trip. Can be found in the /api/v3/trips output",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "date",
+            "in": "query",
+            "description": "Format - date-time (as date-time in RFC3339). Datetime to use when reconstructing trip, may be a different date than the trip was originally planned.",
+            "type": "string"
+          },
+          {
+            "name": "travelRequestType",
+            "in": "query",
+            "description": "Specify directions or directionsOnly to include directions for walk/bike/car legs in the result.",
+            "type": "string",
+            "default": "DEFAULT",
+            "enum": [
+              "DEFAULT",
+              "DIRECTIONS",
+              "DIRECTIONS_ONLY"
+            ]
+          },
+          {
+            "name": "product",
+            "in": "query",
+            "description": "Name of the product that will be used in travel.",
+            "type": "string",
+            "enum": [
+              "GEEN",
+              "OVCHIPKAART_ENKELE_REIS",
+              "OVCHIPKAART_RETOUR",
+              "DAL_VOORDEEL",
+              "ALTIJD_VOORDEEL",
+              "DAL_VRIJ",
+              "WEEKEND_VRIJ",
+              "ALTIJD_VRIJ",
+              "BUSINESSCARD",
+              "BUSINESSCARD_DAL",
+              "STUDENT_WEEK",
+              "STUDENT_WEEKEND",
+              "VDU",
+              "SAMENREISKORTING",
+              "TRAJECT_VRIJ"
+            ]
+          },
+          {
+            "name": "discount",
+            "in": "query",
+            "description": "Discount of travel to use when calculating product prices",
+            "type": "string",
+            "default": "NO_DISCOUNT"
+          },
+          {
+            "name": "travelClass",
+            "in": "query",
+            "description": "Format - int32. Class of travel to use when calculating product prices",
+            "type": "integer",
+            "default": 2
+          },
+          {
+            "name": "API Key",
+            "in": "header",
+            "description": "Account details to use when querying trip assistance options",
+            "type": "string"
+          },
+          {
+            "name": "lang",
+            "in": "header",
+            "description": "Language to use for localizing the travel advice. Only a small subset of text is translated, mainly notes. Defaults to Dutch",
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "A trip that matches the given parameters",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/TravelAdvice"
+              }
+            },
+            "examples": {
+              "application/json": [
+                {
+                  "source": "HARP",
+                  "trips": [
+                    {
+                      "uid": "string",
+                      "ctxRecon": "string",
+                      "plannedDurationInMinutes": 0,
+                      "actualDurationInMinutes": 0,
+                      "transfers": 0,
+                      "status": "CANCELLED",
+                      "messages": [
+                        {
+                          "id": "string",
+                          "externalId": "string",
+                          "head": "string",
+                          "text": "string",
+                          "lead": "string",
+                          "routeIdxFrom": 0,
+                          "routeIdxTo": 0,
+                          "type": "MAINTENANCE",
+                          "startDate": "string",
+                          "endDate": "string",
+                          "startTime": "string",
+                          "endTime": "string"
+                        }
+                      ],
+                      "legs": [
+                        {
+                          "idx": "string",
+                          "name": "string",
+                          "travelType": "PUBLIC_TRANSIT",
+                          "direction": "string",
+                          "cancelled": true,
+                          "changePossible": true,
+                          "alternativeTransport": true,
+                          "journeyDetailRef": "string",
+                          "origin": {
+                            "name": "string",
+                            "lng": 0,
+                            "lat": 0,
+                            "city": "string",
+                            "countryCode": "string",
+                            "uicCode": "string",
+                            "type": "STATION",
+                            "prognosisType": "string",
+                            "plannedTimeZoneOffset": 0,
+                            "plannedDateTime": "string",
+                            "actualTimeZoneOffset": 0,
+                            "actualDateTime": "string",
+                            "plannedTrack": "string",
+                            "actualTrack": "string",
+                            "exitSide": "LEFT",
+                            "checkinStatus": "CHECKIN",
+                            "travelAssistanceBookingInfo": {
+                              "name": "string",
+                              "tripLegIndex": "string",
+                              "stationUic": "string",
+                              "serviceTypeIds": [
+                                "string"
+                              ],
+                              "defaultAssistanceValue": true,
+                              "canChangeAssistance": true,
+                              "message": "string"
+                            },
+                            "travelAssistanceMeetingPoints": [
+                              "string"
+                            ],
+                            "notes": [
+                              {
+                                "value": "string",
+                                "key": "string",
+                                "noteType": "UNKNOWN",
+                                "priority": 0,
+                                "routeIdxFrom": 0,
+                                "routeIdxTo": 0,
+                                "link": {
+                                  "title": "string",
+                                  "url": "string"
+                                },
+                                "isPresentationRequired": true,
+                                "category": "PLATFORM_INFORMATION"
+                              }
+                            ],
+                            "quayCode": "string"
+                          },
+                          "destination": {
+                            "name": "string",
+                            "lng": 0,
+                            "lat": 0,
+                            "city": "string",
+                            "countryCode": "string",
+                            "uicCode": "string",
+                            "type": "STATION",
+                            "prognosisType": "string",
+                            "plannedTimeZoneOffset": 0,
+                            "plannedDateTime": "string",
+                            "actualTimeZoneOffset": 0,
+                            "actualDateTime": "string",
+                            "plannedTrack": "string",
+                            "actualTrack": "string",
+                            "exitSide": "LEFT",
+                            "checkinStatus": "CHECKIN",
+                            "travelAssistanceBookingInfo": {
+                              "name": "string",
+                              "tripLegIndex": "string",
+                              "stationUic": "string",
+                              "serviceTypeIds": [
+                                "string"
+                              ],
+                              "defaultAssistanceValue": true,
+                              "canChangeAssistance": true,
+                              "message": "string"
+                            },
+                            "travelAssistanceMeetingPoints": [
+                              "string"
+                            ],
+                            "notes": [
+                              {
+                                "value": "string",
+                                "key": "string",
+                                "noteType": "UNKNOWN",
+                                "priority": 0,
+                                "routeIdxFrom": 0,
+                                "routeIdxTo": 0,
+                                "link": {
+                                  "title": "string",
+                                  "url": "string"
+                                },
+                                "isPresentationRequired": true,
+                                "category": "PLATFORM_INFORMATION"
+                              }
+                            ],
+                            "quayCode": "string"
+                          },
+                          "product": {
+                            "number": "string",
+                            "categoryCode": "string",
+                            "shortCategoryName": "string",
+                            "longCategoryName": "string",
+                            "operatorCode": "string",
+                            "operatorName": "string",
+                            "operatorAdministrativeCode": 0,
+                            "type": "TRAIN",
+                            "displayName": "string"
+                          },
+                          "notes": [
+                            {
+                              "value": "string",
+                              "key": "string",
+                              "noteType": "UNKNOWN",
+                              "priority": 0,
+                              "routeIdxFrom": 0,
+                              "routeIdxTo": 0,
+                              "link": {
+                                "title": "string",
+                                "url": "string"
+                              },
+                              "isPresentationRequired": true,
+                              "category": "PLATFORM_INFORMATION"
+                            }
+                          ],
+                          "messages": [
+                            {
+                              "id": "string",
+                              "externalId": "string",
+                              "head": "string",
+                              "text": "string",
+                              "lead": "string",
+                              "routeIdxFrom": 0,
+                              "routeIdxTo": 0,
+                              "type": "MAINTENANCE",
+                              "startDate": "string",
+                              "endDate": "string",
+                              "startTime": "string",
+                              "endTime": "string"
+                            }
+                          ],
+                          "stops": [
+                            {
+                              "uicCode": "string",
+                              "name": "string",
+                              "lat": 0,
+                              "lng": 0,
+                              "countryCode": "string",
+                              "notes": [
+                                {
+                                  "value": "string",
+                                  "key": "string",
+                                  "type": "U",
+                                  "priority": 0
+                                }
+                              ],
+                              "routeIdx": 0,
+                              "departurePrognosisType": "string",
+                              "plannedDepartureDateTime": "string",
+                              "plannedDepartureTimeZoneOffset": 0,
+                              "actualDepartureDateTime": "string",
+                              "actualDepartureTimeZoneOffset": 0,
+                              "plannedArrivalDateTime": "string",
+                              "plannedArrivalTimeZoneOffset": 0,
+                              "actualArrivalDateTime": "string",
+                              "actualArrivalTimeZoneOffset": 0,
+                              "plannedPassingDateTime": "string",
+                              "actualPassingDateTime": "string",
+                              "arrivalPrognosisType": "string",
+                              "actualDepartureTrack": "string",
+                              "plannedDepartureTrack": "string",
+                              "plannedArrivalTrack": "string",
+                              "actualArrivalTrack": "string",
+                              "departureDelayInSeconds": 0,
+                              "arrivalDelayInSeconds": 0,
+                              "cancelled": true,
+                              "borderStop": true,
+                              "passing": true,
+                              "quayCode": "string"
+                            }
+                          ],
+                          "steps": [
+                            {
+                              "distanceInMeters": 0,
+                              "durationInSeconds": 0,
+                              "startLocation": {
+                                "name": "string",
+                                "lat": 0,
+                                "lng": 0,
+                                "city": "string",
+                                "country": "string"
+                              },
+                              "endLocation": {
+                                "name": "string",
+                                "lat": 0,
+                                "lng": 0,
+                                "city": "string",
+                                "country": "string"
+                              },
+                              "instructions": "string"
+                            }
+                          ],
+                          "coordinates": [
+                            [
+                              0
+                            ]
+                          ],
+                          "crowdForecast": "UNKNOWN",
+                          "punctuality": 0,
+                          "crossPlatformTransfer": true,
+                          "shorterStock": true,
+                          "changeCouldBePossible": true,
+                          "shorterStockWarning": "string",
+                          "shorterStockClassification": "BUSY",
+                          "journeyDetail": [
+                            {
+                              "type": "BTM",
+                              "link": {
+                                "title": "string",
+                                "url": "string"
+                              }
+                            }
+                          ],
+                          "reachable": true,
+                          "plannedDurationInMinutes": 0,
+                          "travelAssistanceDeparture": {
+                            "name": "string",
+                            "tripLegIndex": "string",
+                            "stationUic": "string",
+                            "serviceTypeIds": [
+                              "string"
+                            ],
+                            "defaultAssistanceValue": true,
+                            "canChangeAssistance": true,
+                            "message": "string"
+                          },
+                          "travelAssistanceArrival": {
+                            "name": "string",
+                            "tripLegIndex": "string",
+                            "stationUic": "string",
+                            "serviceTypeIds": [
+                              "string"
+                            ],
+                            "defaultAssistanceValue": true,
+                            "canChangeAssistance": true,
+                            "message": "string"
+                          },
+                          "overviewPolyLine": [
+                            {
+                              "lat": 0,
+                              "lng": 0
+                            }
+                          ]
+                        }
+                      ],
+                      "overviewPolyLine": [
+                        {
+                          "lat": 0,
+                          "lng": 0
+                        }
+                      ],
+                      "crowdForecast": "UNKNOWN",
+                      "punctuality": 0,
+                      "optimal": true,
+                      "fareRoute": {
+                        "routeId": "string",
+                        "origin": {
+                          "varCode": 0,
+                          "name": "string"
+                        },
+                        "destination": {
+                          "varCode": 0,
+                          "name": "string"
+                        }
+                      },
+                      "fares": [
+                        {
+                          "priceInCents": 0,
+                          "product": "OVCHIPKAART_ENKELE_REIS",
+                          "travelClass": "FIRST_CLASS",
+                          "priceInCentsExcludingSupplement": 0,
+                          "discountType": "NO_DISCOUNT",
+                          "supplementInCents": 0,
+                          "link": "string"
+                        }
+                      ],
+                      "fareLegs": [
+                        {
+                          "origin": {
+                            "name": "string",
+                            "lng": 0,
+                            "lat": 0,
+                            "city": "string",
+                            "countryCode": "string",
+                            "uicCode": "string",
+                            "type": "STATION",
+                            "prognosisType": "string",
+                            "plannedTimeZoneOffset": 0,
+                            "plannedDateTime": "string",
+                            "actualTimeZoneOffset": 0,
+                            "actualDateTime": "string",
+                            "plannedTrack": "string",
+                            "actualTrack": "string",
+                            "exitSide": "LEFT",
+                            "checkinStatus": "CHECKIN",
+                            "travelAssistanceBookingInfo": {
+                              "name": "string",
+                              "tripLegIndex": "string",
+                              "stationUic": "string",
+                              "serviceTypeIds": [
+                                "string"
+                              ],
+                              "defaultAssistanceValue": true,
+                              "canChangeAssistance": true,
+                              "message": "string"
+                            },
+                            "travelAssistanceMeetingPoints": [
+                              "string"
+                            ],
+                            "notes": [
+                              {
+                                "value": "string",
+                                "key": "string",
+                                "noteType": "UNKNOWN",
+                                "priority": 0,
+                                "routeIdxFrom": 0,
+                                "routeIdxTo": 0,
+                                "link": {
+                                  "title": "string",
+                                  "url": "string"
+                                },
+                                "isPresentationRequired": true,
+                                "category": "PLATFORM_INFORMATION"
+                              }
+                            ],
+                            "quayCode": "string"
+                          },
+                          "destination": {
+                            "name": "string",
+                            "lng": 0,
+                            "lat": 0,
+                            "city": "string",
+                            "countryCode": "string",
+                            "uicCode": "string",
+                            "type": "STATION",
+                            "prognosisType": "string",
+                            "plannedTimeZoneOffset": 0,
+                            "plannedDateTime": "string",
+                            "actualTimeZoneOffset": 0,
+                            "actualDateTime": "string",
+                            "plannedTrack": "string",
+                            "actualTrack": "string",
+                            "exitSide": "LEFT",
+                            "checkinStatus": "CHECKIN",
+                            "travelAssistanceBookingInfo": {
+                              "name": "string",
+                              "tripLegIndex": "string",
+                              "stationUic": "string",
+                              "serviceTypeIds": [
+                                "string"
+                              ],
+                              "defaultAssistanceValue": true,
+                              "canChangeAssistance": true,
+                              "message": "string"
+                            },
+                            "travelAssistanceMeetingPoints": [
+                              "string"
+                            ],
+                            "notes": [
+                              {
+                                "value": "string",
+                                "key": "string",
+                                "noteType": "UNKNOWN",
+                                "priority": 0,
+                                "routeIdxFrom": 0,
+                                "routeIdxTo": 0,
+                                "link": {
+                                  "title": "string",
+                                  "url": "string"
+                                },
+                                "isPresentationRequired": true,
+                                "category": "PLATFORM_INFORMATION"
+                              }
+                            ],
+                            "quayCode": "string"
+                          },
+                          "operator": "string",
+                          "productTypes": [
+                            "TRAIN"
+                          ],
+                          "fares": [
+                            {
+                              "priceInCents": 0,
+                              "priceInCentsExcludingSupplement": 0,
+                              "supplementInCents": 0,
+                              "buyableTicketPriceInCents": 0,
+                              "buyableTicketPriceInCentsExcludingSupplement": 0,
+                              "buyableTicketSupplementPriceInCents": 0,
+                              "product": "GEEN",
+                              "travelClass": "FIRST_CLASS",
+                              "discountType": "NO_DISCOUNT",
+                              "link": "string"
+                            }
+                          ]
+                        }
+                      ],
+                      "productFare": {
+                        "priceInCents": 0,
+                        "priceInCentsExcludingSupplement": 0,
+                        "supplementInCents": 0,
+                        "buyableTicketPriceInCents": 0,
+                        "buyableTicketPriceInCentsExcludingSupplement": 0,
+                        "buyableTicketSupplementPriceInCents": 0,
+                        "product": "GEEN",
+                        "travelClass": "FIRST_CLASS",
+                        "discountType": "NO_DISCOUNT",
+                        "link": "string"
+                      },
+                      "fareOptions": {
+                        "isInternationalBookable": true,
+                        "isInternational": true,
+                        "isEticketBuyable": true,
+                        "isPossibleWithOvChipkaart": true,
+                        "isTotalPriceUnknown": true,
+                        "supplementsBasedOnSelectedFare": [
+                          {
+                            "supplementPriceInCents": 0,
+                            "legIdx": "string",
+                            "fromUICCode": "string",
+                            "toUICCode": "string",
+                            "link": {
+                              "title": "string",
+                              "url": "string"
+                            }
+                          }
+                        ],
+                        "reasonEticketNotBuyable": {
+                          "reason": "UNKNOWN_PRICE",
+                          "description": "string"
+                        },
+                        "salesOptions": [
+                          {
+                            "type": "EARLY_BOOKING_DISCOUNT",
+                            "permilleFullTariff": 0,
+                            "recommendationText": "string"
+                          }
+                        ]
+                      },
+                      "bookingUrl": {
+                        "title": "string",
+                        "url": "string"
+                      },
+                      "type": "NS",
+                      "shareUrl": {
+                        "title": "string",
+                        "url": "string"
+                      },
+                      "realtime": true,
+                      "travelAssistanceInfo": {
+                        "termsAndConditionsLink": "string",
+                        "tripRequestId": 0,
+                        "isAssistanceRequired": true
+                      },
+                      "routeId": "string",
+                      "registerJourney": {
+                        "url": "string",
+                        "searchUrl": "string",
+                        "status": "REGISTRATION_POSSIBLE",
+                        "bicycleReservationRequired": true,
+                        "availability": {
+                          "seats": true,
+                          "numberOfSeats": 0,
+                          "bicycle": true,
+                          "numberOfBicyclePlaces": 0
+                        }
+                      }
+                    }
+                  ],
+                  "scrollRequestBackwardContext": "string",
+                  "scrollRequestForwardContext": "string",
+                  "message": "string"
+                }
+              ]
+            }
+          },
+          "400": {
+            "description": "Bad request. One or more parameters are invalid",
+            "schema": {
+              "$ref": "#/definitions/APIError"
+            },
+            "examples": {
+              "application/json": {
+                "timestamp": "string",
+                "code": 0,
+                "message": "string",
+                "path": "string",
+                "exception": "string",
+                "errors": [
+                  {
+                    "message": "string",
+                    "type": "string",
+                    "lang": "string"
+                  }
+                ],
+                "requestId": "string"
+              }
+            }
+          },
+          "419": {
+            "description": "Backend system failed in an unrecoverable way.",
+            "schema": {
+              "$ref": "#/definitions/APIError"
+            },
+            "examples": {
+              "application/json": {
+                "timestamp": "string",
+                "code": 0,
+                "message": "string",
+                "path": "string",
+                "exception": "string",
+                "errors": [
+                  {
+                    "message": "string",
+                    "type": "string",
+                    "lang": "string"
+                  }
+                ],
+                "requestId": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/calamities": {
+      "get": {
+        "description": "List of calamities. This operation is deprecated. Use /api/v3/disruptions instead",
+        "operationId": "getCalamities",
+        "summary": "Calamities",
+        "tags": [
+          "Disruptions"
+        ],
+        "parameters": [
+          {
+            "name": "lang",
+            "in": "query",
+            "description": "Language to use for localizing the calamities",
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "*/*"
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of calamities",
+            "schema": {
+              "$ref": "#/definitions/CalamitiesResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/price/international": {
+      "get": {
+        "description": "Returns price information for international trips",
+        "operationId": "getInternationalPrices",
+        "summary": "International prices",
+        "tags": [
+          "Prices"
+        ],
+        "parameters": [
+          {
+            "name": "fromStation",
+            "in": "query",
+            "description": "UIC code of the origin station",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "toStation",
+            "in": "query",
+            "description": "UIC code of the destination station",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "departureDateTime",
+            "in": "query",
+            "description": "Format - date-time (as date-time in RFC3339). Planned departure time of the trip.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "arrivalDateTime",
+            "in": "query",
+            "description": "Format - date-time (as date-time in RFC3339). Planned arrival time of the trip.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "*/*",
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Information about the price to pay given the input parameters",
+            "schema": {
+              "$ref": "#/definitions/RepresentationResponseInternationalPrice"
+            }
+          },
+          "400": {
+            "description": "Bad request. One or more parameters are invalid",
+            "schema": {
+              "$ref": "#/definitions/APIError"
+            },
+            "examples": {
+              "application/json": {
+                "timestamp": "string",
+                "code": 0,
+                "message": "string",
+                "path": "string",
+                "exception": "string",
+                "errors": [
+                  {
+                    "message": "string",
+                    "type": "string",
+                    "lang": "string"
+                  }
+                ],
+                "requestId": "string"
+              }
+            }
+          },
+          "404": {
+            "description": "Stationcode provided in the parameters could not be found, or the price is unknown",
+            "schema": {
+              "$ref": "#/definitions/APIError"
+            },
+            "examples": {
+              "application/json": {
+                "timestamp": "string",
+                "code": 0,
+                "message": "string",
+                "path": "string",
+                "exception": "string",
+                "errors": [
+                  {
+                    "message": "string",
+                    "type": "string",
+                    "lang": "string"
+                  }
+                ],
+                "requestId": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/price": {
+      "get": {
+        "description": "Returns price information for domestic trips",
+        "operationId": "getPrices",
+        "summary": "Domestic prices",
+        "tags": [
+          "Prices"
+        ],
+        "parameters": [
+          {
+            "name": "fromStation",
+            "in": "query",
+            "description": "NS station code of the origin station",
+            "type": "string"
+          },
+          {
+            "name": "toStation",
+            "in": "query",
+            "description": "NS Station code of the destination station",
+            "type": "string"
+          },
+          {
+            "name": "travelClass",
+            "in": "query",
+            "description": "Travel class to return the price for",
+            "type": "string",
+            "enum": [
+              "FIRST_CLASS",
+              "SECOND_CLASS"
+            ]
+          },
+          {
+            "name": "travelType",
+            "in": "query",
+            "description": "Return the price for a single or return trip. Defaults to single",
+            "type": "string",
+            "enum": [
+              "single",
+              "return"
+            ]
+          },
+          {
+            "name": "isJointJourney",
+            "in": "query",
+            "description": "Set to true to return the price including joint journey discount",
+            "type": "boolean",
+            "default": false
+          },
+          {
+            "name": "adults",
+            "in": "query",
+            "description": "Format - int32. Number of adults to return the price for. Defaults to 1",
+            "type": "integer",
+            "default": 1
+          },
+          {
+            "name": "children",
+            "in": "query",
+            "description": "Format - int32. Number of children to return the price for. Defaults to 0",
+            "type": "integer",
+            "default": 0
+          },
+          {
+            "name": "routeId",
+            "in": "query",
+            "description": "Specific identifier for the route to take between the two stations. This routeId is returned in the /api/v3/trips call.",
+            "type": "string"
+          },
+          {
+            "name": "plannedDepartureTime",
+            "in": "query",
+            "description": "Format - date-time (as date-time in RFC3339). Planned departure time of the trip. Is used to find the correct route, if multiple routes are possible between the origin and destination station.",
+            "type": "string"
+          },
+          {
+            "name": "plannedArrivalTime",
+            "in": "query",
+            "description": "Format - date-time (as date-time in RFC3339). Planned arrival time of the trip. Is used to find the correct route, if multiple routes are possible between the origin and destination station.",
+            "type": "string"
+          },
+          {
+            "name": "yearCard",
+            "in": "query",
+            "description": "Whether or not a yearcard should be included in price calculation.",
+            "type": "boolean",
+            "default": false
+          }
+        ],
+        "produces": [
+          "*/*",
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Information about the price to pay given the input parameters",
+            "schema": {
+              "$ref": "#/definitions/RepresentationResponsePricesResponseV3"
+            }
+          },
+          "400": {
+            "description": "Bad request. One or more parameters are invalid",
+            "schema": {
+              "$ref": "#/definitions/APIError"
+            },
+            "examples": {
+              "application/json": {
+                "timestamp": "string",
+                "code": 0,
+                "message": "string",
+                "path": "string",
+                "exception": "string",
+                "errors": [
+                  {
+                    "message": "string",
+                    "type": "string",
+                    "lang": "string"
+                  }
+                ],
+                "requestId": "string"
+              }
+            }
+          },
+          "404": {
+            "description": "Stationcode provided in the parameters could not be found or the price is unknown",
+            "schema": {
+              "$ref": "#/definitions/APIError"
+            },
+            "examples": {
+              "application/json": {
+                "timestamp": "string",
+                "code": 0,
+                "message": "string",
+                "path": "string",
+                "exception": "string",
+                "errors": [
+                  {
+                    "message": "string",
+                    "type": "string",
+                    "lang": "string"
+                  }
+                ],
+                "requestId": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/stations": {
+      "get": {
+        "description": "List of stations",
+        "operationId": "getStations",
+        "summary": "Stations",
+        "tags": [
+          "Stations"
+        ],
+        "produces": [
+          "*/*"
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of stations that can be used to plan trips",
+            "schema": {
+              "$ref": "#/definitions/StationResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/trips": {
+      "get": {
+        "description": "Returns a travel advice for the given parameters",
+        "operationId": "getTravelAdvice",
+        "summary": "Trips",
+        "tags": [
+          "Trips"
+        ],
+        "parameters": [
+          {
+            "name": "lang",
+            "in": "query",
+            "description": "Language to use for localizing the travel advice. Only a small subset of text is translated, mainly notes. Defaults to Dutch",
+            "type": "string"
+          },
+          {
+            "name": "fromStation",
+            "in": "query",
+            "description": "NS station code of the origin station",
+            "type": "string"
+          },
+          {
+            "name": "originUicCode",
+            "in": "query",
+            "description": "UIC code of the origin station",
+            "type": "string"
+          },
+          {
+            "name": "originLat",
+            "in": "query",
+            "description": "Latitude of the origin location. Should be used together with originLng. If the origin is a station, just provide the uicCode instead of the lat/lng",
+            "type": "number"
+          },
+          {
+            "name": "originLng",
+            "in": "query",
+            "description": "Longitude of the origin location. Should be used together with originLat. If the origin is a station, just provide the uicCode instead of the lat/lng",
+            "type": "number"
+          },
+          {
+            "name": "originName",
+            "in": "query",
+            "description": "Name of the origin location. Will be returned in the response",
+            "type": "string"
+          },
+          {
+            "name": "toStation",
+            "in": "query",
+            "description": "NS station code of the destination station",
+            "type": "string"
+          },
+          {
+            "name": "destinationUicCode",
+            "in": "query",
+            "description": "UIC code of the destination station",
+            "type": "string"
+          },
+          {
+            "name": "destinationLat",
+            "in": "query",
+            "description": "Latitude of the destination location. Should be used together with destinationLng. If the destination is a station, just provide the uicCode instead of the lat/lng",
+            "type": "number"
+          },
+          {
+            "name": "destinationLng",
+            "in": "query",
+            "description": "Longitude of the destination location. Should be used together with destinationLat. If the destination is a station, just provide the uicCode instead of the lat/lng",
+            "type": "number"
+          },
+          {
+            "name": "destinationName",
+            "in": "query",
+            "description": "Name of the destination location. Will be returned in the response",
+            "type": "string"
+          },
+          {
+            "name": "viaStation",
+            "in": "query",
+            "description": "NS station code of the via station",
+            "type": "string"
+          },
+          {
+            "name": "viaUicCode",
+            "in": "query",
+            "description": "UIC code of the via station",
+            "type": "string"
+          },
+          {
+            "name": "viaLat",
+            "in": "query",
+            "description": "Latitude of the via location. Should be used together with viaLng. Will only be used for door-to-door trips. If the via location is a station, just provide the uicCode instead of the lat/lng.",
+            "type": "number"
+          },
+          {
+            "name": "viaLng",
+            "in": "query",
+            "description": "Longitude of the via location. Should be used together with viaLat. Will only be used for door-to-door trips. If the via location is a station, just provide the uicCode instead of the lat/lng.",
+            "type": "number"
+          },
+          {
+            "name": "originWalk",
+            "in": "query",
+            "description": "Return trip advices with walking options to start travel from origin to a train station (first mile)",
+            "type": "boolean",
+            "default": false
+          },
+          {
+            "name": "originBike",
+            "in": "query",
+            "description": "Return trip advices with biking options to start travel from origin to a train station (first mile)",
+            "type": "boolean",
+            "default": false
+          },
+          {
+            "name": "originCar",
+            "in": "query",
+            "description": "Return trip advices with car options to start travel from origin to a train station (first mile)",
+            "type": "boolean",
+            "default": false
+          },
+          {
+            "name": "destinationWalk",
+            "in": "query",
+            "description": "Return trip advices with walking options to finish travel to the destination (last mile)",
+            "type": "boolean",
+            "default": false
+          },
+          {
+            "name": "destinationBike",
+            "in": "query",
+            "description": "Return trip advices with biking options to finish travel to the destination (last mile)",
+            "type": "boolean",
+            "default": false
+          },
+          {
+            "name": "destinationCar",
+            "in": "query",
+            "description": "Return trip advices with car options to finish travel to the destination (last mile)",
+            "type": "boolean",
+            "default": false
+          },
+          {
+            "name": "dateTime",
+            "in": "query",
+            "description": "Format - date-time (as date-time in RFC3339). Datetime that the user want to depart from his origin or or arrive at his destination",
+            "type": "string"
+          },
+          {
+            "name": "searchForArrival",
+            "in": "query",
+            "description": "If set, the date and time parameters specify the arrival time for the trip search instead of the departure time",
+            "type": "boolean"
+          },
+          {
+            "name": "departure",
+            "in": "query",
+            "description": "Use searchForArrival parameter instead",
+            "type": "boolean"
+          },
+          {
+            "name": "context",
+            "in": "query",
+            "description": "Parameter specifying that the user wants a next or previous page of the results",
+            "type": "string"
+          },
+          {
+            "name": "shorterChange",
+            "in": "query",
+            "description": "Changes the CHANGE_NOT_POSSIBLE status to CHANGE_COULD_BE_POSSIBLE if the traveler can walk twice as fast",
+            "type": "boolean",
+            "default": false
+          },
+          {
+            "name": "addChangeTime",
+            "in": "query",
+            "description": "Format - int32. Extra time in minutes required at all transfers to change trains.",
+            "type": "integer"
+          },
+          {
+            "name": "minimalChangeTime",
+            "in": "query",
+            "description": "Format - int32. Use addChangeTime instead",
+            "type": "integer"
+          },
+          {
+            "name": "viaWaitTime",
+            "in": "query",
+            "description": "Format - int32. Waiting time in minutes at the via location, exclusive of transfer time",
+            "type": "integer"
+          },
+          {
+            "name": "originAccessible",
+            "in": "query",
+            "description": "Use travelAssistance parameter instead",
+            "type": "boolean"
+          },
+          {
+            "name": "travelAssistance",
+            "in": "query",
+            "description": "Return trip advices from the trip assistance booking engine PAS",
+            "type": "boolean",
+            "default": false
+          },
+          {
+            "name": "nsr",
+            "in": "query",
+            "description": "Format - int32. NSR number for the customer making this request. This parameter should only be provided if travelAssistance = true",
+            "type": "integer"
+          },
+          {
+            "name": "travelAssistanceTransferTime",
+            "in": "query",
+            "description": "Format - int32. Use addChangeTime parameter instead",
+            "type": "integer"
+          },
+          {
+            "name": "accessibilityEquipment1",
+            "in": "query",
+            "description": "Accesibility equipment to use when searching for trip assistance options (AVG/PAS)",
+            "type": "string"
+          },
+          {
+            "name": "accessibilityEquipment2",
+            "in": "query",
+            "description": "Accesibility equipment to use when searching for trip assistance options (AVG/PAS)",
+            "type": "string"
+          },
+          {
+            "name": "searchForAccessibleTrip",
+            "in": "query",
+            "description": "Return trip advices that are accessible. (might be bookable too)",
+            "type": "boolean",
+            "default": false
+          },
+          {
+            "name": "filterTransportMode",
+            "in": "query",
+            "description": "Could be used to filter for REGIONAL_TRAINS. This parameter is replaced by the localTrainsOnly parameter",
+            "type": "string"
+          },
+          {
+            "name": "localTrainsOnly",
+            "in": "query",
+            "description": "Search only for local train options, i.e. sprinter/sneltrein/stoptrein",
+            "type": "boolean",
+            "default": false
+          },
+          {
+            "name": "excludeHighSpeedTrains",
+            "in": "query",
+            "description": "Exclude high speed trains from results (including those with a required reservation)",
+            "type": "boolean",
+            "default": false
+          },
+          {
+            "name": "excludeTrainsWithReservationRequired",
+            "in": "query",
+            "description": "Exclude trains for domestic trips that require a reservation (e.g. Thalys)",
+            "type": "boolean",
+            "default": false
+          },
+          {
+            "name": "yearCard",
+            "in": "query",
+            "description": "Show options which are only allowed with a year card",
+            "type": "boolean",
+            "default": false
+          },
+          {
+            "name": "product",
+            "in": "query",
+            "description": "Name of the product that will be used in travel",
+            "type": "string",
+            "enum": [
+              "GEEN",
+              "OVCHIPKAART_ENKELE_REIS",
+              "OVCHIPKAART_RETOUR",
+              "DAL_VOORDEEL",
+              "ALTIJD_VOORDEEL",
+              "DAL_VRIJ",
+              "WEEKEND_VRIJ",
+              "ALTIJD_VRIJ",
+              "BUSINESSCARD",
+              "BUSINESSCARD_DAL",
+              "STUDENT_WEEK",
+              "STUDENT_WEEKEND",
+              "VDU",
+              "SAMENREISKORTING",
+              "TRAJECT_VRIJ"
+            ]
+          },
+          {
+            "name": "discount",
+            "in": "query",
+            "description": "Discount of travel to use when calculating product prices",
+            "type": "string",
+            "default": "NO_DISCOUNT"
+          },
+          {
+            "name": "travelClass",
+            "in": "query",
+            "description": "Format - int32. Class of travel to use when calculating product prices",
+            "type": "integer",
+            "default": 2
+          },
+          {
+            "name": "passing",
+            "in": "query",
+            "description": "Show intermediate stops that the journey passes but doesn't stop at (only works for source:HARP not multi-modal trips from negentwee)",
+            "type": "boolean",
+            "default": false
+          },
+          {
+            "name": "travelRequestType",
+            "in": "query",
+            "description": "directionsOnly only plans a google directions (walk/bike/car) advice",
+            "type": "string",
+            "default": "DEFAULT",
+            "enum": [
+              "DEFAULT",
+              "DIRECTIONS",
+              "DIRECTIONS_ONLY"
+            ]
+          },
+          {
+            "name": "API Key",
+            "in": "header",
+            "description": "Account details to use when querying trip assistance options",
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "A traveladvice with zero or more trips",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/TravelAdvice"
+              }
+            },
+            "examples": {
+              "application/json": [
+                {
+                  "source": "HARP",
+                  "trips": [
+                    {
+                      "uid": "string",
+                      "ctxRecon": "string",
+                      "plannedDurationInMinutes": 0,
+                      "actualDurationInMinutes": 0,
+                      "transfers": 0,
+                      "status": "CANCELLED",
+                      "messages": [
+                        {
+                          "id": "string",
+                          "externalId": "string",
+                          "head": "string",
+                          "text": "string",
+                          "lead": "string",
+                          "routeIdxFrom": 0,
+                          "routeIdxTo": 0,
+                          "type": "MAINTENANCE",
+                          "startDate": "string",
+                          "endDate": "string",
+                          "startTime": "string",
+                          "endTime": "string"
+                        }
+                      ],
+                      "legs": [
+                        {
+                          "idx": "string",
+                          "name": "string",
+                          "travelType": "PUBLIC_TRANSIT",
+                          "direction": "string",
+                          "cancelled": true,
+                          "changePossible": true,
+                          "alternativeTransport": true,
+                          "journeyDetailRef": "string",
+                          "origin": {
+                            "name": "string",
+                            "lng": 0,
+                            "lat": 0,
+                            "city": "string",
+                            "countryCode": "string",
+                            "uicCode": "string",
+                            "type": "STATION",
+                            "prognosisType": "string",
+                            "plannedTimeZoneOffset": 0,
+                            "plannedDateTime": "string",
+                            "actualTimeZoneOffset": 0,
+                            "actualDateTime": "string",
+                            "plannedTrack": "string",
+                            "actualTrack": "string",
+                            "exitSide": "LEFT",
+                            "checkinStatus": "CHECKIN",
+                            "travelAssistanceBookingInfo": {
+                              "name": "string",
+                              "tripLegIndex": "string",
+                              "stationUic": "string",
+                              "serviceTypeIds": [
+                                "string"
+                              ],
+                              "defaultAssistanceValue": true,
+                              "canChangeAssistance": true,
+                              "message": "string"
+                            },
+                            "travelAssistanceMeetingPoints": [
+                              "string"
+                            ],
+                            "notes": [
+                              {
+                                "value": "string",
+                                "key": "string",
+                                "noteType": "UNKNOWN",
+                                "priority": 0,
+                                "routeIdxFrom": 0,
+                                "routeIdxTo": 0,
+                                "link": {
+                                  "title": "string",
+                                  "url": "string"
+                                },
+                                "isPresentationRequired": true,
+                                "category": "PLATFORM_INFORMATION"
+                              }
+                            ],
+                            "quayCode": "string"
+                          },
+                          "destination": {
+                            "name": "string",
+                            "lng": 0,
+                            "lat": 0,
+                            "city": "string",
+                            "countryCode": "string",
+                            "uicCode": "string",
+                            "type": "STATION",
+                            "prognosisType": "string",
+                            "plannedTimeZoneOffset": 0,
+                            "plannedDateTime": "string",
+                            "actualTimeZoneOffset": 0,
+                            "actualDateTime": "string",
+                            "plannedTrack": "string",
+                            "actualTrack": "string",
+                            "exitSide": "LEFT",
+                            "checkinStatus": "CHECKIN",
+                            "travelAssistanceBookingInfo": {
+                              "name": "string",
+                              "tripLegIndex": "string",
+                              "stationUic": "string",
+                              "serviceTypeIds": [
+                                "string"
+                              ],
+                              "defaultAssistanceValue": true,
+                              "canChangeAssistance": true,
+                              "message": "string"
+                            },
+                            "travelAssistanceMeetingPoints": [
+                              "string"
+                            ],
+                            "notes": [
+                              {
+                                "value": "string",
+                                "key": "string",
+                                "noteType": "UNKNOWN",
+                                "priority": 0,
+                                "routeIdxFrom": 0,
+                                "routeIdxTo": 0,
+                                "link": {
+                                  "title": "string",
+                                  "url": "string"
+                                },
+                                "isPresentationRequired": true,
+                                "category": "PLATFORM_INFORMATION"
+                              }
+                            ],
+                            "quayCode": "string"
+                          },
+                          "product": {
+                            "number": "string",
+                            "categoryCode": "string",
+                            "shortCategoryName": "string",
+                            "longCategoryName": "string",
+                            "operatorCode": "string",
+                            "operatorName": "string",
+                            "operatorAdministrativeCode": 0,
+                            "type": "TRAIN",
+                            "displayName": "string"
+                          },
+                          "notes": [
+                            {
+                              "value": "string",
+                              "key": "string",
+                              "noteType": "UNKNOWN",
+                              "priority": 0,
+                              "routeIdxFrom": 0,
+                              "routeIdxTo": 0,
+                              "link": {
+                                "title": "string",
+                                "url": "string"
+                              },
+                              "isPresentationRequired": true,
+                              "category": "PLATFORM_INFORMATION"
+                            }
+                          ],
+                          "messages": [
+                            {
+                              "id": "string",
+                              "externalId": "string",
+                              "head": "string",
+                              "text": "string",
+                              "lead": "string",
+                              "routeIdxFrom": 0,
+                              "routeIdxTo": 0,
+                              "type": "MAINTENANCE",
+                              "startDate": "string",
+                              "endDate": "string",
+                              "startTime": "string",
+                              "endTime": "string"
+                            }
+                          ],
+                          "stops": [
+                            {
+                              "uicCode": "string",
+                              "name": "string",
+                              "lat": 0,
+                              "lng": 0,
+                              "countryCode": "string",
+                              "notes": [
+                                {
+                                  "value": "string",
+                                  "key": "string",
+                                  "type": "U",
+                                  "priority": 0
+                                }
+                              ],
+                              "routeIdx": 0,
+                              "departurePrognosisType": "string",
+                              "plannedDepartureDateTime": "string",
+                              "plannedDepartureTimeZoneOffset": 0,
+                              "actualDepartureDateTime": "string",
+                              "actualDepartureTimeZoneOffset": 0,
+                              "plannedArrivalDateTime": "string",
+                              "plannedArrivalTimeZoneOffset": 0,
+                              "actualArrivalDateTime": "string",
+                              "actualArrivalTimeZoneOffset": 0,
+                              "plannedPassingDateTime": "string",
+                              "actualPassingDateTime": "string",
+                              "arrivalPrognosisType": "string",
+                              "actualDepartureTrack": "string",
+                              "plannedDepartureTrack": "string",
+                              "plannedArrivalTrack": "string",
+                              "actualArrivalTrack": "string",
+                              "departureDelayInSeconds": 0,
+                              "arrivalDelayInSeconds": 0,
+                              "cancelled": true,
+                              "borderStop": true,
+                              "passing": true,
+                              "quayCode": "string"
+                            }
+                          ],
+                          "steps": [
+                            {
+                              "distanceInMeters": 0,
+                              "durationInSeconds": 0,
+                              "startLocation": {
+                                "name": "string",
+                                "lat": 0,
+                                "lng": 0,
+                                "city": "string",
+                                "country": "string"
+                              },
+                              "endLocation": {
+                                "name": "string",
+                                "lat": 0,
+                                "lng": 0,
+                                "city": "string",
+                                "country": "string"
+                              },
+                              "instructions": "string"
+                            }
+                          ],
+                          "coordinates": [
+                            [
+                              0
+                            ]
+                          ],
+                          "crowdForecast": "UNKNOWN",
+                          "punctuality": 0,
+                          "crossPlatformTransfer": true,
+                          "shorterStock": true,
+                          "changeCouldBePossible": true,
+                          "shorterStockWarning": "string",
+                          "shorterStockClassification": "BUSY",
+                          "journeyDetail": [
+                            {
+                              "type": "BTM",
+                              "link": {
+                                "title": "string",
+                                "url": "string"
+                              }
+                            }
+                          ],
+                          "reachable": true,
+                          "plannedDurationInMinutes": 0,
+                          "travelAssistanceDeparture": {
+                            "name": "string",
+                            "tripLegIndex": "string",
+                            "stationUic": "string",
+                            "serviceTypeIds": [
+                              "string"
+                            ],
+                            "defaultAssistanceValue": true,
+                            "canChangeAssistance": true,
+                            "message": "string"
+                          },
+                          "travelAssistanceArrival": {
+                            "name": "string",
+                            "tripLegIndex": "string",
+                            "stationUic": "string",
+                            "serviceTypeIds": [
+                              "string"
+                            ],
+                            "defaultAssistanceValue": true,
+                            "canChangeAssistance": true,
+                            "message": "string"
+                          },
+                          "overviewPolyLine": [
+                            {
+                              "lat": 0,
+                              "lng": 0
+                            }
+                          ]
+                        }
+                      ],
+                      "overviewPolyLine": [
+                        {
+                          "lat": 0,
+                          "lng": 0
+                        }
+                      ],
+                      "crowdForecast": "UNKNOWN",
+                      "punctuality": 0,
+                      "optimal": true,
+                      "fareRoute": {
+                        "routeId": "string",
+                        "origin": {
+                          "varCode": 0,
+                          "name": "string"
+                        },
+                        "destination": {
+                          "varCode": 0,
+                          "name": "string"
+                        }
+                      },
+                      "fares": [
+                        {
+                          "priceInCents": 0,
+                          "product": "OVCHIPKAART_ENKELE_REIS",
+                          "travelClass": "FIRST_CLASS",
+                          "priceInCentsExcludingSupplement": 0,
+                          "discountType": "NO_DISCOUNT",
+                          "supplementInCents": 0,
+                          "link": "string"
+                        }
+                      ],
+                      "fareLegs": [
+                        {
+                          "origin": {
+                            "name": "string",
+                            "lng": 0,
+                            "lat": 0,
+                            "city": "string",
+                            "countryCode": "string",
+                            "uicCode": "string",
+                            "type": "STATION",
+                            "prognosisType": "string",
+                            "plannedTimeZoneOffset": 0,
+                            "plannedDateTime": "string",
+                            "actualTimeZoneOffset": 0,
+                            "actualDateTime": "string",
+                            "plannedTrack": "string",
+                            "actualTrack": "string",
+                            "exitSide": "LEFT",
+                            "checkinStatus": "CHECKIN",
+                            "travelAssistanceBookingInfo": {
+                              "name": "string",
+                              "tripLegIndex": "string",
+                              "stationUic": "string",
+                              "serviceTypeIds": [
+                                "string"
+                              ],
+                              "defaultAssistanceValue": true,
+                              "canChangeAssistance": true,
+                              "message": "string"
+                            },
+                            "travelAssistanceMeetingPoints": [
+                              "string"
+                            ],
+                            "notes": [
+                              {
+                                "value": "string",
+                                "key": "string",
+                                "noteType": "UNKNOWN",
+                                "priority": 0,
+                                "routeIdxFrom": 0,
+                                "routeIdxTo": 0,
+                                "link": {
+                                  "title": "string",
+                                  "url": "string"
+                                },
+                                "isPresentationRequired": true,
+                                "category": "PLATFORM_INFORMATION"
+                              }
+                            ],
+                            "quayCode": "string"
+                          },
+                          "destination": {
+                            "name": "string",
+                            "lng": 0,
+                            "lat": 0,
+                            "city": "string",
+                            "countryCode": "string",
+                            "uicCode": "string",
+                            "type": "STATION",
+                            "prognosisType": "string",
+                            "plannedTimeZoneOffset": 0,
+                            "plannedDateTime": "string",
+                            "actualTimeZoneOffset": 0,
+                            "actualDateTime": "string",
+                            "plannedTrack": "string",
+                            "actualTrack": "string",
+                            "exitSide": "LEFT",
+                            "checkinStatus": "CHECKIN",
+                            "travelAssistanceBookingInfo": {
+                              "name": "string",
+                              "tripLegIndex": "string",
+                              "stationUic": "string",
+                              "serviceTypeIds": [
+                                "string"
+                              ],
+                              "defaultAssistanceValue": true,
+                              "canChangeAssistance": true,
+                              "message": "string"
+                            },
+                            "travelAssistanceMeetingPoints": [
+                              "string"
+                            ],
+                            "notes": [
+                              {
+                                "value": "string",
+                                "key": "string",
+                                "noteType": "UNKNOWN",
+                                "priority": 0,
+                                "routeIdxFrom": 0,
+                                "routeIdxTo": 0,
+                                "link": {
+                                  "title": "string",
+                                  "url": "string"
+                                },
+                                "isPresentationRequired": true,
+                                "category": "PLATFORM_INFORMATION"
+                              }
+                            ],
+                            "quayCode": "string"
+                          },
+                          "operator": "string",
+                          "productTypes": [
+                            "TRAIN"
+                          ],
+                          "fares": [
+                            {
+                              "priceInCents": 0,
+                              "priceInCentsExcludingSupplement": 0,
+                              "supplementInCents": 0,
+                              "buyableTicketPriceInCents": 0,
+                              "buyableTicketPriceInCentsExcludingSupplement": 0,
+                              "buyableTicketSupplementPriceInCents": 0,
+                              "product": "GEEN",
+                              "travelClass": "FIRST_CLASS",
+                              "discountType": "NO_DISCOUNT",
+                              "link": "string"
+                            }
+                          ]
+                        }
+                      ],
+                      "productFare": {
+                        "priceInCents": 0,
+                        "priceInCentsExcludingSupplement": 0,
+                        "supplementInCents": 0,
+                        "buyableTicketPriceInCents": 0,
+                        "buyableTicketPriceInCentsExcludingSupplement": 0,
+                        "buyableTicketSupplementPriceInCents": 0,
+                        "product": "GEEN",
+                        "travelClass": "FIRST_CLASS",
+                        "discountType": "NO_DISCOUNT",
+                        "link": "string"
+                      },
+                      "fareOptions": {
+                        "isInternationalBookable": true,
+                        "isInternational": true,
+                        "isEticketBuyable": true,
+                        "isPossibleWithOvChipkaart": true,
+                        "isTotalPriceUnknown": true,
+                        "supplementsBasedOnSelectedFare": [
+                          {
+                            "supplementPriceInCents": 0,
+                            "legIdx": "string",
+                            "fromUICCode": "string",
+                            "toUICCode": "string",
+                            "link": {
+                              "title": "string",
+                              "url": "string"
+                            }
+                          }
+                        ],
+                        "reasonEticketNotBuyable": {
+                          "reason": "UNKNOWN_PRICE",
+                          "description": "string"
+                        },
+                        "salesOptions": [
+                          {
+                            "type": "EARLY_BOOKING_DISCOUNT",
+                            "permilleFullTariff": 0,
+                            "recommendationText": "string"
+                          }
+                        ]
+                      },
+                      "bookingUrl": {
+                        "title": "string",
+                        "url": "string"
+                      },
+                      "type": "NS",
+                      "shareUrl": {
+                        "title": "string",
+                        "url": "string"
+                      },
+                      "realtime": true,
+                      "travelAssistanceInfo": {
+                        "termsAndConditionsLink": "string",
+                        "tripRequestId": 0,
+                        "isAssistanceRequired": true
+                      },
+                      "routeId": "string",
+                      "registerJourney": {
+                        "url": "string",
+                        "searchUrl": "string",
+                        "status": "REGISTRATION_POSSIBLE",
+                        "bicycleReservationRequired": true,
+                        "availability": {
+                          "seats": true,
+                          "numberOfSeats": 0,
+                          "bicycle": true,
+                          "numberOfBicyclePlaces": 0
+                        }
+                      }
+                    }
+                  ],
+                  "scrollRequestBackwardContext": "string",
+                  "scrollRequestForwardContext": "string",
+                  "message": "string"
+                }
+              ]
+            }
+          },
+          "400": {
+            "description": "Bad request. One or more parameters are invalid",
+            "schema": {
+              "$ref": "#/definitions/APIError"
+            },
+            "examples": {
+              "application/json": {
+                "timestamp": "string",
+                "code": 0,
+                "message": "string",
+                "path": "string",
+                "exception": "string",
+                "errors": [
+                  {
+                    "message": "string",
+                    "type": "string",
+                    "lang": "string"
+                  }
+                ],
+                "requestId": "string"
+              }
+            }
+          },
+          "419": {
+            "description": "Backend system failed in an unrecoverable way.",
+            "schema": {
+              "$ref": "#/definitions/APIError"
+            },
+            "examples": {
+              "application/json": {
+                "timestamp": "string",
+                "code": 0,
+                "message": "string",
+                "path": "string",
+                "exception": "string",
+                "errors": [
+                  {
+                    "message": "string",
+                    "type": "string",
+                    "lang": "string"
+                  }
+                ],
+                "requestId": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/disruptions/station/{stationCode}": {},
+    "/api/v2/disruptions/{id}": {},
+    "/api/v2/disruptions": {},
+    "/api/v3/disruptions/station/{stationCode}": {
+      "get": {
+        "description": "List of disruptions relevant for the current station",
+        "operationId": "getStationDisruptions",
+        "summary": "Station disruptions",
+        "tags": [
+          "Disruptions"
+        ],
+        "parameters": [
+          {
+            "name": "stationCode",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of disruptions relevant for the given station",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/DisruptionBase"
+              }
+            },
+            "examples": {
+              "application/json": [
+                {
+                  "id": "string",
+                  "type": "CALAMITY",
+                  "title": "string",
+                  "topic": "string",
+                  "isActive": true,
+                  "registrationTime": "string",
+                  "releaseTime": "string",
+                  "local": true,
+                  "titleSections": [
+                    [
+                      {
+                        "type": "STATION",
+                        "value": "string"
+                      }
+                    ]
+                  ],
+                  "start": "string",
+                  "end": "string",
+                  "period": "string",
+                  "phase": {
+                    "id": "string",
+                    "label": "string"
+                  },
+                  "impact": {
+                    "value": 0
+                  },
+                  "expectedDuration": {
+                    "description": "string",
+                    "endTime": "string"
+                  },
+                  "summaryAdditionalTravelTime": {
+                    "label": "string",
+                    "shortLabel": "string",
+                    "minimumDurationInMinutes": 0,
+                    "maximumDurationInMinutes": 0
+                  },
+                  "publicationSections": [
+                    {
+                      "section": {
+                        "stations": [
+                          {
+                            "uicCode": "string",
+                            "stationCode": "string",
+                            "name": "string",
+                            "coordinate": {
+                              "lat": 0,
+                              "lng": 0
+                            },
+                            "countryCode": "string"
+                          }
+                        ],
+                        "direction": "ONE_WAY"
+                      },
+                      "consequence": {
+                        "section": {
+                          "stations": [
+                            {
+                              "uicCode": "string",
+                              "stationCode": "string",
+                              "name": "string",
+                              "coordinate": {
+                                "lat": 0,
+                                "lng": 0
+                              },
+                              "countryCode": "string"
+                            }
+                          ],
+                          "direction": "ONE_WAY"
+                        },
+                        "description": "string",
+                        "level": "NO_OR_MUCH_LESS_TRAINS"
+                      },
+                      "sectionType": "NL"
+                    }
+                  ],
+                  "timespans": [
+                    {
+                      "start": "string",
+                      "end": "string",
+                      "period": "string",
+                      "situation": {
+                        "label": "string"
+                      },
+                      "cause": {
+                        "label": "string"
+                      },
+                      "additionalTravelTime": {
+                        "label": "string",
+                        "shortLabel": "string",
+                        "minimumDurationInMinutes": 0,
+                        "maximumDurationInMinutes": 0
+                      },
+                      "alternativeTransport": {
+                        "label": "string",
+                        "shortLabel": "string"
+                      },
+                      "advices": [
+                        "string"
+                      ]
+                    }
+                  ],
+                  "alternativeTransportTimespans": [
+                    {
+                      "start": "string",
+                      "end": "string",
+                      "alternativeTransport": {
+                        "label": "string",
+                        "shortLabel": "string"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "400": {
+            "description": "Bad request. One or more parameters are invalid",
+            "schema": {
+              "$ref": "#/definitions/APIError"
+            },
+            "examples": {
+              "application/json": {
+                "timestamp": "string",
+                "code": 0,
+                "message": "string",
+                "path": "string",
+                "exception": "string",
+                "errors": [
+                  {
+                    "message": "string",
+                    "type": "string",
+                    "lang": "string"
+                  }
+                ],
+                "requestId": "string"
+              }
+            }
+          },
+          "404": {
+            "description": "Station not found",
+            "schema": {
+              "$ref": "#/definitions/APIError"
+            },
+            "examples": {
+              "application/json": {
+                "timestamp": "string",
+                "code": 0,
+                "message": "string",
+                "path": "string",
+                "exception": "string",
+                "errors": [
+                  {
+                    "message": "string",
+                    "type": "string",
+                    "lang": "string"
+                  }
+                ],
+                "requestId": "string"
+              }
+            }
+          },
+          "500": {
+            "description": "A list of disruptions relevant for the given station",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/DisruptionBase"
+              }
+            },
+            "examples": {
+              "application/json": [
+                {
+                  "id": "string",
+                  "type": "CALAMITY",
+                  "title": "string",
+                  "topic": "string",
+                  "isActive": true,
+                  "registrationTime": "string",
+                  "releaseTime": "string",
+                  "local": true,
+                  "titleSections": [
+                    [
+                      {
+                        "type": "STATION",
+                        "value": "string"
+                      }
+                    ]
+                  ],
+                  "start": "string",
+                  "end": "string",
+                  "period": "string",
+                  "phase": {
+                    "id": "string",
+                    "label": "string"
+                  },
+                  "impact": {
+                    "value": 0
+                  },
+                  "expectedDuration": {
+                    "description": "string",
+                    "endTime": "string"
+                  },
+                  "summaryAdditionalTravelTime": {
+                    "label": "string",
+                    "shortLabel": "string",
+                    "minimumDurationInMinutes": 0,
+                    "maximumDurationInMinutes": 0
+                  },
+                  "publicationSections": [
+                    {
+                      "section": {
+                        "stations": [
+                          {
+                            "uicCode": "string",
+                            "stationCode": "string",
+                            "name": "string",
+                            "coordinate": {
+                              "lat": 0,
+                              "lng": 0
+                            },
+                            "countryCode": "string"
+                          }
+                        ],
+                        "direction": "ONE_WAY"
+                      },
+                      "consequence": {
+                        "section": {
+                          "stations": [
+                            {
+                              "uicCode": "string",
+                              "stationCode": "string",
+                              "name": "string",
+                              "coordinate": {
+                                "lat": 0,
+                                "lng": 0
+                              },
+                              "countryCode": "string"
+                            }
+                          ],
+                          "direction": "ONE_WAY"
+                        },
+                        "description": "string",
+                        "level": "NO_OR_MUCH_LESS_TRAINS"
+                      },
+                      "sectionType": "NL"
+                    }
+                  ],
+                  "timespans": [
+                    {
+                      "start": "string",
+                      "end": "string",
+                      "period": "string",
+                      "situation": {
+                        "label": "string"
+                      },
+                      "cause": {
+                        "label": "string"
+                      },
+                      "additionalTravelTime": {
+                        "label": "string",
+                        "shortLabel": "string",
+                        "minimumDurationInMinutes": 0,
+                        "maximumDurationInMinutes": 0
+                      },
+                      "alternativeTransport": {
+                        "label": "string",
+                        "shortLabel": "string"
+                      },
+                      "advices": [
+                        "string"
+                      ]
+                    }
+                  ],
+                  "alternativeTransportTimespans": [
+                    {
+                      "start": "string",
+                      "end": "string",
+                      "alternativeTransport": {
+                        "label": "string",
+                        "shortLabel": "string"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/disruptions/{type}/{id}": {
+      "get": {
+        "description": "Returns information on a single disruption/maintenance/calamity",
+        "operationId": "getDisruption",
+        "summary": "Single disruption",
+        "tags": [
+          "Disruptions"
+        ],
+        "parameters": [
+          {
+            "name": "type",
+            "in": "path",
+            "description": "Disruption type for the disruption to return.",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "CALAMITY",
+              "DISRUPTION",
+              "MAINTENANCE"
+            ]
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unique identifier of the disruption to return. Can be found using the /api/v3/disruptions call",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "The requested disruption",
+            "schema": {
+              "$ref": "#/definitions/DisruptionBase"
+            },
+            "examples": {
+              "application/json": {
+                "id": "string",
+                "type": "CALAMITY",
+                "title": "string",
+                "topic": "string",
+                "isActive": true,
+                "registrationTime": "string",
+                "releaseTime": "string",
+                "local": true,
+                "titleSections": [
+                  [
+                    {
+                      "type": "STATION",
+                      "value": "string"
+                    }
+                  ]
+                ],
+                "start": "string",
+                "end": "string",
+                "period": "string",
+                "phase": {
+                  "id": "string",
+                  "label": "string"
+                },
+                "impact": {
+                  "value": 0
+                },
+                "expectedDuration": {
+                  "description": "string",
+                  "endTime": "string"
+                },
+                "summaryAdditionalTravelTime": {
+                  "label": "string",
+                  "shortLabel": "string",
+                  "minimumDurationInMinutes": 0,
+                  "maximumDurationInMinutes": 0
+                },
+                "publicationSections": [
+                  {
+                    "section": {
+                      "stations": [
+                        {
+                          "uicCode": "string",
+                          "stationCode": "string",
+                          "name": "string",
+                          "coordinate": {
+                            "lat": 0,
+                            "lng": 0
+                          },
+                          "countryCode": "string"
+                        }
+                      ],
+                      "direction": "ONE_WAY"
+                    },
+                    "consequence": {
+                      "section": {
+                        "stations": [
+                          {
+                            "uicCode": "string",
+                            "stationCode": "string",
+                            "name": "string",
+                            "coordinate": {
+                              "lat": 0,
+                              "lng": 0
+                            },
+                            "countryCode": "string"
+                          }
+                        ],
+                        "direction": "ONE_WAY"
+                      },
+                      "description": "string",
+                      "level": "NO_OR_MUCH_LESS_TRAINS"
+                    },
+                    "sectionType": "NL"
+                  }
+                ],
+                "timespans": [
+                  {
+                    "start": "string",
+                    "end": "string",
+                    "period": "string",
+                    "situation": {
+                      "label": "string"
+                    },
+                    "cause": {
+                      "label": "string"
+                    },
+                    "additionalTravelTime": {
+                      "label": "string",
+                      "shortLabel": "string",
+                      "minimumDurationInMinutes": 0,
+                      "maximumDurationInMinutes": 0
+                    },
+                    "alternativeTransport": {
+                      "label": "string",
+                      "shortLabel": "string"
+                    },
+                    "advices": [
+                      "string"
+                    ]
+                  }
+                ],
+                "alternativeTransportTimespans": [
+                  {
+                    "start": "string",
+                    "end": "string",
+                    "alternativeTransport": {
+                      "label": "string",
+                      "shortLabel": "string"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request. One or more parameters are invalid",
+            "schema": {
+              "$ref": "#/definitions/APIError"
+            },
+            "examples": {
+              "application/json": {
+                "timestamp": "string",
+                "code": 0,
+                "message": "string",
+                "path": "string",
+                "exception": "string",
+                "errors": [
+                  {
+                    "message": "string",
+                    "type": "string",
+                    "lang": "string"
+                  }
+                ],
+                "requestId": "string"
+              }
+            }
+          },
+          "404": {
+            "description": "Disruption not found or wrong type given",
+            "schema": {
+              "$ref": "#/definitions/APIError"
+            },
+            "examples": {
+              "application/json": {
+                "timestamp": "string",
+                "code": 0,
+                "message": "string",
+                "path": "string",
+                "exception": "string",
+                "errors": [
+                  {
+                    "message": "string",
+                    "type": "string",
+                    "lang": "string"
+                  }
+                ],
+                "requestId": "string"
+              }
+            }
+          },
+          "500": {
+            "description": "The requested disruption",
+            "schema": {
+              "$ref": "#/definitions/DisruptionBase"
+            },
+            "examples": {
+              "application/json": {
+                "id": "string",
+                "type": "CALAMITY",
+                "title": "string",
+                "topic": "string",
+                "isActive": true,
+                "registrationTime": "string",
+                "releaseTime": "string",
+                "local": true,
+                "titleSections": [
+                  [
+                    {
+                      "type": "STATION",
+                      "value": "string"
+                    }
+                  ]
+                ],
+                "start": "string",
+                "end": "string",
+                "period": "string",
+                "phase": {
+                  "id": "string",
+                  "label": "string"
+                },
+                "impact": {
+                  "value": 0
+                },
+                "expectedDuration": {
+                  "description": "string",
+                  "endTime": "string"
+                },
+                "summaryAdditionalTravelTime": {
+                  "label": "string",
+                  "shortLabel": "string",
+                  "minimumDurationInMinutes": 0,
+                  "maximumDurationInMinutes": 0
+                },
+                "publicationSections": [
+                  {
+                    "section": {
+                      "stations": [
+                        {
+                          "uicCode": "string",
+                          "stationCode": "string",
+                          "name": "string",
+                          "coordinate": {
+                            "lat": 0,
+                            "lng": 0
+                          },
+                          "countryCode": "string"
+                        }
+                      ],
+                      "direction": "ONE_WAY"
+                    },
+                    "consequence": {
+                      "section": {
+                        "stations": [
+                          {
+                            "uicCode": "string",
+                            "stationCode": "string",
+                            "name": "string",
+                            "coordinate": {
+                              "lat": 0,
+                              "lng": 0
+                            },
+                            "countryCode": "string"
+                          }
+                        ],
+                        "direction": "ONE_WAY"
+                      },
+                      "description": "string",
+                      "level": "NO_OR_MUCH_LESS_TRAINS"
+                    },
+                    "sectionType": "NL"
+                  }
+                ],
+                "timespans": [
+                  {
+                    "start": "string",
+                    "end": "string",
+                    "period": "string",
+                    "situation": {
+                      "label": "string"
+                    },
+                    "cause": {
+                      "label": "string"
+                    },
+                    "additionalTravelTime": {
+                      "label": "string",
+                      "shortLabel": "string",
+                      "minimumDurationInMinutes": 0,
+                      "maximumDurationInMinutes": 0
+                    },
+                    "alternativeTransport": {
+                      "label": "string",
+                      "shortLabel": "string"
+                    },
+                    "advices": [
+                      "string"
+                    ]
+                  }
+                ],
+                "alternativeTransportTimespans": [
+                  {
+                    "start": "string",
+                    "end": "string",
+                    "alternativeTransport": {
+                      "label": "string",
+                      "shortLabel": "string"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/disruptions": {
+      "get": {
+        "description": "List of calamities/disruptions/maintenance",
+        "operationId": "getDisruptions",
+        "summary": "Disruptions",
+        "tags": [
+          "Disruptions"
+        ],
+        "parameters": [
+          {
+            "name": "type",
+            "in": "query",
+            "description": "Type of the disruptions to be returned. If not present all types will be returned.",
+            "type": "array"
+          },
+          {
+            "name": "isActive",
+            "in": "query",
+            "description": "Flag to filter maintenance to only return active items, i.e. maintenance that is happening right now",
+            "type": "boolean",
+            "default": false
+          },
+          {
+            "name": "Accept-Language",
+            "in": "header",
+            "description": "Language for the disruptions. Defaults to nl. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language for details. Please note that only the calamities will be translated, as no translation is available for maintenance and disruptions",
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of disruptions",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/DisruptionBase"
+              }
+            },
+            "examples": {
+              "application/json": [
+                {
+                  "id": "string",
+                  "type": "CALAMITY",
+                  "title": "string",
+                  "topic": "string",
+                  "isActive": true,
+                  "registrationTime": "string",
+                  "releaseTime": "string",
+                  "local": true,
+                  "titleSections": [
+                    [
+                      {
+                        "type": "STATION",
+                        "value": "string"
+                      }
+                    ]
+                  ],
+                  "start": "string",
+                  "end": "string",
+                  "period": "string",
+                  "phase": {
+                    "id": "string",
+                    "label": "string"
+                  },
+                  "impact": {
+                    "value": 0
+                  },
+                  "expectedDuration": {
+                    "description": "string",
+                    "endTime": "string"
+                  },
+                  "summaryAdditionalTravelTime": {
+                    "label": "string",
+                    "shortLabel": "string",
+                    "minimumDurationInMinutes": 0,
+                    "maximumDurationInMinutes": 0
+                  },
+                  "publicationSections": [
+                    {
+                      "section": {
+                        "stations": [
+                          {
+                            "uicCode": "string",
+                            "stationCode": "string",
+                            "name": "string",
+                            "coordinate": {
+                              "lat": 0,
+                              "lng": 0
+                            },
+                            "countryCode": "string"
+                          }
+                        ],
+                        "direction": "ONE_WAY"
+                      },
+                      "consequence": {
+                        "section": {
+                          "stations": [
+                            {
+                              "uicCode": "string",
+                              "stationCode": "string",
+                              "name": "string",
+                              "coordinate": {
+                                "lat": 0,
+                                "lng": 0
+                              },
+                              "countryCode": "string"
+                            }
+                          ],
+                          "direction": "ONE_WAY"
+                        },
+                        "description": "string",
+                        "level": "NO_OR_MUCH_LESS_TRAINS"
+                      },
+                      "sectionType": "NL"
+                    }
+                  ],
+                  "timespans": [
+                    {
+                      "start": "string",
+                      "end": "string",
+                      "period": "string",
+                      "situation": {
+                        "label": "string"
+                      },
+                      "cause": {
+                        "label": "string"
+                      },
+                      "additionalTravelTime": {
+                        "label": "string",
+                        "shortLabel": "string",
+                        "minimumDurationInMinutes": 0,
+                        "maximumDurationInMinutes": 0
+                      },
+                      "alternativeTransport": {
+                        "label": "string",
+                        "shortLabel": "string"
+                      },
+                      "advices": [
+                        "string"
+                      ]
+                    }
+                  ],
+                  "alternativeTransportTimespans": [
+                    {
+                      "start": "string",
+                      "end": "string",
+                      "alternativeTransport": {
+                        "label": "string",
+                        "shortLabel": "string"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "400": {
+            "description": "Bad request. One or more parameters are invalid",
+            "schema": {
+              "$ref": "#/definitions/APIError"
+            },
+            "examples": {
+              "application/json": {
+                "timestamp": "string",
+                "code": 0,
+                "message": "string",
+                "path": "string",
+                "exception": "string",
+                "errors": [
+                  {
+                    "message": "string",
+                    "type": "string",
+                    "lang": "string"
+                  }
+                ],
+                "requestId": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/price": {}
+  },
+  "definitions": {
+    "Coordinate": {
+      "required": [
+        "lat",
+        "lng"
+      ],
+      "type": "object",
+      "properties": {
+        "lat": {
+          "type": "number"
+        },
+        "lng": {
+          "type": "number"
+        }
+      }
+    },
+    "EticketNotBuyableReason": {
+      "required": [
+        "reason"
+      ],
+      "type": "object",
+      "properties": {
+        "reason": {
+          "enum": [
+            "UNKNOWN_PRICE",
+            "TOO_MANY_SEPARATE_PARTS",
+            "TOO_FAR_IN_PAST",
+            "TOO_FAR_IN_FUTURE",
+            "STATION_NOT_OPEN_YET",
+            "TRIP_IS_NOT_DOMESTIC",
+            "VIA_STATION_REQUESTED",
+            "NO_TRAIN_LEGS_IN_TRIP"
+          ],
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "FareLeg": {
+      "required": [
+        "destination",
+        "fares",
+        "origin",
+        "productTypes"
+      ],
+      "type": "object",
+      "properties": {
+        "origin": {
+          "$ref": "#/definitions/TripOriginDestination"
+        },
+        "destination": {
+          "$ref": "#/definitions/TripOriginDestination"
+        },
+        "operator": {
+          "type": "string"
+        },
+        "productTypes": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "TRAIN",
+              "BUS",
+              "TRAM",
+              "METRO",
+              "FERRY",
+              "WALK",
+              "BIKE",
+              "CAR",
+              "TAXI",
+              "SUBWAY",
+              "UNKNOWN"
+            ],
+            "type": "string"
+          }
+        },
+        "fares": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TripTravelFare"
+          }
+        }
+      }
+    },
+    "FareLegStop": {
+      "required": [
+        "varCode"
+      ],
+      "type": "object",
+      "properties": {
+        "varCode": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "FareRoute": {
+      "required": [
+        "destination",
+        "origin"
+      ],
+      "type": "object",
+      "properties": {
+        "routeId": {
+          "type": "string"
+        },
+        "origin": {
+          "$ref": "#/definitions/FareLegStop"
+        },
+        "destination": {
+          "$ref": "#/definitions/FareLegStop"
+        }
+      }
+    },
+    "JourneyDetailLink": {
+      "required": [
+        "link",
+        "type"
+      ],
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "BTM",
+            "TRAIN_XML",
+            "TRAIN_JSON"
+          ],
+          "type": "string"
+        },
+        "link": {
+          "$ref": "#/definitions/Link"
+        }
+      }
+    },
+    "JourneyRegistrationParameters": {
+      "required": [
+        "bicycleReservationRequired",
+        "searchUrl",
+        "status"
+      ],
+      "type": "object",
+      "properties": {
+        "url": {
+          "format": "uri",
+          "type": "string"
+        },
+        "searchUrl": {
+          "format": "uri",
+          "type": "string"
+        },
+        "status": {
+          "enum": [
+            "REGISTRATION_POSSIBLE",
+            "NOT_AVAILABLE",
+            "DATE_IN_PAST",
+            "DATE_TOO_FAR_FUTURE",
+            "NOT_NECESSARY_OTHER_OPERATOR",
+            "UNKNOWN"
+          ],
+          "type": "string"
+        },
+        "bicycleReservationRequired": {
+          "type": "boolean"
+        },
+        "availability": {
+          "$ref": "#/definitions/RegistrationAvailability"
+        }
+      }
+    },
+    "Leg": {
+      "required": [
+        "alternativeTransport",
+        "cancelled",
+        "changePossible",
+        "destination",
+        "origin",
+        "reachable",
+        "stops"
+      ],
+      "type": "object",
+      "properties": {
+        "idx": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "travelType": {
+          "enum": [
+            "PUBLIC_TRANSIT",
+            "WALK",
+            "TRANSFER",
+            "BIKE",
+            "CAR",
+            "KISS",
+            "TAXI",
+            "UNKNOWN"
+          ],
+          "type": "string"
+        },
+        "direction": {
+          "type": "string"
+        },
+        "cancelled": {
+          "type": "boolean"
+        },
+        "changePossible": {
+          "type": "boolean"
+        },
+        "alternativeTransport": {
+          "type": "boolean"
+        },
+        "journeyDetailRef": {
+          "type": "string"
+        },
+        "origin": {
+          "$ref": "#/definitions/TripOriginDestination"
+        },
+        "destination": {
+          "$ref": "#/definitions/TripOriginDestination"
+        },
+        "product": {
+          "$ref": "#/definitions/Product"
+        },
+        "notes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Note"
+          }
+        },
+        "messages": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Message"
+          }
+        },
+        "stops": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Stop"
+          }
+        },
+        "steps": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Step"
+          }
+        },
+        "coordinates": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "format": "double",
+              "type": "number"
+            }
+          }
+        },
+        "crowdForecast": {
+          "enum": [
+            "UNKNOWN",
+            "LOW",
+            "MEDIUM",
+            "HIGH"
+          ],
+          "type": "string"
+        },
+        "punctuality": {
+          "format": "double",
+          "type": "number"
+        },
+        "crossPlatformTransfer": {
+          "type": "boolean"
+        },
+        "shorterStock": {
+          "type": "boolean"
+        },
+        "changeCouldBePossible": {
+          "type": "boolean"
+        },
+        "shorterStockWarning": {
+          "type": "string"
+        },
+        "shorterStockClassification": {
+          "enum": [
+            "BUSY",
+            "EXTRA_BUSY"
+          ],
+          "type": "string"
+        },
+        "journeyDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/JourneyDetailLink"
+          }
+        },
+        "reachable": {
+          "type": "boolean"
+        },
+        "plannedDurationInMinutes": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "travelAssistanceDeparture": {
+          "$ref": "#/definitions/ServiceBookingInfo"
+        },
+        "travelAssistanceArrival": {
+          "$ref": "#/definitions/ServiceBookingInfo"
+        },
+        "overviewPolyLine": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Coordinate"
+          }
+        }
+      }
+    },
+    "Link": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      }
+    },
+    "Location": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "lat": {
+          "type": "number"
+        },
+        "lng": {
+          "type": "number"
+        },
+        "city": {
+          "type": "string"
+        },
+        "country": {
+          "type": "string"
+        }
+      }
+    },
+    "Message": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "head": {
+          "type": "string"
+        },
+        "text": {
+          "type": "string"
+        },
+        "lead": {
+          "type": "string"
+        },
+        "routeIdxFrom": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "routeIdxTo": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "type": {
+          "enum": [
+            "MAINTENANCE",
+            "DISRUPTION"
+          ],
+          "type": "string"
+        },
+        "startDate": {
+          "type": "string"
+        },
+        "endDate": {
+          "type": "string"
+        },
+        "startTime": {
+          "type": "string"
+        },
+        "endTime": {
+          "type": "string"
+        }
+      }
+    },
+    "Note": {
+      "required": [
+        "isPresentationRequired"
+      ],
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "noteType": {
+          "enum": [
+            "UNKNOWN",
+            "ATTRIBUTE",
+            "INFOTEXT",
+            "REALTIME",
+            "TICKET",
+            "HINT"
+          ],
+          "type": "string"
+        },
+        "priority": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "routeIdxFrom": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "routeIdxTo": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "link": {
+          "$ref": "#/definitions/Link"
+        },
+        "isPresentationRequired": {
+          "type": "boolean"
+        },
+        "category": {
+          "enum": [
+            "PLATFORM_INFORMATION",
+            "OVERCHECK_INSTRUCTION",
+            "UNKNOWN"
+          ],
+          "type": "string"
+        }
+      }
+    },
+    "Product": {
+      "required": [
+        "type"
+      ],
+      "type": "object",
+      "properties": {
+        "number": {
+          "type": "string"
+        },
+        "categoryCode": {
+          "type": "string"
+        },
+        "shortCategoryName": {
+          "type": "string"
+        },
+        "longCategoryName": {
+          "type": "string"
+        },
+        "operatorCode": {
+          "type": "string"
+        },
+        "operatorName": {
+          "type": "string"
+        },
+        "operatorAdministrativeCode": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "type": {
+          "enum": [
+            "TRAIN",
+            "BUS",
+            "TRAM",
+            "METRO",
+            "FERRY",
+            "WALK",
+            "BIKE",
+            "CAR",
+            "TAXI",
+            "SUBWAY",
+            "UNKNOWN"
+          ],
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string"
+        }
+      }
+    },
+    "RegistrationAvailability": {
+      "required": [
+        "bicycle",
+        "seats"
+      ],
+      "type": "object",
+      "properties": {
+        "seats": {
+          "type": "boolean"
+        },
+        "numberOfSeats": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "bicycle": {
+          "type": "boolean"
+        },
+        "numberOfBicyclePlaces": {
+          "format": "int32",
+          "type": "integer"
+        }
+      }
+    },
+    "SalesOption": {
+      "required": [
+        "type"
+      ],
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "EARLY_BOOKING_DISCOUNT",
+            "NS_DEAL_DISCOUNT"
+          ],
+          "type": "string"
+        },
+        "permilleFullTariff": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "recommendationText": {
+          "type": "string"
+        }
+      }
+    },
+    "ServiceBookingInfo": {
+      "required": [
+        "canChangeAssistance",
+        "defaultAssistanceValue",
+        "name",
+        "serviceTypeIds",
+        "tripLegIndex"
+      ],
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "tripLegIndex": {
+          "type": "string"
+        },
+        "stationUic": {
+          "type": "string"
+        },
+        "serviceTypeIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "defaultAssistanceValue": {
+          "type": "boolean"
+        },
+        "canChangeAssistance": {
+          "type": "boolean"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    },
+    "Step": {
+      "required": [
+        "distanceInMeters",
+        "durationInSeconds",
+        "endLocation",
+        "instructions",
+        "startLocation"
+      ],
+      "type": "object",
+      "properties": {
+        "distanceInMeters": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "durationInSeconds": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "startLocation": {
+          "$ref": "#/definitions/Location"
+        },
+        "endLocation": {
+          "$ref": "#/definitions/Location"
+        },
+        "instructions": {
+          "type": "string"
+        }
+      }
+    },
+    "Stop": {
+      "required": [
+        "borderStop",
+        "cancelled",
+        "notes",
+        "passing"
+      ],
+      "type": "object",
+      "properties": {
+        "uicCode": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "lat": {
+          "type": "number"
+        },
+        "lng": {
+          "type": "number"
+        },
+        "countryCode": {
+          "type": "string"
+        },
+        "notes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/StopNote"
+          }
+        },
+        "routeIdx": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "departurePrognosisType": {
+          "type": "string"
+        },
+        "plannedDepartureDateTime": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "plannedDepartureTimeZoneOffset": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "actualDepartureDateTime": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "actualDepartureTimeZoneOffset": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "plannedArrivalDateTime": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "plannedArrivalTimeZoneOffset": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "actualArrivalDateTime": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "actualArrivalTimeZoneOffset": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "plannedPassingDateTime": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "actualPassingDateTime": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "arrivalPrognosisType": {
+          "type": "string"
+        },
+        "actualDepartureTrack": {
+          "type": "string"
+        },
+        "plannedDepartureTrack": {
+          "type": "string"
+        },
+        "plannedArrivalTrack": {
+          "type": "string"
+        },
+        "actualArrivalTrack": {
+          "type": "string"
+        },
+        "departureDelayInSeconds": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "arrivalDelayInSeconds": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "cancelled": {
+          "type": "boolean"
+        },
+        "borderStop": {
+          "type": "boolean"
+        },
+        "passing": {
+          "type": "boolean"
+        },
+        "quayCode": {
+          "type": "string"
+        }
+      }
+    },
+    "StopNote": {
+      "required": [
+        "type",
+        "value"
+      ],
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "U",
+            "A",
+            "I",
+            "R",
+            "H"
+          ],
+          "type": "string"
+        },
+        "priority": {
+          "format": "int32",
+          "type": "integer"
+        }
+      }
+    },
+    "TravelAdvice": {
+      "required": [
+        "source",
+        "trips"
+      ],
+      "type": "object",
+      "properties": {
+        "source": {
+          "description": "Source system that has generated these travel advices",
+          "enum": [
+            "HARP",
+            "NEGENTWEE",
+            "GOOGLE",
+            "PAS"
+          ],
+          "type": "string"
+        },
+        "trips": {
+          "description": "List of trips",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Trip"
+          }
+        },
+        "scrollRequestBackwardContext": {
+          "description": "Scroll context to use when scrolling back in time. Can be used in scrollContext query parameter",
+          "type": "string"
+        },
+        "scrollRequestForwardContext": {
+          "description": "Scroll context to use when scrolling forward in time. Can be used in scrollContext query parameter",
+          "type": "string"
+        },
+        "message": {
+          "description": "Optional message indicating why the list of trips is empty.",
+          "type": "string"
+        }
+      }
+    },
+    "TravelAssistanceInfo": {
+      "required": [
+        "isAssistanceRequired",
+        "tripRequestId"
+      ],
+      "type": "object",
+      "properties": {
+        "termsAndConditionsLink": {
+          "description": "link to terms and conditions",
+          "type": "string"
+        },
+        "tripRequestId": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "isAssistanceRequired": {
+          "type": "boolean"
+        }
+      }
+    },
+    "Trip": {
+      "description": "List of trips",
+      "required": [
+        "ctxRecon",
+        "legs",
+        "optimal",
+        "realtime",
+        "status",
+        "transfers",
+        "type",
+        "uid"
+      ],
+      "type": "object",
+      "properties": {
+        "uid": {
+          "description": "Unique identifier for this trip",
+          "type": "string"
+        },
+        "ctxRecon": {
+          "description": "Reconstruction context for this trip. Can be used to reconstruct this exact trip with the v3/trips/trip endpoint",
+          "type": "string"
+        },
+        "plannedDurationInMinutes": {
+          "format": "int64",
+          "description": "Planned duration of this trip in minutes",
+          "type": "integer"
+        },
+        "actualDurationInMinutes": {
+          "format": "int64",
+          "description": "Actual duration of this trip in minutes, or the planned duration if no realtime information about this trip is available.",
+          "type": "integer"
+        },
+        "transfers": {
+          "format": "int32",
+          "description": "Number of public transit transfers",
+          "type": "integer"
+        },
+        "status": {
+          "description": "Status of this trip",
+          "enum": [
+            "CANCELLED",
+            "CHANGE_NOT_POSSIBLE",
+            "CHANGE_COULD_BE_POSSIBLE",
+            "ALTERNATIVE_TRANSPORT",
+            "DISRUPTION",
+            "MAINTENANCE",
+            "UNCERTAIN",
+            "REPLACEMENT",
+            "ADDITIONAL",
+            "SPECIAL",
+            "NORMAL"
+          ],
+          "type": "string"
+        },
+        "messages": {
+          "description": "List of messages regarding maintenance or disruption that influences this trip.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Message"
+          }
+        },
+        "legs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Leg"
+          }
+        },
+        "overviewPolyLine": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Coordinate"
+          }
+        },
+        "crowdForecast": {
+          "enum": [
+            "UNKNOWN",
+            "LOW",
+            "MEDIUM",
+            "HIGH"
+          ],
+          "type": "string"
+        },
+        "punctuality": {
+          "format": "double",
+          "type": "number"
+        },
+        "optimal": {
+          "description": "Whether or not this trip is regarded the best possible option of all returned trips",
+          "type": "boolean"
+        },
+        "fareRoute": {
+          "$ref": "#/definitions/FareRoute"
+        },
+        "fares": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TripSalesFare"
+          }
+        },
+        "fareLegs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FareLeg"
+          }
+        },
+        "productFare": {
+          "$ref": "#/definitions/TripTravelFare"
+        },
+        "fareOptions": {
+          "$ref": "#/definitions/TripFareOptions"
+        },
+        "bookingUrl": {
+          "$ref": "#/definitions/Link"
+        },
+        "type": {
+          "enum": [
+            "NS",
+            "NS_ACCESSIBLE",
+            "NEGENTWEE",
+            "GOOGLE",
+            "PAS"
+          ],
+          "type": "string"
+        },
+        "shareUrl": {
+          "$ref": "#/definitions/Link"
+        },
+        "realtime": {
+          "type": "boolean"
+        },
+        "travelAssistanceInfo": {
+          "$ref": "#/definitions/TravelAssistanceInfo"
+        },
+        "routeId": {
+          "type": "string"
+        },
+        "registerJourney": {
+          "$ref": "#/definitions/JourneyRegistrationParameters"
+        }
+      }
+    },
+    "TripFareOptions": {
+      "required": [
+        "isEticketBuyable",
+        "isInternational",
+        "isInternationalBookable",
+        "isPossibleWithOvChipkaart",
+        "isTotalPriceUnknown"
+      ],
+      "type": "object",
+      "properties": {
+        "isInternationalBookable": {
+          "type": "boolean"
+        },
+        "isInternational": {
+          "type": "boolean"
+        },
+        "isEticketBuyable": {
+          "type": "boolean"
+        },
+        "isPossibleWithOvChipkaart": {
+          "type": "boolean"
+        },
+        "isTotalPriceUnknown": {
+          "type": "boolean"
+        },
+        "supplementsBasedOnSelectedFare": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TripFareSupplement"
+          }
+        },
+        "reasonEticketNotBuyable": {
+          "$ref": "#/definitions/EticketNotBuyableReason"
+        },
+        "salesOptions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SalesOption"
+          }
+        }
+      }
+    },
+    "TripFareSupplement": {
+      "required": [
+        "supplementPriceInCents"
+      ],
+      "type": "object",
+      "properties": {
+        "supplementPriceInCents": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "legIdx": {
+          "type": "string"
+        },
+        "fromUICCode": {
+          "type": "string"
+        },
+        "toUICCode": {
+          "type": "string"
+        },
+        "link": {
+          "$ref": "#/definitions/Link"
+        }
+      }
+    },
+    "TripOriginDestination": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "lng": {
+          "type": "number"
+        },
+        "lat": {
+          "type": "number"
+        },
+        "city": {
+          "type": "string"
+        },
+        "countryCode": {
+          "type": "string"
+        },
+        "uicCode": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "STATION",
+            "ADDRESS",
+            "POINT_OF_INTEREST"
+          ],
+          "type": "string"
+        },
+        "prognosisType": {
+          "type": "string"
+        },
+        "plannedTimeZoneOffset": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "plannedDateTime": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "actualTimeZoneOffset": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "actualDateTime": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "plannedTrack": {
+          "type": "string"
+        },
+        "actualTrack": {
+          "type": "string"
+        },
+        "exitSide": {
+          "enum": [
+            "LEFT",
+            "RIGHT",
+            "UNKNOWN"
+          ],
+          "type": "string"
+        },
+        "checkinStatus": {
+          "enum": [
+            "CHECKIN",
+            "CHECKOUT",
+            "OVERCHECK",
+            "DETOUR",
+            "REQUIRED_CHECK_OUT_IN",
+            "NOTHING"
+          ],
+          "type": "string"
+        },
+        "travelAssistanceBookingInfo": {
+          "$ref": "#/definitions/ServiceBookingInfo"
+        },
+        "travelAssistanceMeetingPoints": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "notes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Note"
+          }
+        },
+        "quayCode": {
+          "type": "string"
+        }
+      }
+    },
+    "TripSalesFare": {
+      "type": "object",
+      "properties": {
+        "priceInCents": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "product": {
+          "enum": [
+            "OVCHIPKAART_ENKELE_REIS",
+            "OVCHIPKAART_RETOUR",
+            "TRAJECT_VRIJ_MAAND",
+            "TRAJECT_VRIJ_JAAR",
+            "BUSINESS_CARD_TRAJECT_VRIJ_JAAR",
+            "ETICKET_ENKELE_REIS",
+            "ETICKET_RETOUR",
+            "ETICKET_JOINT_JOURNEY_DISCOUNT_RETOUR",
+            "ETICKET_JOINT_JOURNEY_DISCOUNT_ENKELE_REIS",
+            "EARLY_BOOKING_DISCOUNT_ENKELE_REIS",
+            "EARLY_BOOKING_DISCOUNT_RETOUR",
+            "GROUP_OFF_PEAK",
+            "NS_DEAL_DISCOUNT_ENKELE_REIS",
+            "RAILRUNNER",
+            "ICE_SUPPLEMENT",
+            "ICD_SUPPLEMENT",
+            "NSI"
+          ],
+          "type": "string"
+        },
+        "travelClass": {
+          "enum": [
+            "FIRST_CLASS",
+            "SECOND_CLASS"
+          ],
+          "type": "string"
+        },
+        "priceInCentsExcludingSupplement": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "discountType": {
+          "enum": [
+            "NO_DISCOUNT",
+            "DISCOUNT_20_PERCENT",
+            "DISCOUNT_40_PERCENT",
+            "NO_CHARGE",
+            "OTHER"
+          ],
+          "type": "string"
+        },
+        "supplementInCents": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "link": {
+          "type": "string"
+        }
+      }
+    },
+    "TripTravelFare": {
+      "required": [
+        "discountType"
+      ],
+      "type": "object",
+      "properties": {
+        "priceInCents": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "priceInCentsExcludingSupplement": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "supplementInCents": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "buyableTicketPriceInCents": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "buyableTicketPriceInCentsExcludingSupplement": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "buyableTicketSupplementPriceInCents": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "product": {
+          "enum": [
+            "GEEN",
+            "OVCHIPKAART_ENKELE_REIS",
+            "OVCHIPKAART_RETOUR",
+            "DAL_VOORDEEL",
+            "ALTIJD_VOORDEEL",
+            "DAL_VRIJ",
+            "WEEKEND_VRIJ",
+            "ALTIJD_VRIJ",
+            "BUSINESSCARD",
+            "BUSINESSCARD_DAL",
+            "STUDENT_WEEK",
+            "STUDENT_WEEKEND",
+            "VDU",
+            "SAMENREISKORTING",
+            "TRAJECT_VRIJ"
+          ],
+          "type": "string"
+        },
+        "travelClass": {
+          "enum": [
+            "FIRST_CLASS",
+            "SECOND_CLASS"
+          ],
+          "type": "string"
+        },
+        "discountType": {
+          "enum": [
+            "NO_DISCOUNT",
+            "DISCOUNT_20_PERCENT",
+            "DISCOUNT_40_PERCENT",
+            "NO_CHARGE",
+            "OTHER"
+          ],
+          "type": "string"
+        },
+        "link": {
+          "type": "string"
+        }
+      }
+    },
+    "APIError": {
+      "required": [
+        "code",
+        "message",
+        "path",
+        "requestId",
+        "timestamp"
+      ],
+      "type": "object",
+      "properties": {
+        "timestamp": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "code": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "message": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "exception": {
+          "type": "string"
+        },
+        "errors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LocalizedErrorDetail"
+          }
+        },
+        "requestId": {
+          "type": "string"
+        }
+      }
+    },
+    "LocalizedErrorDetail": {
+      "required": [
+        "lang",
+        "message",
+        "type"
+      ],
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "lang": {
+          "type": "string"
+        }
+      }
+    },
+    "PriceV3": {
+      "required": [
+        "conditionsHeader",
+        "discountType",
+        "displayName",
+        "isBestOption",
+        "isSelectable",
+        "pricePerAdultInCents",
+        "productId",
+        "totalPriceInCents",
+        "travelClass",
+        "travelProducts"
+      ],
+      "type": "object",
+      "properties": {
+        "totalPriceInCents": {
+          "format": "int32",
+          "description": "Total price",
+          "type": "integer"
+        },
+        "pricePerAdultInCents": {
+          "format": "int32",
+          "description": "Price per adult",
+          "type": "integer"
+        },
+        "discountInCents": {
+          "format": "int32",
+          "description": "Discount price compared to total price without any discount",
+          "type": "integer"
+        },
+        "operatorName": {
+          "description": "Name of the operator",
+          "type": "string"
+        },
+        "discountType": {
+          "description": "Type of discount",
+          "enum": [
+            "NONE",
+            "EARLY_BOOKING",
+            "GROUP",
+            "JOINT_JOURNEY",
+            "RAILRUNNER",
+            "NS_DEAL"
+          ],
+          "type": "string"
+        },
+        "travelClass": {
+          "description": "Traveling class",
+          "enum": [
+            "FIRST_CLASS",
+            "SECOND_CLASS"
+          ],
+          "type": "string"
+        },
+        "travelProducts": {
+          "description": "Travel products types",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Unit"
+          }
+        },
+        "isSelectable": {
+          "description": "Denotes if the user can select this option",
+          "type": "boolean"
+        },
+        "displayName": {
+          "description": "Display name of product",
+          "type": "string"
+        },
+        "conditionsHeader": {
+          "description": "Header of conditions",
+          "type": "string"
+        },
+        "conditionsText": {
+          "description": "Conditions of product",
+          "type": "string"
+        },
+        "conditionsUrl": {
+          "description": "Url to webpage with common conditions",
+          "type": "string"
+        },
+        "productId": {
+          "description": "Product ID used to buy ticket",
+          "type": "string"
+        },
+        "isBestOption": {
+          "description": "Indicates if this price is the best option for client",
+          "type": "boolean"
+        }
+      }
+    },
+    "PricesResponseV3": {
+      "required": [
+        "prices"
+      ],
+      "type": "object",
+      "properties": {
+        "prices": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PriceV3"
+          }
+        }
+      }
+    },
+    "RepresentationResponsePricesResponseV3": {
+      "required": [
+        "payload"
+      ],
+      "type": "object",
+      "properties": {
+        "payload": {
+          "$ref": "#/definitions/PricesResponseV3"
+        },
+        "links": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Link"
+          }
+        },
+        "meta": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "Unit": {
+      "description": "Travel products types",
+      "type": "object"
+    },
+    "AdditionalTravelTime": {
+      "description": "Information about the cause of the additional travel time that is expected",
+      "required": [
+        "label"
+      ],
+      "type": "object",
+      "properties": {
+        "label": {
+          "description": "Human readable description of the additional travel time that is expected",
+          "type": "string"
+        },
+        "shortLabel": {
+          "description": "Short human readable description of the additional travel time that is expected",
+          "type": "string"
+        },
+        "minimumDurationInMinutes": {
+          "format": "int64",
+          "description": "Minimum expected additional travel time in minutes",
+          "type": "integer"
+        },
+        "maximumDurationInMinutes": {
+          "format": "int64",
+          "description": "Maximum expected additional travel time in minutes",
+          "type": "integer"
+        }
+      }
+    },
+    "AlternativeTransport": {
+      "description": "Information about the alternative transport that is available to the user",
+      "required": [
+        "label"
+      ],
+      "type": "object",
+      "properties": {
+        "label": {
+          "description": "Human readable description of the alternative transport that is available to the user",
+          "type": "string"
+        },
+        "shortLabel": {
+          "description": "Short label indicating the alternative transport that is available to the user",
+          "type": "string"
+        }
+      }
+    },
+    "AlternativeTransportTimespan": {
+      "description": "Distinguishable timespans for alternative transport within this disruption.",
+      "required": [
+        "alternativeTransport",
+        "start"
+      ],
+      "type": "object",
+      "properties": {
+        "start": {
+          "format": "date-time",
+          "description": "Start time of this timespan",
+          "type": "string"
+        },
+        "end": {
+          "format": "date-time",
+          "description": "End time of this timespan",
+          "type": "string"
+        },
+        "alternativeTransport": {
+          "$ref": "#/definitions/AlternativeTransport"
+        }
+      }
+    },
+    "BodyItem": {
+      "description": "Body items to render when showing this calamity",
+      "required": [
+        "content",
+        "type"
+      ],
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "TEXT",
+            "DOWNLOADS",
+            "LINKS"
+          ],
+          "type": "string"
+        },
+        "content": {
+          "$ref": "#/definitions/BodyItemContent"
+        }
+      },
+      "discriminator": "type"
+    },
+    "BodyItemContent": {
+      "type": "object"
+    },
+    "Button": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "PLANNER",
+            "DISRUPTIONS",
+            "MAINTENANCE",
+            "EXTERNAL"
+          ],
+          "type": "string"
+        },
+        "accessibilityLabel": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      }
+    },
+    "Buttons": {
+      "description": "Buttons to render when showing this calamity",
+      "required": [
+        "items",
+        "position"
+      ],
+      "type": "object",
+      "properties": {
+        "position": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "TOP",
+              "BOTTOM"
+            ],
+            "type": "string"
+          }
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Button"
+          }
+        }
+      }
+    },
+    "Calamity": {
+      "required": [
+        "bodyItems",
+        "buttons",
+        "id",
+        "isActive",
+        "priority",
+        "title",
+        "type"
+      ],
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Unique identifier of the calamity",
+          "type": "string"
+        },
+        "title": {
+          "description": "Title of the calamity",
+          "type": "string"
+        },
+        "topic": {
+          "description": "Topic to subscribe to in order to receive updates for this disruption.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human readable description for this calamity",
+          "type": "string"
+        },
+        "priority": {
+          "description": "Priority for this calamity",
+          "enum": [
+            "PRIO_1",
+            "PRIO_2",
+            "PRIO_3"
+          ],
+          "type": "string"
+        },
+        "lastUpdated": {
+          "format": "date-time",
+          "description": "Moment that this calamity was last updated",
+          "type": "string"
+        },
+        "expectedNextUpdate": {
+          "format": "date-time",
+          "description": "Expected moment that this calamity will be updated",
+          "type": "string"
+        },
+        "bodyItems": {
+          "description": "Body items to render when showing this calamity",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BodyItem"
+          }
+        },
+        "buttons": {
+          "$ref": "#/definitions/Buttons"
+        },
+        "url": {
+          "format": "uri",
+          "description": "URL for more information about this calamity",
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "CALAMITY",
+            "DISRUPTION",
+            "MAINTENANCE"
+          ],
+          "type": "string"
+        },
+        "isActive": {
+          "type": "boolean"
+        }
+      }
+    },
+    "Cause": {
+      "description": "Information about the cause of the disruption in this timespan",
+      "required": [
+        "label"
+      ],
+      "type": "object",
+      "properties": {
+        "label": {
+          "description": "Human readable description of the cause of the disruption",
+          "type": "string"
+        }
+      }
+    },
+    "Disruption": {
+      "required": [
+        "alternativeTransportTimespans",
+        "id",
+        "isActive",
+        "local",
+        "publicationSections",
+        "start",
+        "timespans",
+        "title",
+        "titleSections",
+        "type"
+      ],
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Unique identifier of the disruption",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type of disruption",
+          "enum": [
+            "CALAMITY",
+            "DISRUPTION",
+            "MAINTENANCE"
+          ],
+          "type": "string"
+        },
+        "registrationTime": {
+          "format": "date-time",
+          "description": "Registration time of this disruption",
+          "type": "string"
+        },
+        "releaseTime": {
+          "format": "date-time",
+          "description": "Release time of this disruption",
+          "type": "string"
+        },
+        "local": {
+          "description": "A local disruption has messages tailored towards a specific station.",
+          "type": "boolean"
+        },
+        "title": {
+          "description": "Title of the disruption, containing the location(s) of the disruption",
+          "type": "string"
+        },
+        "titleSections": {
+          "description": "Title of the disruption which includes where the disruption takes place. For example: Utrecht - Gouda -Icon- Den Haag",
+          "type": "array",
+          "items": {
+            "description": "Title of the disruption which includes where the disruption takes place. For example: Utrecht - Gouda -Icon- Den Haag",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/TitleSection"
+            }
+          }
+        },
+        "topic": {
+          "description": "Topic to subscribe to in order to receive updates for this disruption.",
+          "type": "string"
+        },
+        "isActive": {
+          "description": "Whether or not this item is active, i.e. it is currently happening. For example maintenance that starts in the future has this property set to false",
+          "type": "boolean"
+        },
+        "start": {
+          "format": "date-time",
+          "description": "Start time of the disruption",
+          "type": "string"
+        },
+        "end": {
+          "format": "date-time",
+          "description": "End time of the disruption. May be left empty if unknown",
+          "type": "string"
+        },
+        "period": {
+          "description": "Human readable description of the period for this disruption",
+          "type": "string"
+        },
+        "phase": {
+          "$ref": "#/definitions/Phase"
+        },
+        "impact": {
+          "$ref": "#/definitions/Impact"
+        },
+        "expectedDuration": {
+          "$ref": "#/definitions/ExpectedDuration"
+        },
+        "summaryAdditionalTravelTime": {
+          "$ref": "#/definitions/AdditionalTravelTime"
+        },
+        "publicationSections": {
+          "description": "Publication sections for this disruptions. Please note that these may be larger than the actual\ntrack sections where the disruption is. This has to do with stations being recognizable for the customer.\nFor example, there could be a disruption between Utrecht Vaartse Rijn and Bunnik. In that case, the\ntrajectory could be Utrecht Centraal to Driebergen-Zeist, as most customers do not know where Utrecht Vaartse\nRijn and Bunnik are. In this case, the trajectory will contain Utrecht Centraal to Driebergen-Zeist, whereas\nthe disruptedTrackSection will contain Utrecht Vaartse Rijn to Bunnik",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PublicationSection"
+          }
+        },
+        "timespans": {
+          "description": "Distinguishable timespans within this disruption. Multiple timespans may occur for maintenance.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Timespan"
+          }
+        },
+        "alternativeTransportTimespans": {
+          "description": "Distinguishable timespans for alternative transport within this disruption.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AlternativeTransportTimespan"
+          }
+        }
+      }
+    },
+    "DisruptionBase": {
+      "required": [
+        "id",
+        "isActive",
+        "title",
+        "type"
+      ],
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Unique identifier of the disruption",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type of disruption",
+          "enum": [
+            "CALAMITY",
+            "DISRUPTION",
+            "MAINTENANCE"
+          ],
+          "type": "string"
+        },
+        "title": {
+          "description": "Title of the disruption, containing the location(s) of the disruption",
+          "type": "string"
+        },
+        "topic": {
+          "description": "Topic to subscribe to in order to receive updates for this disruption.",
+          "type": "string"
+        },
+        "isActive": {
+          "description": "Whether or not this item is active, i.e. it is currently happening. For example maintenance that starts in the future has this property set to false",
+          "type": "boolean"
+        }
+      },
+      "discriminator": "type"
+    },
+    "DisruptionConsequence": {
+      "required": [
+        "level",
+        "section"
+      ],
+      "type": "object",
+      "properties": {
+        "section": {
+          "$ref": "#/definitions/Section"
+        },
+        "description": {
+          "type": "string"
+        },
+        "level": {
+          "enum": [
+            "NO_OR_MUCH_LESS_TRAINS",
+            "LESS_TRAINS",
+            "NORMAL_OR_MORE_TRAINS"
+          ],
+          "type": "string"
+        }
+      }
+    },
+    "Download": {
+      "required": [
+        "contentLength"
+      ],
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "contentLength": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "mimeType": {
+          "type": "string"
+        },
+        "lastModified": {
+          "format": "date-time",
+          "type": "string"
+        }
+      }
+    },
+    "DownloadsBodyItem": {
+      "required": [
+        "content",
+        "type"
+      ],
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "content": {
+          "$ref": "#/definitions/DownloadsBodyItemContent"
+        },
+        "type": {
+          "enum": [
+            "TEXT",
+            "DOWNLOADS",
+            "LINKS"
+          ],
+          "type": "string"
+        }
+      }
+    },
+    "DownloadsBodyItemContent": {
+      "required": [
+        "downloads"
+      ],
+      "type": "object",
+      "properties": {
+        "downloads": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Download"
+          }
+        }
+      }
+    },
+    "ExpectedDuration": {
+      "description": "Information on the expected duration for this disruption. Is empty for maintenance",
+      "required": [
+        "description"
+      ],
+      "type": "object",
+      "properties": {
+        "description": {
+          "description": "Human readable description of the expected duration of the disruption.",
+          "type": "string"
+        },
+        "endTime": {
+          "format": "date-time",
+          "description": "Expected end time for this disruption",
+          "type": "string"
+        }
+      }
+    },
+    "Impact": {
+      "description": "Impact of the disruption, from 0 - 5",
+      "required": [
+        "value"
+      ],
+      "type": "object",
+      "properties": {
+        "value": {
+          "format": "int32",
+          "type": "integer"
+        }
+      }
+    },
+    "LinksBodyItem": {
+      "required": [
+        "content",
+        "type"
+      ],
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "content": {
+          "$ref": "#/definitions/LinksBodyItemContent"
+        },
+        "type": {
+          "enum": [
+            "TEXT",
+            "DOWNLOADS",
+            "LINKS"
+          ],
+          "type": "string"
+        }
+      }
+    },
+    "LinksBodyItemContent": {
+      "required": [
+        "links"
+      ],
+      "type": "object",
+      "properties": {
+        "links": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Link"
+          }
+        }
+      }
+    },
+    "Phase": {
+      "description": "Phase of the disruption",
+      "required": [
+        "id",
+        "label"
+      ],
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        }
+      }
+    },
+    "PublicationSection": {
+      "description": "Publication sections for this disruptions. Please note that these may be larger than the actual\ntrack sections where the disruption is. This has to do with stations being recognizable for the customer.\nFor example, there could be a disruption between Utrecht Vaartse Rijn and Bunnik. In that case, the\ntrajectory could be Utrecht Centraal to Driebergen-Zeist, as most customers do not know where Utrecht Vaartse\nRijn and Bunnik are. In this case, the trajectory will contain Utrecht Centraal to Driebergen-Zeist, whereas\nthe disruptedTrackSection will contain Utrecht Vaartse Rijn to Bunnik",
+      "required": [
+        "section",
+        "sectionType"
+      ],
+      "type": "object",
+      "properties": {
+        "section": {
+          "$ref": "#/definitions/Section"
+        },
+        "consequence": {
+          "$ref": "#/definitions/DisruptionConsequence"
+        },
+        "sectionType": {
+          "enum": [
+            "NL",
+            "NEIGHBORING_COUNTRY",
+            "HSL",
+            "INTERNATIONAL"
+          ],
+          "type": "string"
+        }
+      }
+    },
+    "Section": {
+      "required": [
+        "direction",
+        "stations"
+      ],
+      "type": "object",
+      "properties": {
+        "stations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/StationReference"
+          }
+        },
+        "direction": {
+          "enum": [
+            "ONE_WAY",
+            "BOTH"
+          ],
+          "type": "string"
+        }
+      }
+    },
+    "Situation": {
+      "description": "Information about the situation caused by the disruption",
+      "required": [
+        "label"
+      ],
+      "type": "object",
+      "properties": {
+        "label": {
+          "description": "Human readable description of the situation caused by the disruption",
+          "type": "string"
+        }
+      }
+    },
+    "StationReference": {
+      "required": [
+        "countryCode",
+        "name",
+        "uicCode"
+      ],
+      "type": "object",
+      "properties": {
+        "uicCode": {
+          "type": "string"
+        },
+        "stationCode": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "coordinate": {
+          "$ref": "#/definitions/Coordinate"
+        },
+        "countryCode": {
+          "type": "string"
+        }
+      }
+    },
+    "TextBodyItem": {
+      "required": [
+        "content",
+        "type"
+      ],
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "content": {
+          "$ref": "#/definitions/TextBodyItemContent"
+        },
+        "type": {
+          "enum": [
+            "TEXT",
+            "DOWNLOADS",
+            "LINKS"
+          ],
+          "type": "string"
+        }
+      }
+    },
+    "TextBodyItemContent": {
+      "type": "object",
+      "properties": {
+        "text": {
+          "type": "string"
+        }
+      }
+    },
+    "Timespan": {
+      "description": "Distinguishable timespans within this disruption. Multiple timespans may occur for maintenance.",
+      "required": [
+        "advices",
+        "situation",
+        "start"
+      ],
+      "type": "object",
+      "properties": {
+        "start": {
+          "format": "date-time",
+          "description": "Start time of this timespan",
+          "type": "string"
+        },
+        "end": {
+          "format": "date-time",
+          "description": "End time of this timespan. May be left empty if unknown",
+          "type": "string"
+        },
+        "period": {
+          "description": "Human readable description of the period for this disruption",
+          "type": "string"
+        },
+        "situation": {
+          "$ref": "#/definitions/Situation"
+        },
+        "cause": {
+          "$ref": "#/definitions/Cause"
+        },
+        "additionalTravelTime": {
+          "$ref": "#/definitions/AdditionalTravelTime"
+        },
+        "alternativeTransport": {
+          "$ref": "#/definitions/AlternativeTransport"
+        },
+        "advices": {
+          "description": "List of advices",
+          "type": "array",
+          "items": {
+            "description": "List of advices",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "TitleSection": {
+      "description": "Title of the disruption which includes where the disruption takes place. For example: Utrecht - Gouda -Icon- Den Haag",
+      "required": [
+        "type",
+        "value"
+      ],
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "STATION",
+            "ICON"
+          ],
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "NearbyMeLocationId": {
+      "required": [
+        "type",
+        "value"
+      ],
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      }
+    },
+    "Station": {
+      "required": [
+        "UICCode",
+        "heeftFaciliteiten",
+        "heeftReisassistentie",
+        "heeftVertrektijden",
+        "sporen",
+        "stationType",
+        "synoniemen"
+      ],
+      "type": "object",
+      "properties": {
+        "UICCode": {
+          "type": "string"
+        },
+        "stationType": {
+          "type": "string"
+        },
+        "EVACode": {
+          "type": "string"
+        },
+        "code": {
+          "type": "string"
+        },
+        "sporen": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Track"
+          }
+        },
+        "synoniemen": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "heeftFaciliteiten": {
+          "type": "boolean"
+        },
+        "heeftVertrektijden": {
+          "type": "boolean"
+        },
+        "heeftReisassistentie": {
+          "type": "boolean"
+        },
+        "namen": {
+          "$ref": "#/definitions/StationsNamen"
+        },
+        "land": {
+          "type": "string"
+        },
+        "lat": {
+          "type": "number"
+        },
+        "lng": {
+          "type": "number"
+        },
+        "radius": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "naderenRadius": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "ingangsDatum": {
+          "format": "date",
+          "type": "string"
+        },
+        "eindDatum": {
+          "format": "date",
+          "type": "string"
+        },
+        "nearbyMeLocationId": {
+          "$ref": "#/definitions/NearbyMeLocationId"
+        }
+      }
+    },
+    "StationResponse": {
+      "required": [
+        "payload"
+      ],
+      "type": "object",
+      "properties": {
+        "payload": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Station"
+          }
+        },
+        "links": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "meta": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "StationsNamen": {
+      "required": [
+        "kort",
+        "lang",
+        "middel"
+      ],
+      "type": "object",
+      "properties": {
+        "lang": {
+          "type": "string"
+        },
+        "middel": {
+          "type": "string"
+        },
+        "kort": {
+          "type": "string"
+        }
+      }
+    },
+    "Track": {
+      "required": [
+        "spoorNummer"
+      ],
+      "type": "object",
+      "properties": {
+        "spoorNummer": {
+          "type": "string"
+        }
+      }
+    },
+    "Price": {
+      "required": [
+        "totalPriceInCents",
+        "travelClass",
+        "travelDiscount",
+        "travelProducts"
+      ],
+      "type": "object",
+      "properties": {
+        "totalPriceInCents": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "priceDifferenceInCentsBetweenFirstAndSecondClass": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "priceDifferenceInCentsBetweenJointJourneyDiscount": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "operatorName": {
+          "type": "string"
+        },
+        "travelDiscount": {
+          "enum": [
+            "NO_DISCOUNT",
+            "DISCOUNT_20",
+            "DISCOUNT_40",
+            "NO_CHARGE"
+          ],
+          "type": "string"
+        },
+        "travelClass": {
+          "enum": [
+            "FIRST_CLASS",
+            "SECOND_CLASS"
+          ],
+          "type": "string"
+        },
+        "travelProducts": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "OVCHIPKAART_ENKELE_REIS",
+              "OVCHIPKAART_RETOUR",
+              "TRAJECT_VRIJ_MAAND",
+              "TRAJECT_VRIJ_JAAR",
+              "BUSINESS_CARD_TRAJECT_VRIJ_JAAR",
+              "RAILRUNNER",
+              "ETICKET_ENKELE_REIS",
+              "ETICKET_RETOUR",
+              "ETICKET_JOINT_JOURNEY_DISCOUNT_RETOUR",
+              "ETICKET_JOINT_JOURNEY_DISCOUNT_ENKELE_REIS"
+            ],
+            "type": "string"
+          }
+        }
+      }
+    },
+    "RepresentationResponsePrice": {
+      "required": [
+        "payload"
+      ],
+      "type": "object",
+      "properties": {
+        "payload": {
+          "$ref": "#/definitions/Price"
+        },
+        "links": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Link"
+          }
+        },
+        "meta": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "InternationalPrice": {
+      "required": [
+        "priceInCents",
+        "priceInCentsExcludingSupplement",
+        "product",
+        "travelClass"
+      ],
+      "type": "object",
+      "properties": {
+        "priceInCents": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "priceInCentsExcludingSupplement": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "product": {
+          "type": "string"
+        },
+        "travelClass": {
+          "enum": [
+            "FIRST_CLASS",
+            "SECOND_CLASS"
+          ],
+          "type": "string"
+        },
+        "link": {
+          "format": "uri",
+          "type": "string"
+        }
+      }
+    },
+    "RepresentationResponseInternationalPrice": {
+      "required": [
+        "payload"
+      ],
+      "type": "object",
+      "properties": {
+        "payload": {
+          "$ref": "#/definitions/InternationalPrice"
+        },
+        "links": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Link"
+          }
+        },
+        "meta": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "ArrivalOrDeparture": {
+      "required": [
+        "cancelled",
+        "crowdForecast",
+        "product"
+      ],
+      "type": "object",
+      "properties": {
+        "product": {
+          "$ref": "#/definitions/Product"
+        },
+        "origin": {
+          "$ref": "#/definitions/Station"
+        },
+        "destination": {
+          "$ref": "#/definitions/Station"
+        },
+        "plannedTime": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "actualTime": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "delayInSeconds": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "plannedTrack": {
+          "type": "string"
+        },
+        "actualTrack": {
+          "type": "string"
+        },
+        "cancelled": {
+          "type": "boolean"
+        },
+        "punctuality": {
+          "format": "double",
+          "type": "number"
+        },
+        "crowdForecast": {
+          "enum": [
+            "UNKNOWN",
+            "LOW",
+            "MEDIUM",
+            "HIGH"
+          ],
+          "type": "string"
+        },
+        "shorterStockClassification": {
+          "enum": [
+            "BUSY",
+            "EXTRA_BUSY"
+          ],
+          "type": "string"
+        },
+        "stockIdentifiers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "CoachCrowdForecast": {
+      "required": [
+        "classification",
+        "paddingLeft",
+        "width"
+      ],
+      "type": "object",
+      "properties": {
+        "paddingLeft": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "width": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "classification": {
+          "enum": [
+            "UNKNOWN",
+            "LOW",
+            "MEDIUM",
+            "HIGH"
+          ],
+          "type": "string"
+        }
+      }
+    },
+    "Journey": {
+      "required": [
+        "allowCrowdReporting",
+        "notes",
+        "productNumbers",
+        "source",
+        "stops"
+      ],
+      "type": "object",
+      "properties": {
+        "notes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Note"
+          }
+        },
+        "productNumbers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "stops": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/JourneyStop"
+          }
+        },
+        "allowCrowdReporting": {
+          "type": "boolean"
+        },
+        "source": {
+          "type": "string"
+        }
+      }
+    },
+    "JourneyStop": {
+      "required": [
+        "arrivals",
+        "departures",
+        "id",
+        "nextStopId",
+        "previousStopId",
+        "stop"
+      ],
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "stop": {
+          "$ref": "#/definitions/Station"
+        },
+        "previousStopId": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "nextStopId": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destination": {
+          "type": "string"
+        },
+        "status": {
+          "enum": [
+            "ORIGIN",
+            "SPLIT",
+            "STOP",
+            "PASSING",
+            "COMBINE",
+            "DESTINATION",
+            "STOP_CHANGED_ORIGIN",
+            "STOP_CHANGED_DESTINATION"
+          ],
+          "type": "string"
+        },
+        "kind": {
+          "enum": [
+            "DEPARTURE",
+            "ARRIVAL",
+            "TRANSFER"
+          ],
+          "type": "string"
+        },
+        "arrivals": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ArrivalOrDeparture"
+          }
+        },
+        "departures": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ArrivalOrDeparture"
+          }
+        },
+        "actualStock": {
+          "$ref": "#/definitions/Stock"
+        },
+        "plannedStock": {
+          "$ref": "#/definitions/Stock"
+        },
+        "platformFeatures": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PlatformFeature"
+          }
+        },
+        "coachCrowdForecast": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CoachCrowdForecast"
+          }
+        }
+      }
+    },
+    "Part": {
+      "required": [
+        "facilities"
+      ],
+      "type": "object",
+      "properties": {
+        "stockIdentifier": {
+          "type": "string"
+        },
+        "destination": {
+          "$ref": "#/definitions/Station"
+        },
+        "facilities": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "image": {
+          "$ref": "#/definitions/StockPartLink"
+        }
+      }
+    },
+    "PlatformFeature": {
+      "required": [
+        "description",
+        "paddingLeft",
+        "type",
+        "width"
+      ],
+      "type": "object",
+      "properties": {
+        "paddingLeft": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "width": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "type": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "RepresentationResponseJourney": {
+      "required": [
+        "payload"
+      ],
+      "type": "object",
+      "properties": {
+        "payload": {
+          "$ref": "#/definitions/Journey"
+        },
+        "links": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Link"
+          }
+        },
+        "meta": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "Stock": {
+      "required": [
+        "hasSignificantChange",
+        "numberOfParts",
+        "numberOfSeats",
+        "trainParts"
+      ],
+      "type": "object",
+      "properties": {
+        "trainType": {
+          "type": "string"
+        },
+        "numberOfSeats": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "numberOfParts": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "trainParts": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Part"
+          }
+        },
+        "hasSignificantChange": {
+          "type": "boolean"
+        }
+      }
+    },
+    "StockPartLink": {
+      "required": [
+        "uri"
+      ],
+      "type": "object",
+      "properties": {
+        "uri": {
+          "type": "string"
+        }
+      }
+    },
+    "AlternatiefVervoer": {
+      "type": "object",
+      "properties": {
+        "beschrijving": {
+          "type": "string"
+        },
+        "begintijd": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "eindtijd": {
+          "format": "date-time",
+          "type": "string"
+        }
+      }
+    },
+    "Baanvak": {
+      "type": "object",
+      "properties": {
+        "stations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "BaanvakBeperking": {
+      "required": [
+        "tot",
+        "van"
+      ],
+      "type": "object",
+      "properties": {
+        "van": {
+          "$ref": "#/definitions/StationCode"
+        },
+        "tot": {
+          "$ref": "#/definitions/StationCode"
+        }
+      }
+    },
+    "Geldigheid": {
+      "type": "object",
+      "properties": {
+        "startDatum": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "eindDatum": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "startTijd": {
+          "type": "string"
+        },
+        "eindTijd": {
+          "type": "string"
+        }
+      }
+    },
+    "Gevolg": {
+      "type": "object",
+      "properties": {
+        "stations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "niveau": {
+          "enum": [
+            "GEEN_OF_VEEL_MINDER_TREINEN",
+            "MINDER_TREINEN",
+            "NORMAAL_AANTAL_OF_MEER_TREINEN"
+          ],
+          "type": "string"
+        }
+      }
+    },
+    "Melding": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "titel": {
+          "type": "string"
+        },
+        "beschrijving": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prio_1",
+            "prio_2",
+            "prio_3"
+          ],
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "buttonPositie": {
+          "enum": [
+            "beide",
+            "boven",
+            "onder"
+          ],
+          "type": "string"
+        },
+        "laatstGewijzigd": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "volgendeUpdate": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "bodyItems": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BodyItem"
+          }
+        },
+        "buttons": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Button"
+          }
+        }
+      }
+    },
+    "Reisadviezen": {
+      "required": [
+        "reisadvies"
+      ],
+      "type": "object",
+      "properties": {
+        "titel": {
+          "type": "string"
+        },
+        "reisadvies": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/VerstoringReisadvies"
+          }
+        }
+      }
+    },
+    "RepresentationResponseListVerstoringContainer": {
+      "required": [
+        "payload"
+      ],
+      "type": "object",
+      "properties": {
+        "payload": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/VerstoringContainer"
+          }
+        },
+        "links": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Link"
+          }
+        },
+        "meta": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "StationCode": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "string"
+        }
+      }
+    },
+    "Traject": {
+      "type": "object",
+      "properties": {
+        "stations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "begintijd": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "eindtijd": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "richting": {
+          "enum": [
+            "VANUIT",
+            "NAAR",
+            "VANUIT_EN_NAAR",
+            "HEEN",
+            "HEEN_EN_TERUG"
+          ],
+          "type": "string"
+        },
+        "gevolg": {
+          "$ref": "#/definitions/Gevolg"
+        }
+      }
+    },
+    "Verstoring": {
+      "required": [
+        "geldigheidsLijst",
+        "landelijk",
+        "type"
+      ],
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "MELDING_PRIO_1",
+            "MELDING_PRIO_2",
+            "MELDING_PRIO_3",
+            "STORING",
+            "WERKZAAMHEID",
+            "EVENEMENT"
+          ],
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "baanvakBeperking": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BaanvakBeperking"
+          }
+        },
+        "reden": {
+          "type": "string"
+        },
+        "extraReistijd": {
+          "type": "string"
+        },
+        "leafletUrl": {
+          "type": "string"
+        },
+        "reisadviezen": {
+          "$ref": "#/definitions/Reisadviezen"
+        },
+        "geldigheidsLijst": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Geldigheid"
+          }
+        },
+        "verwachting": {
+          "type": "string"
+        },
+        "gevolg": {
+          "type": "string"
+        },
+        "gevolgType": {
+          "type": "string"
+        },
+        "fase": {
+          "type": "string"
+        },
+        "faseLabel": {
+          "type": "string"
+        },
+        "impact": {
+          "type": "integer"
+        },
+        "maatschappij": {
+          "type": "integer"
+        },
+        "alternatiefVervoer": {
+          "type": "string"
+        },
+        "alternatiefVervoerLijst": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AlternatiefVervoer"
+          }
+        },
+        "landelijk": {
+          "type": "boolean"
+        },
+        "oorzaak": {
+          "type": "string"
+        },
+        "header": {
+          "type": "string"
+        },
+        "meldtijd": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "periode": {
+          "type": "string"
+        },
+        "baanvakken": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Baanvak"
+          }
+        },
+        "trajecten": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Traject"
+          }
+        },
+        "versie": {
+          "type": "string"
+        },
+        "volgnummer": {
+          "type": "string"
+        },
+        "prioriteit": {
+          "format": "int32",
+          "type": "integer"
+        }
+      }
+    },
+    "VerstoringContainer": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prio_1",
+            "prio_2",
+            "prio_3",
+            "verstoring",
+            "werkzaamheid"
+          ],
+          "type": "string"
+        },
+        "titel": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "topic": {
+          "type": "string"
+        },
+        "melding": {
+          "$ref": "#/definitions/Melding"
+        },
+        "verstoring": {
+          "$ref": "#/definitions/Verstoring"
+        }
+      }
+    },
+    "VerstoringReisadvies": {
+      "required": [
+        "advies"
+      ],
+      "type": "object",
+      "properties": {
+        "titel": {
+          "type": "string"
+        },
+        "advies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "RepresentationResponseVerstoringContainer": {
+      "required": [
+        "payload"
+      ],
+      "type": "object",
+      "properties": {
+        "payload": {
+          "$ref": "#/definitions/VerstoringContainer"
+        },
+        "links": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Link"
+          }
+        },
+        "meta": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "Departure": {
+      "required": [
+        "cancelled",
+        "departureStatus",
+        "messages",
+        "name",
+        "product",
+        "routeStations",
+        "trainCategory"
+      ],
+      "type": "object",
+      "properties": {
+        "direction": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "plannedDateTime": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "plannedTimeZoneOffset": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "actualDateTime": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "actualTimeZoneOffset": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "plannedTrack": {
+          "type": "string"
+        },
+        "actualTrack": {
+          "type": "string"
+        },
+        "product": {
+          "$ref": "#/definitions/Product"
+        },
+        "trainCategory": {
+          "type": "string"
+        },
+        "cancelled": {
+          "type": "boolean"
+        },
+        "journeyDetailRef": {
+          "type": "string"
+        },
+        "routeStations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RouteStation"
+          }
+        },
+        "messages": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Message"
+          }
+        },
+        "departureStatus": {
+          "enum": [
+            "ON_STATION",
+            "INCOMING",
+            "DEPARTED",
+            "UNKNOWN"
+          ],
+          "type": "string"
+        }
+      }
+    },
+    "DeparturesPayload": {
+      "required": [
+        "departures",
+        "source"
+      ],
+      "type": "object",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "departures": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Departure"
+          }
+        }
+      }
+    },
+    "RepresentationResponseDeparturesPayload": {
+      "required": [
+        "payload"
+      ],
+      "type": "object",
+      "properties": {
+        "payload": {
+          "$ref": "#/definitions/DeparturesPayload"
+        },
+        "links": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Link"
+          }
+        },
+        "meta": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "RouteStation": {
+      "type": "object",
+      "properties": {
+        "uicCode": {
+          "type": "string"
+        },
+        "mediumName": {
+          "type": "string"
+        }
+      }
+    },
+    "Arrival": {
+      "required": [
+        "arrivalStatus",
+        "cancelled",
+        "messages",
+        "name",
+        "product",
+        "trainCategory"
+      ],
+      "type": "object",
+      "properties": {
+        "origin": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "plannedDateTime": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "plannedTimeZoneOffset": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "actualDateTime": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "actualTimeZoneOffset": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "plannedTrack": {
+          "type": "string"
+        },
+        "actualTrack": {
+          "type": "string"
+        },
+        "product": {
+          "$ref": "#/definitions/Product"
+        },
+        "trainCategory": {
+          "type": "string"
+        },
+        "cancelled": {
+          "type": "boolean"
+        },
+        "journeyDetailRef": {
+          "type": "string"
+        },
+        "messages": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Message"
+          }
+        },
+        "arrivalStatus": {
+          "enum": [
+            "ON_STATION",
+            "INCOMING",
+            "DEPARTED",
+            "UNKNOWN"
+          ],
+          "type": "string"
+        }
+      }
+    },
+    "ArrivalsPayload": {
+      "required": [
+        "arrivals",
+        "source"
+      ],
+      "type": "object",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "arrivals": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Arrival"
+          }
+        }
+      }
+    },
+    "RepresentationResponseArrivalsPayload": {
+      "required": [
+        "payload"
+      ],
+      "type": "object",
+      "properties": {
+        "payload": {
+          "$ref": "#/definitions/ArrivalsPayload"
+        },
+        "links": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Link"
+          }
+        },
+        "meta": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "CalamitiesResourceCalamity": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "titel": {
+          "type": "string"
+        },
+        "beschrijving": {
+          "type": "string"
+        },
+        "lastModified": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "type": {
+          "enum": [
+            "informatie",
+            "waarschuwing"
+          ],
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "buttonPositie": {
+          "enum": [
+            "boven",
+            "onder",
+            "beide"
+          ],
+          "type": "string"
+        },
+        "laatstGewijzigd": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "volgendeUpdate": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "calltoactionbuttons": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CallToActionButton"
+          }
+        },
+        "bodyitems": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CalamityBodyItem"
+          }
+        }
+      }
+    },
+    "CalamitiesResponse": {
+      "type": "object",
+      "properties": {
+        "calamiteit": {
+          "$ref": "#/definitions/CalamitiesResourceCalamity"
+        },
+        "meldingen": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CalamitiesResourceCalamity"
+          }
+        }
+      }
+    },
+    "CalamityBodyItem": {
+      "required": [
+        "objectType"
+      ],
+      "type": "object",
+      "properties": {
+        "objectType": {
+          "type": "string"
+        },
+        "content": {
+          "type": "string"
+        },
+        "titel": {
+          "type": "string"
+        },
+        "downloads": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Download"
+          }
+        },
+        "links": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Link"
+          }
+        }
+      }
+    },
+    "CallToActionButton": {
+      "type": "object",
+      "properties": {
+        "callToAction": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "primary",
+            "secondary",
+            "buy",
+            "print"
+          ],
+          "type": "string"
+        },
+        "voorleestitel": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "parameters": {},
+  "responses": {},
+  "securityDefinitions": {
+    "api_key": {
+      "type": "apiKey",
+      "in": "header",
+      "name": "Ocp-Apim-Subscription-Key"
+    }
+  },
+  "security": [
+    {
+      "apiKeyHeader": []
+    },
+    {
+      "apiKeyQuery": []
+    }
+  ],
+  "tags": []
+}

--- a/independent-publisher-connectors/Nederlandse Spoorwegen/apiProperties.json
+++ b/independent-publisher-connectors/Nederlandse Spoorwegen/apiProperties.json
@@ -1,0 +1,18 @@
+{
+  "properties": {
+    "connectionParameters": {
+      "api_key": {
+        "type": "securestring",
+        "uiDefinition": {
+          "displayName": "API Key",
+          "description": "The API Key for this api. Instructions on how to get the API key, go to https://apiportal.ns.nl/. THe product to choose is Ns-App",
+          "tooltip": "Provide your API Key",
+        }
+      }
+    },
+    "iconBrandColor": "#FFCC19",
+    "capabilities": [],
+    "publisher": "Miguel Verweij",
+    "stackOwner": "Nederlandse Spoorwegen"
+  }
+}


### PR DESCRIPTION
---
### When submitting a connector, please make sure that you follow the requirements below, otherwise your PR might be rejected. We want to make you have a well-built connector, a smooth certification experience, and your users are happy :) 

If this is your first time submitting to GitHub and you need some help, please sign up for this [session](https://forms.office.com/pages/responsepage.aspx?id=KtIy2vgLW0SOgZbwvQuRaXDXyCl9DkBHq4A2OG7uLpdUMTFJWFFGVUxBNUFZQjZWRUdaOE5BMFkwNS4u). 

- [x] I attest that the connector works and I verified by deploying and testing all the operations. 
- [x] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [x] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [x] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [x] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.

If you are an Independent Publisher, you must also attest to the following to ensure a smooth publishing process:
- [x] I have named this PR after the pattern of "Connector Name (Independent Publisher)" ex: HubSpot Marketing (Independent Publisher)
- [x] Within this PR markdown file, I have pasted screenshots that show: 3 unique operations (actions/triggers) working within a Flow. This can be in one flow or part of multiple flows. For each one of those flows, I have pasted in screenshots of the Flow succeeding. 
- [x] Within this PR markdown file, I have pasted in a screenshot from the Test operations section within the Custom Connector UI.
- [x] If the connector uses OAuth, I have provided detailed steps on how to create an app in the readme.md. 

![NederlandseSpoorwegenInFlow](https://user-images.githubusercontent.com/50626860/154795195-5550f33b-1a79-4dcc-9185-e59e05846ab6.png)
![NederlandseSpoorwegenTest](https://user-images.githubusercontent.com/50626860/154795198-42ec1840-f1af-4ac4-84fc-d7fad98e6740.png)

