### PR TITLE
RegEx Matching (Independent Publisher)

### DIFF
--- a/independent-publisher-connectors/RegEx Matching/apiDefinition.swagger.json
+++ b/independent-publisher-connectors/RegEx Matching/apiDefinition.swagger.json
@@ -277,7 +277,7 @@
             "name": "text",
             "in": "query",
             "required": true,
-            "type": "integer",
+            "type": "string",
             "x-ms-visibility": "important",
             "x-ms-summary": "text",
             "description": "Enter text to match with the pattern"


### PR DESCRIPTION
Changed input type from  integer to string for one of the operations

<img width="462" alt="Screenshot_RegEx_CreateFlow_001" src="https://user-images.githubusercontent.com/106451522/173831471-849edaff-8018-4b21-b37d-672577c5d1a6.PNG">
<img width="688" alt="Screenshot_RegEx_CreateFlow_002" src="https://user-images.githubusercontent.com/106451522/173831476-edbc94ca-c727-4895-a2c5-b5f31bffc642.PNG">
<img width="463" alt="Screenshot_RegEx_ActionList" src="https://user-images.githubusercontent.com/106451522/173831478-b24167ac-d428-429c-b277-93a2dde6649e.PNG">
<img width="589" alt="Screenshot_RegEx_SuccessResult_001" src="https://user-images.githubusercontent.com/106451522/173831482-77f1c9d6-a759-43ed-a21d-27500e0c4ecb.PNG">
<img width="555" alt="Screenshot_RegEx_SuccessResult_002" src="https://user-images.githubusercontent.com/106451522/173831486-b04a7fa0-aad2-4415-8809-490f094b5701.PNG">
<img width="419" alt="Screenshot_RegEx_CreateFlow_003" src="https://user-images.githubusercontent.com/106451522/173831490-611b7a04-387a-454f-838c-9170e829f316.PNG">
<img width="446" alt="Screenshot_RegEx_SuccessResult_003" src="https://user-images.githubusercontent.com/106451522/173831494-18f4ce75-5e75-487a-b40b-33734b0793e1.PNG">
<img width="507" alt="Screenshot_RegEx_TestCLI" src="https://user-images.githubusercontent.com/106451522/173831495-bd405fcd-e077-4e56-9a05-c641996a9866.PNG">


---
### When submitting a connector, please make sure that you follow the requirements below, otherwise your PR might be rejected. We want to make you have a well-built connector, a smooth certification experience, and your users are happy :) 

If this is your first time submitting to GitHub and you need some help, please sign up for this [session](https://forms.office.com/pages/responsepage.aspx?id=KtIy2vgLW0SOgZbwvQuRaXDXyCl9DkBHq4A2OG7uLpdUMTFJWFFGVUxBNUFZQjZWRUdaOE5BMFkwNS4u). 

- [ ] I attest that the connector doesn't exist on the Power Platform today. I've verified by checking the pull requests in GitHub and by searching for the connector on the platform or in the documentation. 
- [x] I attest that the connector works and I verified by deploying and testing all the operations. 
- [x] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [x] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [x] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [x] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.

If you are an Independent Publisher, you must also attest to the following to ensure a smooth publishing process:
- [ ] I have named this PR after the pattern of "Connector Name (Independent Publisher)" ex: HubSpot Marketing (Independent Publisher)
- [x] Within this PR markdown file, I have pasted screenshots that show: 3 unique operations (actions/triggers) working within a Flow. This can be in one flow or part of multiple flows. For each one of those flows, I have pasted in screenshots of the Flow succeeding. 
- [x] Within this PR markdown file, I have pasted in a screenshot from the Test operations section within the Custom Connector UI.
- [ ] If the connector uses OAuth, I have provided detailed steps on how to create an app in the readme.md. 


