### PR TITLE
fixed lower case d to upper case D in "resultSetMetaData"

### DIFF
--- a/certified-connectors/snowflake/apiProperties.json
+++ b/certified-connectors/snowflake/apiProperties.json
@@ -48,15 +48,6 @@
       "Convert"
     ],
     "capabilities": [],
-    "policyTemplateInstances": [
-      {
-        "parameters": {
-          "x-ms-apimTemplateParameter.urlTemplate": "https://@connectionParameters('instanceURL')"
-        },
-        "templateId": "dynamichosturl",
-        "title": "instanceURL"
-      }
-    ],
     "publisher": "Koch, Rene",
     "stackOwner": "Snowflake Inc."
   }

--- a/certified-connectors/snowflake/script.csx
+++ b/certified-connectors/snowflake/script.csx
@@ -10,7 +10,7 @@ public class Script : ScriptBase
 
         // Check if the operation ID matches what is specified in the OpenAPI definition of the connector
         // Presence is enforced in swagger
-        var domain = this.Context.Request.Headers.GetValues("Domain").First();
+        var domain = this.Context.Request.Headers.GetValues("Inference").First();
 
         var uriBuilder = new UriBuilder(this.Context.Request.RequestUri);
         uriBuilder.Host = domain;

--- a/certified-connectors/snowflake/script.csx
+++ b/certified-connectors/snowflake/script.csx
@@ -30,13 +30,13 @@ public class Script : ScriptBase
             var contentAsJson = JObject.Parse(contentAsString);
 
             // check for parameters
-            if (contentAsJson["data"] == null || contentAsJson["resultSetMetadata"]==null)
+            if (contentAsJson["data"] == null || contentAsJson["resultSetMetaData"]==null)
             {
-                return createErrorResponse("resultSetMetadata or data parameter are empty!", HttpStatusCode.BadRequest);
+                return createErrorResponse("resultSetMetaData or data parameter are empty!", HttpStatusCode.BadRequest);
             }
 
             // get metadata
-            var cols = JArray.Parse(contentAsJson["resultSetMetadata"].ToString());
+            var cols = JArray.Parse(contentAsJson["resultSetMetaData"].ToString());
             var rows = JArray.Parse(contentAsJson["data"].ToString());
 
             JArray newRows = new JArray();

--- a/certified-connectors/snowflake/script.csx
+++ b/certified-connectors/snowflake/script.csx
@@ -10,7 +10,7 @@ public class Script : ScriptBase
 
         // Check if the operation ID matches what is specified in the OpenAPI definition of the connector
         // Presence is enforced in swagger
-        var domain = this.Context.Request.Headers.GetValues("Inference").First();
+        var domain = this.Context.Request.Headers.GetValues("Instance").First();
 
         var uriBuilder = new UriBuilder(this.Context.Request.RequestUri);
         uriBuilder.Host = domain;


### PR DESCRIPTION
---
### When submitting a connector, please make sure that you follow the requirements below, otherwise your PR might be rejected. We want to make you have a well-built connector, a smooth certification experience, and your users are happy :) 

If this is your first time submitting to GitHub and you need some help, please sign up for this [session](https://forms.office.com/pages/responsepage.aspx?id=KtIy2vgLW0SOgZbwvQuRaXDXyCl9DkBHq4A2OG7uLpdUMTFJWFFGVUxBNUFZQjZWRUdaOE5BMFkwNS4u). 

- [ ] I attest that the connector doesn't exist on the Power Platform today. I've verified by checking the pull requests in GitHub and by searching for the connector on the platform or in the documentation. 
- [ ] I attest that the connector works and I verified by deploying and testing all the operations. 
- [ ] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [ ] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [ ] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [ ] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.

If you are an Independent Publisher, you must also attest to the following to ensure a smooth publishing process:
- [ ] I have named this PR after the pattern of "Connector Name (Independent Publisher)" ex: HubSpot Marketing (Independent Publisher)
- [ ] Within this PR markdown file, I have pasted screenshots that show: 3 unique operations (actions/triggers) working within a Flow. This can be in one flow or part of multiple flows. For each one of those flows, I have pasted in screenshots of the Flow succeeding. 
- [ ] Within this PR markdown file, I have pasted in a screenshot from the Test operations section within the Custom Connector UI.
- [ ] If the connector uses OAuth, I have provided detailed steps on how to create an app in the readme.md. 


