### PR TITLE
Meisterplan Connector: Removed securityDefinitions from swagger json

### DIFF
--- a/certified-connectors/Meisterplan/apiDefinition.swagger.json
+++ b/certified-connectors/Meisterplan/apiDefinition.swagger.json
@@ -4824,19 +4824,6 @@
       }
     }
   },
-  "securityDefinitions": {
-    "API-Token": {
-      "type": "apiKey",
-      "name": "Authorization",
-      "in": "header"
-    },
-    "OAuth": {
-      "type": "oauth2",
-      "authorizationUrl": "https://oauth.meisterplan.com/oauth/authorize",
-      "tokenUrl": "https://oauth.meisterplan.com/oauth/token",
-      "flow": "accessCode"
-    }
-  },
   "definitions": {
     "ActualTimeWorkedCreateOrUpdateRequest": {
       "type": "object",


### PR DESCRIPTION
- the definied securityDefinitions caused the issue that the authorization header was not added to the requests resulting in 401 unauthorized results

