### PR TITLE
iMIS: Update brand color

### DIFF
--- a/certified-connectors/iMIS/apiProperties.json
+++ b/certified-connectors/iMIS/apiProperties.json
@@ -15,7 +15,7 @@
         }
       }
     },
-    "iconBrandColor": "#FCFCFC",
+    "iconBrandColor": "#00A9E0",
     "capabilities": [],
     "publisher": "Computer System Innovations, Inc.",
     "stackOwner": "Advanced Solutions International, Inc."


### PR DESCRIPTION
Fixed the brand color for the iMIS connector, per submission guidelines.

