### PR TITLE
Encodian - Sept 23 Release (Region Connection Update)

### DIFF
--- a/certified-connectors/Encodian/apiProperties.json
+++ b/certified-connectors/Encodian/apiProperties.json
@@ -11,13 +11,13 @@
         "type": "securestring",
         "uiDefinition": {
           "constraints": {
-            "clearText": true,
+            "clearText": false,
             "required": "true",
-            "tabIndex": 0
+            "tabIndex": 2
           },
           "description": "Get an API Key - https://www.encodian.com/apikey/",
           "displayName": "API Key",
-          "tooltip": "Provide your Encodian Flowr API Key"
+          "tooltip": "Provide your API Key"
         }
       },
       "region": {
@@ -26,36 +26,35 @@
           "displayName": "Region",
           "tooltip": "Select a data processing region",
           "constraints": {
-            "required": "true",
-			"tabIndex": 1,
+			"tabIndex": 3,
             "allowedValues": [
               {
                 "text": "Nearest (Fastest)",
-                "value": "api"
+                "value": "https://api.apps-encodian.com"
               },
               {
                 "text": "Australia",
-                "value": "aus-api"
+                "value": "https://aus-api.apps-encodian.com"
               },
               {
                 "text": "Canada",
-                "value": "can-api"
+                "value": "https://can-api.apps-encodian.com"
               },
               {
                 "text": "Europe - Germany",
-                "value": "ger-api"
+                "value": "https://ger-api.apps-encodian.com"
               },
               {
                 "text": "Europe - Switzerland",
-                "value": "swz-api"
+                "value": "https://swz-api.apps-encodian.com"
               },
               {
                 "text": "United Kingdom",
-                "value": "uk-api"
+                "value": "https://uk-api.apps-encodian.com"
               },
               {
                 "text": "United States",
-                "value": "us-api"
+                "value": "https://us-api.apps-encodian.com"
               }
             ]
           }
@@ -68,7 +67,7 @@
         "templateId": "dynamichosturl",
         "title": "Set region from connection parameter",
         "parameters": {
-		  "x-ms-apimTemplateParameter.urlTemplate": "https://@connectionParameters('region').apps-encodian.com"		  
+		  "x-ms-apimTemplateParameter.urlTemplate": "@connectionParameters('region','https://api.apps-encodian.com')"
         }
       }
     ]


### PR DESCRIPTION
- [X] I attest that the connector works and I verified by deploying and testing all the operations. 
- [X] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [X] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [X] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [X] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.

This update contains a fix for the apiProperties.json which prevents existing connections from breaking (where the 'region' property would not exist for an existing connection
