### PR TITLE
Code fix for Snowflake connector in order to avoid 500 errors

### DIFF
--- a/certified-connectors/snowflake/apiDefinition.swagger.json
+++ b/certified-connectors/snowflake/apiDefinition.swagger.json
@@ -401,7 +401,7 @@
           "operationId": "ExecuteSqlStatement",
           "parameters": [
             {
-              "name": "Instance",
+              "name": "Instance -No https://",
               "in": "header",
               "type": "string",
               "required": true,

--- a/certified-connectors/snowflake/apiDefinition.swagger.json
+++ b/certified-connectors/snowflake/apiDefinition.swagger.json
@@ -401,7 +401,7 @@
           "operationId": "ExecuteSqlStatement",
           "parameters": [
             {
-              "name": "Instance -no https://",
+              "name": "Instance",
               "in": "header",
               "type": "string",
               "required": true,

--- a/certified-connectors/snowflake/apiDefinition.swagger.json
+++ b/certified-connectors/snowflake/apiDefinition.swagger.json
@@ -401,7 +401,7 @@
           "operationId": "ExecuteSqlStatement",
           "parameters": [
             {
-              "name": "Instance -No https://",
+              "name": "Instance -no https://",
               "in": "header",
               "type": "string",
               "required": true,

--- a/certified-connectors/snowflake/script.csx
+++ b/certified-connectors/snowflake/script.csx
@@ -10,7 +10,9 @@ public class Script : ScriptBase
 
         // Check if the operation ID matches what is specified in the OpenAPI definition of the connector
         // Presence is enforced in swagger
+        
         var domain = this.Context.Request.Headers.GetValues("Instance").First();
+        string pattern = "http";
         Match m = Regex.Match(domain,pattern,RegexOptions.IgnoreCase);
         if (m.Success) {
             string subs[] = domain.Split(':\\');

--- a/certified-connectors/snowflake/script.csx
+++ b/certified-connectors/snowflake/script.csx
@@ -11,7 +11,11 @@ public class Script : ScriptBase
         // Check if the operation ID matches what is specified in the OpenAPI definition of the connector
         // Presence is enforced in swagger
         var domain = this.Context.Request.Headers.GetValues("Instance").First();
-
+        Match m = Regex.Match(domain,pattern,RegexOptions.IgnoreCase);
+        if (m.Success) {
+            string subs[] = domain.Split(':\\');
+            domain = subs[1];
+        }
         var uriBuilder = new UriBuilder(this.Context.Request.RequestUri);
         uriBuilder.Host = domain;
         this.Context.Request.RequestUri = uriBuilder.Uri;


### PR DESCRIPTION
---
### When submitting a connector, please make sure that you follow the requirements below, otherwise your PR might be rejected. We want to make you have a well-built connector, a smooth certification experience, and your users are happy :) 

If this is your first time submitting to GitHub and you need some help, please sign up for this [session](https://forms.office.com/pages/responsepage.aspx?id=KtIy2vgLW0SOgZbwvQuRaXDXyCl9DkBHq4A2OG7uLpdUMTFJWFFGVUxBNUFZQjZWRUdaOE5BMFkwNS4u). 

- [ ] I attest that the connector doesn't exist on the Power Platform today. I've verified by checking the pull requests in GitHub and by searching for the connector on the platform or in the documentation. 
- [ ] I attest that the connector works and I verified by deploying and testing all the operations. 
- [ ] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [ ] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [ ] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [ ] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.

If you are an Independent Publisher, you must also attest to the following to ensure a smooth publishing process:
- [ ] I have named this PR after the pattern of "Connector Name (Independent Publisher)" ex: HubSpot Marketing (Independent Publisher)
- [ ] Within this PR markdown file, I have pasted screenshots that show: 3 unique operations (actions/triggers) working within a Flow. This can be in one flow or part of multiple flows. For each one of those flows, I have pasted in screenshots of the Flow succeeding. 
- [ ] Within this PR markdown file, I have pasted in a screenshot from the Test operations section within the Custom Connector UI.
- [ ] If the connector uses OAuth, I have provided detailed steps on how to create an app in the readme.md. 


