### PR TITLE
Add transformJsonata operation to Morf connector

### DIFF
--- a/certified-connectors/Morf/Readme.md
+++ b/certified-connectors/Morf/Readme.md
@@ -24,6 +24,18 @@ and returns:
 
 * `Form`: A portable rendered form document (HTML) that can be rendered in browser environments.
 
+### Transform JSONata (V1)
+Transform JSON data using JSONata. Call this API with a JSON payload and a [JSONata](https://jsonata.org/) query or transformation expression to receive the modified data or query result
+
+The operation accepts:
+
+* `JSON Data`: A JSON data payload being submitted for querying or transformation
+* `JSONata Expression`: A [JSONata](https://jsonata.org/) query or transformation expression to execute against the JSON data payload
+
+and returns:
+
+* `Result`: Result of the expression execution containing a string or a stringified object (JSON).
+
 ## Obtaining Credentials
 To get started, head over to our [Morf Editor](https://editor.getmorf.io/) and request access keys. You will be granted one (1) site and one (1) API key. As described in our [authentication documentation](https://github.com/aftialabs/morf-docs/blob/main/guides/Authentication.md), use the provided API key when configuring your new Power Platform connection. Our free usage terms are available [here](https://github.com/aftialabs/morf-docs/blob/main/guides/termsandconditions.md#product-description).
 

--- a/certified-connectors/Morf/apiDefinition.swagger.json
+++ b/certified-connectors/Morf/apiDefinition.swagger.json
@@ -26,14 +26,14 @@
     }
   ],
   "host": "api.getmorf.io",
-  "basePath": "/v1",
+  "basePath": "/",
   "schemes": [
     "https"
   ],
   "consumes": [],
   "produces": [],
   "paths": {
-    "/": {
+    "/v1": {
       "post": {
         "summary": "Render a new Morf data capture experience (V1)",
         "description": "Call this API with a Morf form definition and optionally data to receive a prefilled form document that can be presented to a user in a browser context.",
@@ -68,17 +68,60 @@
               "$ref": "#/definitions/RenderResponse"
             }
           },
+          "400": {
+            "$ref": "#/responses/BadRequest"
+          },
           "401": {
-            "description": "Invalid Authentication",
-            "schema": {
-              "$ref": "#/definitions/ServiceException"
-            }
+            "$ref": "#/responses/InvalidAuthentication"
           },
           "500": {
-            "description": "Render Error",
+            "$ref": "#/responses/RenderError"
+          }
+        }
+      }
+    },
+    "/transformation/v1/transform/jsonata": {
+      "post": {
+        "summary": "Transform a JSON payload using JSONata (V1)",
+        "description": "Call this API with a JSON payload and a JSONata query or transformation expression to receive the modified data or query result.",
+        "operationId": "transformJsonata",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "transformation",
             "schema": {
-              "$ref": "#/definitions/ServiceException"
+              "$ref": "#/definitions/TransformationRequest"
+            },
+            "description": "A data transformation request",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "API-Key": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A transformation response",
+            "schema": {
+              "$ref": "#/definitions/TransformationResponse"
             }
+          },
+          "400": {
+            "$ref": "#/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/responses/InvalidAuthentication"
+          },
+          "500": {
+            "$ref": "#/responses/RenderError"
           }
         }
       }
@@ -109,6 +152,43 @@
       "description": "Rendered Morf HTML",
       "x-ms-summary": "Form"
     },
+    "TransformationRequest": {
+      "type": "object",
+      "required": [
+        "data",
+        "expression"
+      ],
+      "properties": {
+        "data": {
+          "type": "string",
+          "description": "Data to be queried or transformed",
+          "x-ms-summary": "JSON Data",
+          "x-ms-visibility": "important"
+        },
+        "expression": {
+          "type": "string",
+          "description": "JSONata expression to to execute against the data. See https://jsonata.org/",
+          "x-ms-summary": "JSONata Expression",
+          "x-ms-visibility": "important"
+
+        }
+      }
+    },
+    "TransformationResponse": {
+      "type": "object",
+      "description": "A transformation response object",
+      "x-ms-summary": "Response",
+      "required": [
+        "result"
+      ],
+      "properties": {
+        "result": {
+          "type": "string",
+          "description": "Result of the expression execution containing a string or a stringified object.",
+          "x-ms-summary": "Result"
+        }
+      }
+    },
     "ServiceException": {
       "type": "object",
       "description": "A server exception object",
@@ -134,7 +214,26 @@
     }
   },
   "parameters": {},
-  "responses": {},
+  "responses": {
+    "BadRequest": {
+      "description": "Bad Request",
+      "schema": {
+        "$ref": "#/definitions/ServiceException"
+      }
+    },
+    "InvalidAuthentication": {
+      "description": "Invalid Authentication",
+      "schema": {
+        "$ref": "#/definitions/ServiceException"
+      }
+    },
+    "RenderError": {
+      "description": "Render Error",
+      "schema": {
+        "$ref": "#/definitions/ServiceException"
+      }
+    }
+  },
   "securityDefinitions": {
     "API-Key": {
       "type": "apiKey",

--- a/certified-connectors/Morf/apiProperties.json
+++ b/certified-connectors/Morf/apiProperties.json
@@ -5,8 +5,8 @@
         "type": "securestring",
         "uiDefinition": {
           "displayName": "API Key",
-          "description": "The API Key for this api",
-          "tooltip": "Provide your API Key",
+          "description": "The API Key for this service. Get your API key from https://getmorf.io/mspa",
+          "tooltip": "Provide your API key. Get your API key from https://getmorf.io/mspa",
           "constraints": {
             "tabIndex": 2,
             "clearText": false,


### PR DESCRIPTION
---
### Add transformJsonata operation to Morf connector

- [x] I attest that the connector doesn't exist on the Power Platform today. I've verified by checking the pull requests in GitHub and by searching for the connector on the platform or in the documentation. 
- [x] I attest that the connector works and I verified by deploying and testing all the operations. 
- [x] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [x] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [x] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [x] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.

If you are an Independent Publisher, you must also attest to the following to ensure a smooth publishing process:
- [ ] I have named this PR after the pattern of "Connector Name (Independent Publisher)" ex: HubSpot Marketing (Independent Publisher)
- [ ] Within this PR markdown file, I have pasted screenshots that show: 3 unique operations (actions/triggers) working within a Flow. This can be in one flow or part of multiple flows. For each one of those flows, I have pasted in screenshots of the Flow succeeding. 
- [ ] Within this PR markdown file, I have pasted in a screenshot from the Test operations section within the Custom Connector UI.
- [ ] If the connector uses OAuth, I have provided detailed steps on how to create an app in the readme.md. 

#### Notes
- `basePath` was modified but the URI of the API was not. Both `basePath` and the `render` operation `paths` properties were updated accordingly.

