### PR TITLE
make Status always return JSON

### DIFF
--- a/certified-connectors/sms77io/apiDefinition.swagger.json
+++ b/certified-connectors/sms77io/apiDefinition.swagger.json
@@ -771,29 +771,36 @@
           "status"
         ],
         "produces": [
-          "text/plain; charset=utf-8",
           "application/json"
         ],
         "parameters": [
           {
             "in": "query",
             "name": "msg_id",
-            "description": "The ID from the SMS to check",
+            "description": "A comma separated list of SMS IDs to check",
             "required": true,
             "type": "string",
             "x-ms-summary": "Message ID"
+          },
+          {
+            "default": "application/json",
+            "in": "header",
+            "name": "Accept",
+            "required": true,
+            "type": "string",
+            "x-ms-visibility": "internal"
           }
         ],
         "responses": {
           "200": {
             "description": "Success",
             "schema": {
-              "$ref": "#/definitions/StatusJsonResponse"
+              "$ref": "#/definitions/SmsStatus"
             }
           }
         },
         "summary": "Get SMS Status",
-        "description": "Retrieves dispatch status for a given SMS ID",
+        "description": "Retrieves dispatch status for given SMS IDs",
         "operationId": "Status"
       }
     },
@@ -1039,7 +1046,7 @@
       },
       "type": "object"
     },
-    "StatusJsonResponse": {
+    "SmsStatus": {
       "items": {
         "properties": {
           "id": {


### PR DESCRIPTION
- [x ] I attest that the connector doesn't exist on the Power Platform today. I've verified by checking the pull requests in GitHub and by searching for the connector on the platform or in the documentation. 
- [x ] I attest that the connector works and I verified by deploying and testing all the operations. 
- [x ] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [ x] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [x ] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [ x] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.


