### PR TITLE
Fix value of iconBrandColor for independent connectors

### DIFF
--- a/independent-publisher-connectors/Atlassian Jira/apiProperties.json
+++ b/independent-publisher-connectors/Atlassian Jira/apiProperties.json
@@ -39,7 +39,7 @@
         }
       }
     },
-    "iconBrandColor": "#0052CC",
+    "iconBrandColor": "#da3b01",
     "capabilities": [],
     "policyTemplateInstances": [
       {

--- a/independent-publisher-connectors/Brønnøysundregistrene/apiProperties.json
+++ b/independent-publisher-connectors/Brønnøysundregistrene/apiProperties.json
@@ -4,6 +4,6 @@
     "iconBrandColor": "#da3b01",
     "capabilities": [],
     "publisher": "Ahmad Najjar",
-    "stackOwner": "Brønnøysundregistrene (Brønnøysund registries)"
+    "stackOwner": "Bronnoysundregistrene (Bronnoysund registries)"
   }
 }

--- a/independent-publisher-connectors/Brønnøysundregistrene/apiProperties.json
+++ b/independent-publisher-connectors/Brønnøysundregistrene/apiProperties.json
@@ -4,6 +4,6 @@
     "iconBrandColor": "#da3b01",
     "capabilities": [],
     "publisher": "Ahmad Najjar",
-    "stackOwner": "Br�nn�ysundregistrene (Br�nn�ysund registries)"
+    "stackOwner": "Brønnøysundregistrene (Brønnøysund registries)"
   }
 }

--- a/independent-publisher-connectors/Brønnøysundregistrene/apiProperties.json
+++ b/independent-publisher-connectors/Brønnøysundregistrene/apiProperties.json
@@ -1,9 +1,9 @@
 {
   "properties": {
     "connectionParameters": {},
-    "iconBrandColor": "#0B576F",
+    "iconBrandColor": "#da3b01",
     "capabilities": [],
     "publisher": "Ahmad Najjar",
-    "stackOwner": "Brønnøysundregistrene (Brønnøysund registries)"
+    "stackOwner": "Brï¿½nnï¿½ysundregistrene (Brï¿½nnï¿½ysund registries)"
   }
 }

--- a/independent-publisher-connectors/Care Quaility Comission For England/apiProperties.json
+++ b/independent-publisher-connectors/Care Quaility Comission For England/apiProperties.json
@@ -1,7 +1,7 @@
 {
   "properties": {
     "connectionParameters": {},
-    "iconBrandColor": "#000000",
+    "iconBrandColor": "#da3b01",
     "capabilities": [],
     "publisher": "Martyn Lesbirel",
     "website": "https://anypoint.mulesoft.com/exchange/portals/care-quality-commission-5/",

--- a/independent-publisher-connectors/ChuckNorris.io/apiProperties.json
+++ b/independent-publisher-connectors/ChuckNorris.io/apiProperties.json
@@ -1,7 +1,7 @@
 {
   "properties": {
     "connectionParameters": {},
-    "iconBrandColor": "#000000",
+    "iconBrandColor": "#da3b01",
     "capabilities": [],
     "publisher": "Daniel Laskewitz",
     "stackOwner": "ChuckNorris.io"

--- a/independent-publisher-connectors/DPIRD Radar/apiProperties.json
+++ b/independent-publisher-connectors/DPIRD Radar/apiProperties.json
@@ -15,7 +15,7 @@
         }
       }
     },
-    "iconBrandColor": "#0052CC",
+    "iconBrandColor": "#da3b01",
     "capabilities": [],
     "publisher": "Paul Culmsee",
     "stackOwner" : "Department of Primary Industries and Regional Development (DPIRD)"

--- a/independent-publisher-connectors/DPIRD Science/apiProperties.json
+++ b/independent-publisher-connectors/DPIRD Science/apiProperties.json
@@ -15,7 +15,7 @@
         }
       }
     },
-    "iconBrandColor": "#0052CC",
+    "iconBrandColor": "#da3b01",
     "capabilities": [],
     "policyTemplateInstances": [
       {

--- a/independent-publisher-connectors/DPIRD Weather/apiProperties.json
+++ b/independent-publisher-connectors/DPIRD Weather/apiProperties.json
@@ -15,7 +15,7 @@
         }
       }
     },
-    "iconBrandColor": "#0052CC",
+    "iconBrandColor": "#da3b01",
     "capabilities": [],
     "policyTemplateInstances": [
       {

--- a/independent-publisher-connectors/Discord/apiProperties.json
+++ b/independent-publisher-connectors/Discord/apiProperties.json
@@ -27,7 +27,7 @@
         }
       }
     },
-    "iconBrandColor": "#000000",
+    "iconBrandColor": "#da3b01",
     "capabilities": [],
     "publisher": "Daniel Laskewitz | Sogeti",
     "stackOwner": "Discord"

--- a/independent-publisher-connectors/EONET by NASA/apiProperties.json
+++ b/independent-publisher-connectors/EONET by NASA/apiProperties.json
@@ -15,7 +15,7 @@
         }
       }
     },
-    "iconBrandColor": "#0B3D91",
+    "iconBrandColor": "#da3b01",
     "capabilities": [],
     "publisher": "Troy Taylor, Hitachi Solutions",
     "stackOwner": "NASA"

--- a/independent-publisher-connectors/Etsy/apiProperties.json
+++ b/independent-publisher-connectors/Etsy/apiProperties.json
@@ -15,7 +15,7 @@
         }
       }
     },
-    "iconBrandColor": "#ED6100",
+    "iconBrandColor": "#da3b01",
     "capabilities": [],
     "publisher": "Troy Taylor, Hitachi Solutions",
     "stackOwner": "Etsy"

--- a/independent-publisher-connectors/Festivo/apiProperties.json
+++ b/independent-publisher-connectors/Festivo/apiProperties.json
@@ -15,7 +15,7 @@
         }
       }
     },
-    "iconBrandColor": "#007ee5",
+    "iconBrandColor": "#da3b01",
     "capabilities": [],
     "publisher": "Troy Taylor",
     "stackOwner": "Festivo"

--- a/independent-publisher-connectors/Hashify/apiProperties.json
+++ b/independent-publisher-connectors/Hashify/apiProperties.json
@@ -1,7 +1,7 @@
 {
   "properties": {
     "connectionParameters": {},
-    "iconBrandColor": "#7C8083",
+    "iconBrandColor": "#da3b01",
     "capabilities": [],
     "publisher": "Troy Taylor, Hitachi Solutions",
     "stackOwner": "Hashify.net"

--- a/independent-publisher-connectors/MyHospitals by AIHW/apiProperties.json
+++ b/independent-publisher-connectors/MyHospitals by AIHW/apiProperties.json
@@ -1,7 +1,7 @@
 {
   "properties": {
     "connectionParameters": {},
-    "iconBrandColor": "#007ee5",
+    "iconBrandColor": "#da3b01",
     "capabilities": [],
     "policyTemplateInstances": [{
         "templateId": "convertobjecttoarray",

--- a/independent-publisher-connectors/OpenWeather/apiProperties.json
+++ b/independent-publisher-connectors/OpenWeather/apiProperties.json
@@ -15,7 +15,7 @@
         }
       }
     },
-    "iconBrandColor": "#000000",
+    "iconBrandColor": "#da3b01",
     "capabilities": [],
     "publisher": "Mahbub Murshed"
   }

--- a/independent-publisher-connectors/Placedog/apiProperties.json
+++ b/independent-publisher-connectors/Placedog/apiProperties.json
@@ -1,7 +1,7 @@
 {
   "properties": {
     "connectionParameters": {},
-    "iconBrandColor": "#343A40",
+    "iconBrandColor": "#da3b01",
     "capabilities": [],
     "publisher": "Troy Taylor, Hitachi Solutions",
     "stackOwner": "Placedog.net"

--- a/independent-publisher-connectors/Revue/apiProperties.json
+++ b/independent-publisher-connectors/Revue/apiProperties.json
@@ -15,7 +15,7 @@
         }
       }
     },
-    "iconBrandColor": "#000000",
+    "iconBrandColor": "#da3b01",
     "capabilities": [],
     "publisher": "Daniel Laskewitz",
     "stackOwner": "Revue (Owned by Twitter, Inc.)"

--- a/independent-publisher-connectors/Secure Code Warrior/apiProperties.json
+++ b/independent-publisher-connectors/Secure Code Warrior/apiProperties.json
@@ -15,7 +15,7 @@
         }
       }
     },
-    "iconBrandColor": "#F79200",
+    "iconBrandColor": "#da3b01",
     "capabilities": [],
     "publisher": "Troy Taylor, Hitachi Solutions",
     "stackOwner": "Secure Code Warrior"

--- a/independent-publisher-connectors/Spotify/apiProperties.json
+++ b/independent-publisher-connectors/Spotify/apiProperties.json
@@ -29,7 +29,7 @@
         }
       }
     },
-    "iconBrandColor": "#000000",
+    "iconBrandColor": "#da3b01",
     "capabilities": [],
     "publisher": "Daniel Laskewitz",
     "stackOwner": "Spotify"

--- a/independent-publisher-connectors/Synthesia/apiProperties.json
+++ b/independent-publisher-connectors/Synthesia/apiProperties.json
@@ -15,7 +15,7 @@
         }
       }
     },
-    "iconBrandColor": "#007ee5",
+    "iconBrandColor": "#da3b01",
     "capabilities": [],
     "publisher": "Troy Taylor",
     "stackOwner": "Synthesia"

--- a/independent-publisher-connectors/The Lord of the Rings/apiProperties.json
+++ b/independent-publisher-connectors/The Lord of the Rings/apiProperties.json
@@ -15,7 +15,7 @@
         }
       }
     },
-    "iconBrandColor": "#007ee5",
+    "iconBrandColor": "#da3b01",
     "capabilities": [],
     "publisher": "Troy Taylor",
     "stackOwner": "Ulrike Exner"

--- a/independent-publisher-connectors/Toggl Plan/apiProperties.json
+++ b/independent-publisher-connectors/Toggl Plan/apiProperties.json
@@ -27,7 +27,7 @@
         }
       }
     },
-    "iconBrandColor": "#000000",
+    "iconBrandColor": "#da3b01",
     "capabilities": [ ],
     "policyTemplateInstances": [
       {

--- a/independent-publisher-connectors/U.K. Government Bank Holidays/apiProperties.json
+++ b/independent-publisher-connectors/U.K. Government Bank Holidays/apiProperties.json
@@ -1,7 +1,7 @@
 {
   "properties": {
     "connectionParameters": {},
-    "iconBrandColor": "#000000",
+    "iconBrandColor": "#da3b01",
     "capabilities": [],
     "publisher": "Martyn Lesbirel",
     "stackOwner": "United Kingdom Government"

--- a/independent-publisher-connectors/XSOAR/apiProperties.json
+++ b/independent-publisher-connectors/XSOAR/apiProperties.json
@@ -38,7 +38,7 @@
         }
       }
     },
-    "iconBrandColor": "#000000",
+    "iconBrandColor": "#da3b01",
     "capabilities": [ "actions" ],
     "publisher": "Landon Chelf",
     "stackOwner": "Palo Alto Networks",

--- a/independent-publisher-connectors/Yelp/apiProperties.json
+++ b/independent-publisher-connectors/Yelp/apiProperties.json
@@ -35,7 +35,7 @@
         }
       }
     ],
-    "iconBrandColor": "#D32323",
+    "iconBrandColor": "#da3b01",
     "capabilities": [],
     "publisher": "Ahmad Najjar",
     "stackOwner": "Yelp Inc."

--- a/independent-publisher-connectors/icanhazdadjoke/apiProperties.json
+++ b/independent-publisher-connectors/icanhazdadjoke/apiProperties.json
@@ -1,7 +1,7 @@
 {
   "properties": {
     "connectionParameters": {},
-    "iconBrandColor": "#000000",
+    "iconBrandColor": "#da3b01",
     "capabilities": [],
     "publisher": "Daniel Laskewitz",
     "stackOwner": "icanhazdadjoke.com"


### PR DESCRIPTION
According to the guidelines, the iconBrandColor for independent connectors must be `#da3b01`.