### PR TITLE
Provide useful error message for PATCH support

### DIFF
--- a/certified-connectors/Blackbaud SKY Add-ins/script.csx
+++ b/certified-connectors/Blackbaud SKY Add-ins/script.csx
@@ -35,6 +35,14 @@ public class Script : ScriptBase
         var headers = json["headers"]?.ToString();
         var body = json["body"]?.ToString();
 
+        if (method.Equals("PATCH", StringComparison.OrdinalIgnoreCase))
+        {
+            // PATCH is not supported
+            var response = new HttpResponseMessage(HttpStatusCode.BadRequest);
+            response.Content = CreateJsonErrorResponse($"Unsupported HTTP method '{method}'");
+            return response;
+        }
+
         var uriBuilder = new UriBuilder("https://api.sky.blackbaud.com");
         uriBuilder.Path = path;
 
@@ -88,7 +96,7 @@ public class Script : ScriptBase
         }
     
         // set the request body
-        if (new [] {"PUT", "POST", "PATCH"}.Contains(method, StringComparer.OrdinalIgnoreCase) && (!string.IsNullOrWhiteSpace(body)))
+        if (new [] {"PUT", "POST"}.Contains(method, StringComparer.OrdinalIgnoreCase) && (!string.IsNullOrWhiteSpace(body)))
         {
             this.Context.Request.Content = CreateJsonContent(body);
         }


### PR DESCRIPTION
---
### When submitting a connector, please make sure that you follow the requirements below, otherwise your PR might be rejected. We want to make you have a well-built connector, a smooth certification experience, and your users are happy :) 

If this is your first time submitting to GitHub and you need some help, please sign up for this [session](https://forms.office.com/pages/responsepage.aspx?id=KtIy2vgLW0SOgZbwvQuRaXDXyCl9DkBHq4A2OG7uLpdUMTFJWFFGVUxBNUFZQjZWRUdaOE5BMFkwNS4u). 

- [x] I attest that the connector doesn't exist on the Power Platform today. I've verified by checking the pull requests in GitHub and by searching for the connector on the platform or in the documentation. 
- [x] I attest that the connector works and I verified by deploying and testing all the operations. 
- [x] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [x] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [x] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [x] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.

If you are an Independent Publisher, you must also attest to the following to ensure a smooth publishing process:
- [ ] I have named this PR after the pattern of "Connector Name (Independent Publisher)" ex: HubSpot Marketing (Independent Publisher)
- [ ] Within this PR markdown file, I have pasted screenshots that show: 3 unique operations (actions/triggers) working within a Flow. This can be in one flow or part of multiple flows. For each one of those flows, I have pasted in screenshots of the Flow succeeding. 
- [ ] Within this PR markdown file, I have pasted in a screenshot from the Test operations section within the Custom Connector UI.
- [ ] If the connector uses OAuth, I have provided detailed steps on how to create an app in the readme.md. 


