### PR TITLE
Fixed Airtable authentication

### DIFF
--- a/independent-publisher-connectors/Airtable/apiDefinition.swagger.json
+++ b/independent-publisher-connectors/Airtable/apiDefinition.swagger.json
@@ -394,8 +394,9 @@
   "securityDefinitions": {
     "API Key": {
       "type": "apiKey",
-      "in": "query",
-      "name": "api_key"
+      "in": "header",
+      "name": "Authorization",
+      "description": "Generate a personal access token from https://airtable.com/create/tokens. Prefix your token with 'Bearer ', e.g. 'Bearer abcdefg'"
     }
   },
   "security": [


### PR DESCRIPTION
Updated to include API token in the "Authorization" request header as described in https://airtable.com/developers/web/api/authentication.

Value must be prefixed with "Bearer ", e.g. "Bearer abcdefg"