### PR TITLE
Post method for downloading attachments has been replaced with Get

### DIFF
--- a/certified-connectors/Plumsail Forms/apiDefinition.swagger.json
+++ b/certified-connectors/Plumsail Forms/apiDefinition.swagger.json
@@ -10,7 +10,7 @@
     },
     "version": "v5"
   },
-  "host": "forms.plumsail.com",
+  "host": "forms-api.plumsail.com",
   "basePath": "/",
   "schemes": [
     "https"
@@ -19,6 +19,40 @@
   "produces": [],
   "paths": {
     "/api/attachments": {
+      "get": {
+        "tags": [
+          "Attachments"
+        ],
+        "operationId": "DownloadAttachment",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fileUrl",
+            "required": true,
+            "type": "string",
+            "format": "uri",
+            "x-ms-summary": "File URL",
+            "description": "File URL"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The contents of the attachment",
+            "schema": {
+              "format": "binary",
+              "title": "Result file",
+              "description": "The contents of the attachment",
+              "type": "string"
+            }
+          }
+        },
+        "x-ms-visibility": "important",
+        "summary": "Download attachment",
+        "description": "Downloads an attachment by its URL"
+      },
       "delete": {
         "tags": [
           "Attachments"
@@ -51,40 +85,6 @@
         "x-ms-visibility": "important",
         "summary": "Delete attachment",
         "description": "Deletes an attachment by its URL"
-      },
-      "post": {
-        "tags": [
-          "Attachments"
-        ],
-        "operationId": "DownloadAttachmentPost",
-        "produces": [
-          "application/octet-stream"
-        ],
-        "parameters": [
-          {
-            "in": "query",
-            "name": "fileUrl",
-            "required": true,
-            "type": "string",
-            "format": "uri",
-            "x-ms-summary": "File URL",
-            "description": "File URL"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "The contents of the attachment",
-            "schema": {
-              "format": "binary",
-              "title": "Result file",
-              "description": "The contents of the attachment",
-              "type": "string"
-            }
-          }
-        },
-        "x-ms-visibility": "important",
-        "summary": "Download attachment",
-        "description": "Downloads an attachment by its URL"
       }
     },
     "/api/v{version}/designer/forms": {


### PR DESCRIPTION
- [x] I attest that the connector works and I verified by deploying and testing all the operations. 
- [x] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [x] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [x] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [x] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.
