### PR TITLE
Update security parameter for webhook response operation

### DIFF
--- a/certified-connectors/DocuSignDemo/apiDefinition.swagger.json
+++ b/certified-connectors/DocuSignDemo/apiDefinition.swagger.json
@@ -116,6 +116,7 @@
           }
         },
         "deprecated": false,
+        "security": [],
         "x-ms-visibility": "internal",
         "x-ms-no-generic-test": true
       }

--- a/certified-connectors/DocuSignDemo/script.csx
+++ b/certified-connectors/DocuSignDemo/script.csx
@@ -386,7 +386,7 @@ public class Script : ScriptBase
   private JObject CreateHookEnvelopeBodyTransformation(JObject original)
   {
     var body = new JObject();
-
+    
     var uriLogicApps = original["urlToPublishTo"]?.ToString();
     var uriLogicAppsBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(uriLogicApps ?? string.Empty));
     var notificationProxyUri = this.Context.CreateNotificationUri($"/webhook_response?logicAppsUri={uriLogicAppsBase64}");
@@ -399,7 +399,21 @@ public class Script : ScriptBase
     body["requiresAcknowledgement"] = "true";
     body["urlToPublishTo"] = notificationProxyUri.AbsoluteUri;
     body["name"] = original["name"]?.ToString();
-    body["envelopeEvents"] = original["envelopeEvents"]?.ToString();
+
+    var envelopeEvent = original["envelopeEvents"]?.ToString();
+    var envelopeEventsArray = new JArray();
+    envelopeEventsArray.Add(envelopeEvent);
+    body["envelopeEvents"] = envelopeEventsArray;
+
+    body["configurationType"] = "custom";
+    body["deliveryMode"] = "sim";
+    body["restv21"] = "true";
+    body["eventData"] = new JObject
+    {
+        ["version"] = "restv2.1",
+        ["format"] = "",
+        ["includeData"] = new JArray()
+    };
     body["includeSenderAccountasCustomField"] = "true";
     return body;
   }

--- a/certified-connectors/DocuSignDemo/script.csx
+++ b/certified-connectors/DocuSignDemo/script.csx
@@ -411,7 +411,7 @@ public class Script : ScriptBase
     body["eventData"] = new JObject
     {
         ["version"] = "restv2.1",
-        ["format"] = "",
+        ["format"] = "json",
         ["includeData"] = new JArray()
     };
     body["includeSenderAccountasCustomField"] = "true";


### PR DESCRIPTION
---
### When submitting a connector, please make sure that you follow the requirements below, otherwise your PR might be rejected. We want to make you have a well-built connector, a smooth certification experience, and your users are happy :) 

If this is your first time submitting to GitHub and you need some help, please sign up for this [session](https://forms.office.com/pages/responsepage.aspx?id=KtIy2vgLW0SOgZbwvQuRaXDXyCl9DkBHq4A2OG7uLpdUMTFJWFFGVUxBNUFZQjZWRUdaOE5BMFkwNS4u). 

Please note that we are experiencing a significant delay due to a high volume of connector submissions. It may take 1-2 weeks for us to provide comments for your connector.

- [x ] I attest that the connector works and I verified by deploying and testing all the operations. 
- [x ] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [ x] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [ x] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [ x] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.

If you are an Independent Publisher, you must also attest to the following to ensure a smooth publishing process:
- [ ] I have named this PR after the pattern of "Connector Name (Independent Publisher)" ex: HubSpot Marketing (Independent Publisher)
- [ ] Within this PR markdown file, I have pasted screenshots that show: 3 unique operations (actions/triggers) working within a Flow. This can be in one flow or part of multiple flows. For each one of those flows, I have pasted in screenshots of the Flow succeeding. 
- [ ] Within this PR markdown file, I have pasted in a screenshot from the Test operations section within the Custom Connector UI.
- [ ] If the connector uses OAuth, I have provided detailed steps on how to create an app in the readme.md. 


