### PR TITLE
1.2: Elite ID login options; new host (api.elite.com); rebranding

### DIFF
--- a/certified-connectors/3E Events/apiDefinition.swagger.json
+++ b/certified-connectors/3E Events/apiDefinition.swagger.json
@@ -3,28 +3,28 @@
   "info": {
     "contact": {
       "name": "Elite Support",
-      "url": "https://legal.thomsonreuters.com/en/support"
+      "url": "https://elite.com/en/support"
     },
     "title": "3E Events",
     "description": "3E is a SaaS practice and financial management platform that connects all critical areas of a law firm to streamline tasks and provide timely information",
-    "version": "1.1"
+    "version": "1.2"
   },
   "x-ms-connector-metadata":[
     {
       "propertyName": "Website",
-      "propertyValue": "https://legal.thomsonreuters.com/en/products/3e"
+      "propertyValue": "https://www.elite.com/en/products/3e"
     },
     {
       "propertyName": "Privacy policy",
-      "propertyValue": "https://www.thomsonreuters.com/en/privacy-statement.html"
+      "propertyValue": "https://elite.com/en/privacy-statement.html"
     },
     {
       "propertyName": "Categories",
       "propertyValue": "Productivity;Business Management"
     }
   ],
-  "host": "api.us.3e.thomsonreuters.com",
-  "basePath": "/webhook",
+  "host": "api.elite.com",
+  "basePath": "/3e/events/webhook",
   "schemes": [
     "https"
   ],
@@ -269,7 +269,7 @@
                     },
                     "enterprise_user_id": {
                       "type": "string",
-                      "description": "The enterprise user ID of the user fired the DataObjectAttribute event.",
+                      "description": "The enterprise or federated user ID of the user fired the DataObjectAttribute event.",
                       "title": "Enteprise User ID"
                     }
                   },
@@ -493,7 +493,7 @@
                     },
                     "enterprise_user_id": {
                       "type": "string",
-                      "description": "The enterprise user ID of the user fired the WorkflowAction event.",
+                      "description": "The enterprise or federated user ID of the user fired the WorkflowAction event.",
                       "title": "Enteprise User ID"
                     }
                   },
@@ -1872,7 +1872,7 @@
         },
         "enterprise_user_id": {
           "type": "string",
-          "description": "The enterprise user ID of the user fired the DataObject event.",
+          "description": "The enterprise or federated user ID of the user fired the DataObject event.",
           "title": "Enteprise User ID"
         }
       },

--- a/certified-connectors/3E Events/apiProperties.json
+++ b/certified-connectors/3E Events/apiProperties.json
@@ -16,10 +16,10 @@
                 "value": "https://auth-nonprod.thomsonreuters.com/"
               },
               "authorizationUrlTemplate": {
-                "value": "https://{customHost}/webhook/v1/authorize"
+                "value": "https://{customHost}/3e/events/connector/v1/authorize"
               },
               "authorizationUrlQueryStringTemplate": {
-                "value": "?response_type=code&client_id={clientId}&scope={scopes}&redirect_uri={redirectUrl}&tenantId={tenantId}&state={State}&usePam={usePam}"
+                "value": "?response_type=code&client_id={clientId}&scope={scopes}&redirect_uri={redirectUrl}&3eInstanceId={3eInstanceId}&state={State}&usePam={usePam}"
               },
               "tokenUrlTemplate": {
                 "value": "{ciamAuthority}oauth/token"
@@ -57,16 +57,16 @@
           "tooltip": "Enter host domain."
         }
       },
-      "token:tenantId": {
+      "token:3eInstanceId": {
         "type": "string",
         "uiDefinition": {
           "constraints": {
             "required": "true",
             "tabIndex": 2
           },
-          "description": "The Tenant ID of the 3E instance.",
-          "displayName": "3E Tenant",
-          "tooltip": "Enter the 3E Instance TRS ID."
+          "description": "ID of the 3E instance.",
+          "displayName": "3E Instance ID",
+          "tooltip": "Enter the 3E Instance ID."
         }
       },
       "token:clientId": {
@@ -90,7 +90,7 @@
           },
           "description": "Client Secret.",
           "displayName": "Client Secret",
-          "tooltip": "Enter CIAM Client Id"
+          "tooltip": "Enter CIAM Client Secret"
         }
       },
       "token:notes": {
@@ -135,9 +135,339 @@
       },
       "values": [
         {
+          "name": "aadProd",
+          "uiDefinition": {
+            "displayName": "Production (Elite ID)",
+            "description": "Production (Elite ID)."
+          },
+          "metadata": {
+            "allowSharing": false
+          },
+          "parameters": {
+            "token": {
+              "type": "oauthSetting",
+              "oAuthSettings": {
+                "identityProvider": "oauth2generic",
+                "clientId": "[[DUMMY]]",
+                "clientSecret": "[[DUMMY]]",
+                "redirectMode": "Global",
+                "redirectUrl": "https://global.consent.azure-apim.net/redirect",
+                "scopes": [
+                  "https://elite.com/prod/live/3e/ewh.all",
+                  "offline_access",
+                  "openid",
+                  "profile"
+                ],
+                "customParameters": {
+                  "authorizationUrlTemplate": {
+                    "value": "https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize"
+                  },
+                  "authorizationUrlQueryStringTemplate": {
+                    "value": "?response_type=code&client_id={clientId}&scope={scopes}&redirect_uri={redirectUrl}&state={State}&prompt=select_account"
+                  },
+                  "tokenUrlTemplate": {
+                    "value": "https://login.microsoftonline.com/organizations/oauth2/v2.0/token"
+                  },
+                  "tokenBodyTemplate": {
+                    "value": "code={code}&grant_type=authorization_code&redirect_uri={redirectUrl}&client_id={clientId}&client_secret={clientSecret}"
+                  },
+                  "refreshUrlTemplate": {
+                    "value": "https://login.microsoftonline.com/organizations/oauth2/v2.0/token"
+                  },
+                  "refreshBodyTemplate": {
+                    "value": "code={code}&grant_type=refresh_token&refresh_token={refreshToken}&redirect_uri={redirectUrl}&client_id={clientId}&client_secret={clientSecret}"
+                  }
+                }
+              },
+              "uiDefinition": {
+                "displayName": "Sign in with your Azure Active Directory credentials",
+                "description": "Sign in with your Azure Active Directory credentials",
+                "tooltip": "Provide Azure Active Directory credentials",
+                "constraints": {
+                  "required": "false",
+                  "hidden": "false"
+                }
+              }
+            },
+            "token:3eInstanceId": {
+              "type": "string",
+              "uiDefinition": {
+                "description": "ID of the 3E instance.",
+                "displayName": "3E Instance ID",
+                "tooltip": "Enter the 3E Instance ID.",
+                "constraints": {
+                  "required": "true",
+                  "hidden": "false"
+                }
+              }
+            },
+            "token:customHost": {
+              "type": "string",
+              "defaultValue": "api.elite.com",
+              "uiDefinition": {
+                "constraints": {
+                  "required": "true",
+                  "tabIndex": 1,
+                  "hidden": "true",
+                  "allowedValues": [
+                    {
+                      "text": "default",
+                      "value": "api.elite.com"
+                    }
+                  ]
+                },
+                "description": "Select default to continue.",
+                "displayName": "Host",
+                "tooltip": "Select default to continue."
+              }
+            },
+            "token:notes": {
+              "type": "string",
+              "uiDefinition": {
+                "constraints": {
+                  "required": "false"
+                },
+                "description": "Notes for connection.",
+                "displayName": "Notes",
+                "tooltip": "Save your notes about this connection."
+              }
+            }
+          }
+        },
+        {
+          "name": "aadPreview",
+          "uiDefinition": {
+            "displayName": "Preview (Elite ID)",
+            "description": "Preview (Elite ID)."
+          },
+          "metadata": {
+            "allowSharing": false
+          },
+          "parameters": {
+            "token": {
+              "type": "oauthSetting",
+              "oAuthSettings": {
+                "identityProvider": "oauth2generic",
+                "clientId": "[[DUMMY]]",
+                "clientSecret": "[[DUMMY]]",
+                "redirectMode": "Global",
+                "redirectUrl": "https://global.consent.azure-apim.net/redirect",
+                "scopes": [
+                  "https://elite.com/prod/preview/3e/ewh.all",
+                  "offline_access",
+                  "openid",
+                  "profile"
+                ],
+                "customParameters": {
+                  "authorizationUrlTemplate": {
+                    "value": "https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize"
+                  },
+                  "authorizationUrlQueryStringTemplate": {
+                    "value": "?response_type=code&client_id={clientId}&scope={scopes}&redirect_uri={redirectUrl}&state={State}&prompt=select_account"
+                  },
+                  "tokenUrlTemplate": {
+                    "value": "https://login.microsoftonline.com/organizations/oauth2/v2.0/token"
+                  },
+                  "tokenBodyTemplate": {
+                    "value": "code={code}&grant_type=authorization_code&redirect_uri={redirectUrl}&client_id={clientId}&client_secret={clientSecret}"
+                  },
+                  "refreshUrlTemplate": {
+                    "value": "https://login.microsoftonline.com/organizations/oauth2/v2.0/token"
+                  },
+                  "refreshBodyTemplate": {
+                    "value": "code={code}&grant_type=refresh_token&refresh_token={refreshToken}&redirect_uri={redirectUrl}&client_id={clientId}&client_secret={clientSecret}"
+                  }
+                }
+              },
+              "uiDefinition": {
+                "displayName": "Sign in with your Azure Active Directory credentials",
+                "description": "Sign in with your Azure Active Directory credentials",
+                "tooltip": "Provide Azure Active Directory credentials",
+                "constraints": {
+                  "required": "false",
+                  "hidden": "false"
+                }
+              }
+            },
+            "token:3eInstanceId": {
+              "type": "string",
+              "uiDefinition": {
+                "description": "ID of the 3E instance.",
+                "displayName": "3E Instance ID",
+                "tooltip": "Enter the 3E Instance ID.",
+                "constraints": {
+                  "required": "true",
+                  "hidden": "false"
+                }
+              }
+            },
+            "token:customHost": {
+              "type": "string",
+              "defaultValue": "api.elite.com/preview",
+              "uiDefinition": {
+                "constraints": {
+                  "required": "true",
+                  "tabIndex": 1,
+                  "hidden": "true",
+                  "allowedValues": [
+                    {
+                      "text": "default",
+                      "value": "api.elite.com/preview"
+                    }
+                  ]
+                },
+                "description": "Select default to continue.",
+                "displayName": "Host",
+                "tooltip": "Select default to continue."
+              }
+            },
+            "token:notes": {
+              "type": "string",
+              "uiDefinition": {
+                "constraints": {
+                  "required": "false"
+                },
+                "description": "Notes for connection.",
+                "displayName": "Notes",
+                "tooltip": "Save your notes about this connection."
+              }
+            }
+          }
+        },
+        {
+          "name": "aadNonprod",
+          "uiDefinition": {
+            "displayName": "Development (For Elite use only) (Elite ID)",
+            "description": "For non-production Elite environments."
+          },
+          "metadata": {
+            "allowSharing": false
+          },
+          "parameters": {
+            "token": {
+              "type": "oauthSetting",
+              "oAuthSettings": {
+                "identityProvider": "oauth2generic",
+                "redirectMode": "Global",
+                "redirectUrl": "https://global.consent.azure-apim.net/redirect",
+                "customParameters": {
+                  "authorizationUrlTemplate": {
+                    "value": "https://login.microsoftonline.com/{tenantId}/oauth2/v2.0/authorize"
+                  },
+                  "authorizationUrlQueryStringTemplate": {
+                    "value": "?response_type=code&client_id={clientId}&scope={customScopes}&redirect_uri={redirectUrl}&state={State}&prompt=select_account"
+                  },
+                  "tokenUrlTemplate": {
+                    "value": "https://login.microsoftonline.com/{tenantId}/oauth2/v2.0/token"
+                  },
+                  "tokenBodyTemplate": {
+                    "value": "code={code}&grant_type=authorization_code&redirect_uri={redirectUrl}&client_id={clientId}&client_secret={clientSecret}"
+                  },
+                  "refreshUrlTemplate": {
+                    "value": "https://login.microsoftonline.com/{tenantId}/oauth2/v2.0/token"
+                  },
+                  "refreshBodyTemplate": {
+                    "value": "code={code}&grant_type=refresh_token&refresh_token={refreshToken}&redirect_uri={redirectUrl}&client_id={clientId}&client_secret={clientSecret}"
+                  }
+                }
+              },
+              "uiDefinition": {
+                "displayName": "Sign in with your Azure Active Directory credentials",
+                "description": "Sign in with your Azure Active Directory credentials",
+                "tooltip": "Provide Azure Active Directory credentials",
+                "constraints": {
+                  "required": "false",
+                  "hidden": "false"
+                }
+              }
+            },
+            "token:customHost": {
+              "type": "string",
+              "uiDefinition": {
+                "constraints": {
+                  "required": "true"
+                },
+                "description": "The APIM host domain.",
+                "displayName": "Host",
+                "tooltip": "Enter host domain, e.g. api.us.nprd.elite.com/dev"
+              }
+            },
+            "token:3eInstanceId": {
+              "type": "string",
+              "uiDefinition": {
+                "description": "ID of the 3E instance.",
+                "displayName": "3E Instance ID",
+                "tooltip": "Enter the 3E Instance ID.",
+                "constraints": {
+                  "required": "true",
+                  "hidden": "false"
+                }
+              }
+            },
+            "token:TenantId": {
+              "type": "string",
+              "metadata": {
+                "sourceType": "AzureActiveDirectoryTenant"
+              },
+              "uiDefinition": {
+                "displayName": "Tenant ID",
+                "description": "Tenant ID of your Azure Active Directory application.",
+                "constraints": {
+                  "required": "true",
+                  "hidden": "false"
+                }
+              }
+            },
+            "token:clientId": {
+              "type": "string",
+              "uiDefinition": {
+                "displayName": "Client ID",
+                "description": "Client (or Application) ID of your Azure Active Directory application.",
+                "constraints": {
+                  "required": "true",
+                  "hidden": "false"
+                }
+              }
+            },
+            "token:clientSecret": {
+              "type": "securestring",
+              "uiDefinition": {
+                "displayName": "Client Secret",
+                "description": "Client secret of your Azure Active Directory application.",
+                "constraints": {
+                  "required": "true",
+                  "hidden": "false"
+                }
+              }
+            },
+            "token:customScopes": {
+              "type": "string",
+              "uiDefinition": {
+                "displayName": "Scopes",
+                "description": "Please enter the scopes.",
+                "constraints": {
+                  "required": "true",
+                  "hidden": "false"
+                }
+              }
+            },
+            "token:notes": {
+              "type": "string",
+              "uiDefinition": {
+                "constraints": {
+                  "required": "false"
+                },
+                "description": "Notes for connection.",
+                "displayName": "Notes",
+                "tooltip": "Save your notes about this connection."
+              }
+            }
+          }
+        },
+        {
           "name": "liveus",
           "uiDefinition": {
-            "displayName": "Production - United States",
+            "displayName": "Production - United States (Deprecated)",
             "description": "Production - United States.",
             "constraints": {
               "hidden": "false"
@@ -168,10 +498,10 @@
                     "value": "{{liveusCustomClientSecret}}"
                   },
                   "authorizationUrlTemplate": {
-                    "value": "https://{customHost}/webhook/v1/authorize"
+                    "value": "https://{customHost}/3e/events/connector/v1/authorize"
                   },
                   "authorizationUrlQueryStringTemplate": {
-                    "value": "?response_type=code&client_id={clientId}&scope={scopes}&redirect_uri={redirectUrl}&tenantId={tenantId}&state={State}&usePam={usePam}"
+                    "value": "?response_type=code&client_id={clientId}&scope={scopes}&redirect_uri={redirectUrl}&3eInstanceId={3eInstanceId}&state={State}&usePam={usePam}"
                   },
                   "tokenUrlTemplate": {
                     "value": "{ciamAuthority}oauth/token"
@@ -199,15 +529,16 @@
             },
             "token:customHost": {
               "type": "string",
+              "defaultValue": "api.us.elite.com",
               "uiDefinition": {
                 "constraints": {
                   "required": "true",
                   "tabIndex": 1,
-                  "hidden": "false",
+                  "hidden": "true",
                   "allowedValues": [
                     {
                       "text": "default",
-                      "value": "api.us.3e.thomsonreuters.com"
+                      "value": "api.us.elite.com"
                     }
                   ]
                 },
@@ -216,16 +547,16 @@
                 "tooltip": "Select default to continue."
               }
             },
-            "token:tenantId": {
+            "token:3eInstanceId": {
               "type": "string",
               "uiDefinition": {
                 "constraints": {
                   "required": "true",
                   "tabIndex": 2
                 },
-                "description": "The Tenant ID of the 3E instance.",
-                "displayName": "3E Tenant",
-                "tooltip": "Enter the 3E Instance TRS ID."
+                "description": "ID of the 3E instance.",
+                "displayName": "3E Instance ID",
+                "tooltip": "Enter the 3E Instance ID."
               }
             },
             "token:notes": {
@@ -267,7 +598,7 @@
         {
           "name": "liveuks",
           "uiDefinition": {
-            "displayName": "Production - United Kingdom",
+            "displayName": "Production - United Kingdom (Deprecated)",
             "description": "Production - United Kingdom.",
             "constraints": {
               "hidden": "false"
@@ -298,10 +629,10 @@
                     "value": "{{liveukCustomClientSecret}}"
                   },
                   "authorizationUrlTemplate": {
-                    "value": "https://{customHost}/webhook/v1/authorize"
+                    "value": "https://{customHost}/3e/events/connector/v1/authorize"
                   },
                   "authorizationUrlQueryStringTemplate": {
-                    "value": "?response_type=code&client_id={clientId}&scope={scopes}&redirect_uri={redirectUrl}&tenantId={tenantId}&state={State}&usePam={usePam}"
+                    "value": "?response_type=code&client_id={clientId}&scope={scopes}&redirect_uri={redirectUrl}&3eInstanceId={3eInstanceId}&state={State}&usePam={usePam}"
                   },
                   "tokenUrlTemplate": {
                     "value": "{ciamAuthority}oauth/token"
@@ -329,15 +660,16 @@
             },
             "token:customHost": {
               "type": "string",
+              "defaultValue": "api.uk.elite.com",
               "uiDefinition": {
                 "constraints": {
                   "required": "true",
                   "tabIndex": 1,
-                  "hidden": "false",
+                  "hidden": "true",
                   "allowedValues": [
                     {
                       "text": "default",
-                      "value": "api.uk.3e.thomsonreuters.com"
+                      "value": "api.uk.elite.com"
                     }
                   ]
                 },
@@ -346,16 +678,16 @@
                 "tooltip": "Select default to continue."
               }
             },
-            "token:tenantId": {
+            "token:3eInstanceId": {
               "type": "string",
               "uiDefinition": {
                 "constraints": {
                   "required": "true",
                   "tabIndex": 2
                 },
-                "description": "The Tenant ID of the 3E instance.",
-                "displayName": "3E Tenant",
-                "tooltip": "Enter the 3E Instance TRS ID."
+                "description": "ID of the 3E instance.",
+                "displayName": "3E Instance ID",
+                "tooltip": "Enter the 3E Instance ID."
               }
             },
             "token:notes": {
@@ -397,7 +729,7 @@
         {
           "name": "livecac",
           "uiDefinition": {
-            "displayName": "Production - Canada",
+            "displayName": "Production - Canada (Deprecated)",
             "description": "Production - Canada.",
             "constraints": {
               "hidden": "false"
@@ -428,10 +760,10 @@
                     "value": "{{livecacCustomClientSecret}}"
                   },
                   "authorizationUrlTemplate": {
-                    "value": "https://{customHost}/webhook/v1/authorize"
+                    "value": "https://{customHost}/3e/events/connector/v1/authorize"
                   },
                   "authorizationUrlQueryStringTemplate": {
-                    "value": "?response_type=code&client_id={clientId}&scope={scopes}&redirect_uri={redirectUrl}&tenantId={tenantId}&state={State}&usePam={usePam}"
+                    "value": "?response_type=code&client_id={clientId}&scope={scopes}&redirect_uri={redirectUrl}&3eInstanceId={3eInstanceId}&state={State}&usePam={usePam}"
                   },
                   "tokenUrlTemplate": {
                     "value": "{ciamAuthority}oauth/token"
@@ -459,15 +791,16 @@
             },
             "token:customHost": {
               "type": "string",
+              "defaultValue": "api.ca.elite.com",
               "uiDefinition": {
                 "constraints": {
                   "required": "true",
                   "tabIndex": 1,
-                  "hidden": "false",
+                  "hidden": "true",
                   "allowedValues": [
                     {
                       "text": "default",
-                      "value": "api.ca.3e.thomsonreuters.com"
+                      "value": "api.ca.elite.com"
                     }
                   ]
                 },
@@ -476,16 +809,16 @@
                 "tooltip": "Select default to continue."
               }
             },
-            "token:tenantId": {
+            "token:3eInstanceId": {
               "type": "string",
               "uiDefinition": {
                 "constraints": {
                   "required": "true",
                   "tabIndex": 2
                 },
-                "description": "The Tenant ID of the 3E instance.",
-                "displayName": "3E Tenant",
-                "tooltip": "Enter the 3E Instance TRS ID."
+                "description": "ID of the 3E instance.",
+                "displayName": "3E Instance ID",
+                "tooltip": "Enter the 3E Instance ID."
               }
             },
             "token:notes": {
@@ -527,7 +860,7 @@
         {
           "name": "liveweu",
           "uiDefinition": {
-            "displayName": "Production - West Europe",
+            "displayName": "Production - West Europe (Deprecated)",
             "description": "Production - West Europe.",
             "constraints": {
               "hidden": "false"
@@ -558,10 +891,10 @@
                     "value": "{{liveweuCustomClientSecret}}"
                   },
                   "authorizationUrlTemplate": {
-                    "value": "https://{customHost}/webhook/v1/authorize"
+                    "value": "https://{customHost}/3e/events/connector/v1/authorize"
                   },
                   "authorizationUrlQueryStringTemplate": {
-                    "value": "?response_type=code&client_id={clientId}&scope={scopes}&redirect_uri={redirectUrl}&tenantId={tenantId}&state={State}&usePam={usePam}"
+                    "value": "?response_type=code&client_id={clientId}&scope={scopes}&redirect_uri={redirectUrl}&3eInstanceId={3eInstanceId}&state={State}&usePam={usePam}"
                   },
                   "tokenUrlTemplate": {
                     "value": "{ciamAuthority}oauth/token"
@@ -589,15 +922,16 @@
             },
             "token:customHost": {
               "type": "string",
+              "defaultValue": "api.eu.elite.com",
               "uiDefinition": {
                 "constraints": {
                   "required": "true",
                   "tabIndex": 1,
-                  "hidden": "false",
+                  "hidden": "true",
                   "allowedValues": [
                     {
                       "text": "default",
-                      "value": "api.eu.3e.thomsonreuters.com"
+                      "value": "api.eu.elite.com"
                     }
                   ]
                 },
@@ -606,16 +940,16 @@
                 "tooltip": "Select default to continue."
               }
             },
-            "token:tenantId": {
+            "token:3eInstanceId": {
               "type": "string",
               "uiDefinition": {
                 "constraints": {
                   "required": "true",
                   "tabIndex": 2
                 },
-                "description": "The Tenant ID of the 3E instance.",
-                "displayName": "3E Tenant",
-                "tooltip": "Enter the 3E Instance TRS ID."
+                "description": "ID of the 3E instance.",
+                "displayName": "3E Instance ID",
+                "tooltip": "Enter the 3E Instance ID."
               }
             },
             "token:notes": {
@@ -657,7 +991,7 @@
         {
           "name": "liveanz",
           "uiDefinition": {
-            "displayName": "Production - Australia",
+            "displayName": "Production - Australia (Deprecated)",
             "description": "Production - Australia.",
             "constraints": {
               "hidden": "false"
@@ -688,10 +1022,10 @@
                     "value": "{{liveanzCustomClientSecret}}"
                   },
                   "authorizationUrlTemplate": {
-                    "value": "https://{customHost}/webhook/v1/authorize"
+                    "value": "https://{customHost}/3e/events/connector/v1/authorize"
                   },
                   "authorizationUrlQueryStringTemplate": {
-                    "value": "?response_type=code&client_id={clientId}&scope={scopes}&redirect_uri={redirectUrl}&tenantId={tenantId}&state={State}&usePam={usePam}"
+                    "value": "?response_type=code&client_id={clientId}&scope={scopes}&redirect_uri={redirectUrl}&3eInstanceId={3eInstanceId}&state={State}&usePam={usePam}"
                   },
                   "tokenUrlTemplate": {
                     "value": "{ciamAuthority}oauth/token"
@@ -719,15 +1053,16 @@
             },
             "token:customHost": {
               "type": "string",
+              "defaultValue": "api.au.elite.com",
               "uiDefinition": {
                 "constraints": {
                   "required": "true",
                   "tabIndex": 1,
-                  "hidden": "false",
+                  "hidden": "true",
                   "allowedValues": [
                     {
                       "text": "default",
-                      "value": "api.au.3e.thomsonreuters.com"
+                      "value": "api.au.elite.com"
                     }
                   ]
                 },
@@ -736,16 +1071,16 @@
                 "tooltip": "Select default to continue."
               }
             },
-            "token:tenantId": {
+            "token:3eInstanceId": {
               "type": "string",
               "uiDefinition": {
                 "constraints": {
                   "required": "true",
                   "tabIndex": 2
                 },
-                "description": "The Tenant ID of the 3E instance.",
-                "displayName": "3E Tenant",
-                "tooltip": "Enter the 3E Instance TRS ID."
+                "description": "ID of the 3E instance.",
+                "displayName": "3E Instance ID",
+                "tooltip": "Enter the 3E Instance ID."
               }
             },
             "token:notes": {
@@ -787,7 +1122,7 @@
         {
           "name": "previewus",
           "uiDefinition": {
-            "displayName": "Preview - United States",
+            "displayName": "Preview - United States (Deprecated)",
             "description": "Preview - United States.",
             "constraints": {
               "hidden": "false"
@@ -818,10 +1153,10 @@
                     "value": "{{previewusCustomClientSecret}}"
                   },
                   "authorizationUrlTemplate": {
-                    "value": "https://{customHost}/webhook/v1/authorize"
+                    "value": "https://{customHost}/3e/events/connector/v1/authorize"
                   },
                   "authorizationUrlQueryStringTemplate": {
-                    "value": "?response_type=code&client_id={clientId}&scope={scopes}&redirect_uri={redirectUrl}&tenantId={tenantId}&state={State}&usePam={usePam}"
+                    "value": "?response_type=code&client_id={clientId}&scope={scopes}&redirect_uri={redirectUrl}&3eInstanceId={3eInstanceId}&state={State}&usePam={usePam}"
                   },
                   "tokenUrlTemplate": {
                     "value": "{ciamAuthority}oauth/token"
@@ -849,15 +1184,16 @@
             },
             "token:customHost": {
               "type": "string",
+              "defaultValue": "api.us.elite.com/preview",
               "uiDefinition": {
                 "constraints": {
                   "required": "true",
                   "tabIndex": 1,
-                  "hidden": "false",
+                  "hidden": "true",
                   "allowedValues": [
                     {
                       "text": "default",
-                      "value": "api.us.preview.3e.thomsonreuters.com"
+                      "value": "api.us.elite.com/preview"
                     }
                   ]
                 },
@@ -866,16 +1202,16 @@
                 "tooltip": "Select default to continue."
               }
             },
-            "token:tenantId": {
+            "token:3eInstanceId": {
               "type": "string",
               "uiDefinition": {
                 "constraints": {
                   "required": "true",
                   "tabIndex": 2
                 },
-                "description": "The Tenant ID of the 3E instance.",
-                "displayName": "3E Tenant",
-                "tooltip": "Enter the 3E Instance TRS ID."
+                "description": "ID of the 3E instance.",
+                "displayName": "3E Instance ID",
+                "tooltip": "Enter the 3E Instance ID."
               }
             },
             "token:notes": {
@@ -917,7 +1253,7 @@
         {
           "name": "previewuk",
           "uiDefinition": {
-            "displayName": "Preview - United Kingdom",
+            "displayName": "Preview - United Kingdom (Deprecated)",
             "description": "Preview - United Kingdom.",
             "constraints": {
               "hidden": "false"
@@ -948,10 +1284,10 @@
                     "value": "{{previewukCustomClientSecret}}"
                   },
                   "authorizationUrlTemplate": {
-                    "value": "https://{customHost}/webhook/v1/authorize"
+                    "value": "https://{customHost}/3e/events/connector/v1/authorize"
                   },
                   "authorizationUrlQueryStringTemplate": {
-                    "value": "?response_type=code&client_id={clientId}&scope={scopes}&redirect_uri={redirectUrl}&tenantId={tenantId}&state={State}&usePam={usePam}"
+                    "value": "?response_type=code&client_id={clientId}&scope={scopes}&redirect_uri={redirectUrl}&3eInstanceId={3eInstanceId}&state={State}&usePam={usePam}"
                   },
                   "tokenUrlTemplate": {
                     "value": "{ciamAuthority}oauth/token"
@@ -979,15 +1315,16 @@
             },
             "token:customHost": {
               "type": "string",
+              "defaultValue": "api.uk.elite.com/preview",
               "uiDefinition": {
                 "constraints": {
                   "required": "true",
                   "tabIndex": 1,
-                  "hidden": "false",
+                  "hidden": "true",
                   "allowedValues": [
                     {
                       "text": "default",
-                      "value": "api.uk.preview.3e.thomsonreuters.com"
+                      "value": "api.uk.elite.com/preview"
                     }
                   ]
                 },
@@ -996,16 +1333,16 @@
                 "tooltip": "Select default to continue."
               }
             },
-            "token:tenantId": {
+            "token:3eInstanceId": {
               "type": "string",
               "uiDefinition": {
                 "constraints": {
                   "required": "true",
                   "tabIndex": 2
                 },
-                "description": "The Tenant ID of the 3E instance.",
-                "displayName": "3E Tenant",
-                "tooltip": "Enter the 3E Instance TRS ID."
+                "description": "ID of the 3E instance.",
+                "displayName": "3E Instance ID",
+                "tooltip": "Enter the 3E Instance ID."
               }
             },
             "token:notes": {
@@ -1047,7 +1384,7 @@
         {
           "name": "previewca",
           "uiDefinition": {
-            "displayName": "Preview - Canada",
+            "displayName": "Preview - Canada (Deprecated)",
             "description": "Preview - Canada.",
             "constraints": {
               "hidden": "false"
@@ -1078,10 +1415,10 @@
                     "value": "{{previewcaCustomClientSecret}}"
                   },
                   "authorizationUrlTemplate": {
-                    "value": "https://{customHost}/webhook/v1/authorize"
+                    "value": "https://{customHost}/3e/events/connector/v1/authorize"
                   },
                   "authorizationUrlQueryStringTemplate": {
-                    "value": "?response_type=code&client_id={clientId}&scope={scopes}&redirect_uri={redirectUrl}&tenantId={tenantId}&state={State}&usePam={usePam}"
+                    "value": "?response_type=code&client_id={clientId}&scope={scopes}&redirect_uri={redirectUrl}&3eInstanceId={3eInstanceId}&state={State}&usePam={usePam}"
                   },
                   "tokenUrlTemplate": {
                     "value": "{ciamAuthority}oauth/token"
@@ -1109,15 +1446,16 @@
             },
             "token:customHost": {
               "type": "string",
+              "defaultValue": "api.ca.elite.com/preview",
               "uiDefinition": {
                 "constraints": {
                   "required": "true",
                   "tabIndex": 1,
-                  "hidden": "false",
+                  "hidden": "true",
                   "allowedValues": [
                     {
                       "text": "default",
-                      "value": "api.ca.preview.3e.thomsonreuters.com"
+                      "value": "api.ca.elite.com/preview"
                     }
                   ]
                 },
@@ -1126,16 +1464,16 @@
                 "tooltip": "Select default to continue."
               }
             },
-            "token:tenantId": {
+            "token:3eInstanceId": {
               "type": "string",
               "uiDefinition": {
                 "constraints": {
                   "required": "true",
                   "tabIndex": 2
                 },
-                "description": "The Tenant ID of the 3E instance.",
-                "displayName": "3E Tenant",
-                "tooltip": "Enter the 3E Instance TRS ID."
+                "description": "ID of the 3E instance.",
+                "displayName": "3E Instance ID",
+                "tooltip": "Enter the 3E Instance ID."
               }
             },
             "token:notes": {
@@ -1177,7 +1515,7 @@
         {
           "name": "previeweu",
           "uiDefinition": {
-            "displayName": "Preview - West Europe",
+            "displayName": "Preview - West Europe (Deprecated)",
             "description": "Preview - West Europe.",
             "constraints": {
               "hidden": "false"
@@ -1208,10 +1546,10 @@
                     "value": "{{previeweuCustomClientSecret}}"
                   },
                   "authorizationUrlTemplate": {
-                    "value": "https://{customHost}/webhook/v1/authorize"
+                    "value": "https://{customHost}/3e/events/connector/v1/authorize"
                   },
                   "authorizationUrlQueryStringTemplate": {
-                    "value": "?response_type=code&client_id={clientId}&scope={scopes}&redirect_uri={redirectUrl}&tenantId={tenantId}&state={State}&usePam={usePam}"
+                    "value": "?response_type=code&client_id={clientId}&scope={scopes}&redirect_uri={redirectUrl}&3eInstanceId={3eInstanceId}&state={State}&usePam={usePam}"
                   },
                   "tokenUrlTemplate": {
                     "value": "{ciamAuthority}oauth/token"
@@ -1239,15 +1577,16 @@
             },
             "token:customHost": {
               "type": "string",
+              "defaultValue": "api.eu.elite.com/preview",
               "uiDefinition": {
                 "constraints": {
                   "required": "true",
                   "tabIndex": 1,
-                  "hidden": "false",
+                  "hidden": "true",
                   "allowedValues": [
                     {
                       "text": "default",
-                      "value": "api.eu.preview.3e.thomsonreuters.com"
+                      "value": "api.eu.elite.com/preview"
                     }
                   ]
                 },
@@ -1256,16 +1595,16 @@
                 "tooltip": "Select default to continue."
               }
             },
-            "token:tenantId": {
+            "token:3eInstanceId": {
               "type": "string",
               "uiDefinition": {
                 "constraints": {
                   "required": "true",
                   "tabIndex": 2
                 },
-                "description": "The Tenant ID of the 3E instance.",
-                "displayName": "3E Tenant",
-                "tooltip": "Enter the 3E Instance TRS ID."
+                "description": "ID of the 3E instance.",
+                "displayName": "3E Instance ID",
+                "tooltip": "Enter the 3E Instance ID."
               }
             },
             "token:notes": {
@@ -1307,7 +1646,7 @@
         {
           "name": "previewau",
           "uiDefinition": {
-            "displayName": "Preview - Australia",
+            "displayName": "Preview - Australia (Deprecated)",
             "description": "Preview - Australia.",
             "constraints": {
               "hidden": "false"
@@ -1338,10 +1677,10 @@
                     "value": "{{previewauCustomClientSecret}}"
                   },
                   "authorizationUrlTemplate": {
-                    "value": "https://{customHost}/webhook/v1/authorize"
+                    "value": "https://{customHost}/3e/events/connector/v1/authorize"
                   },
                   "authorizationUrlQueryStringTemplate": {
-                    "value": "?response_type=code&client_id={clientId}&scope={scopes}&redirect_uri={redirectUrl}&tenantId={tenantId}&state={State}&usePam={usePam}"
+                    "value": "?response_type=code&client_id={clientId}&scope={scopes}&redirect_uri={redirectUrl}&3eInstanceId={3eInstanceId}&state={State}&usePam={usePam}"
                   },
                   "tokenUrlTemplate": {
                     "value": "{ciamAuthority}oauth/token"
@@ -1369,15 +1708,16 @@
             },
             "token:customHost": {
               "type": "string",
+              "defaultValue": "api.au.elite.com/preview",
               "uiDefinition": {
                 "constraints": {
                   "required": "true",
                   "tabIndex": 1,
-                  "hidden": "false",
+                  "hidden": "true",
                   "allowedValues": [
                     {
                       "text": "default",
-                      "value": "api.au.preview.3e.thomsonreuters.com"
+                      "value": "api.au.elite.com/preview"
                     }
                   ]
                 },
@@ -1386,16 +1726,16 @@
                 "tooltip": "Select default to continue."
               }
             },
-            "token:tenantId": {
+            "token:3eInstanceId": {
               "type": "string",
               "uiDefinition": {
                 "constraints": {
                   "required": "true",
                   "tabIndex": 2
                 },
-                "description": "The Tenant ID of the 3E instance.",
-                "displayName": "3E Tenant",
-                "tooltip": "Enter the 3E Instance TRS ID."
+                "description": "ID of the 3E instance.",
+                "displayName": "3E Instance ID",
+                "tooltip": "Enter the 3E Instance ID."
               }
             },
             "token:notes": {
@@ -1437,8 +1777,8 @@
         {
           "name": "nonprod",
           "uiDefinition": {
-            "displayName": "Development (For TR use only)",
-            "description": "For non-production TR environments.",
+            "displayName": "Development (For Elite use only) (Deprecated)",
+            "description": "For non-production Elite environments.",
             "constraints": {
               "hidden": "false"
             }
@@ -1462,10 +1802,10 @@
                     "value": "https://auth-nonprod.thomsonreuters.com/"
                   },
                   "authorizationUrlTemplate": {
-                    "value": "https://{customHost}/webhook/v1/authorize"
+                    "value": "https://{customHost}/3e/events/connector/v1/authorize"
                   },
                   "authorizationUrlQueryStringTemplate": {
-                    "value": "?response_type=code&client_id={clientId}&scope={scopes}&redirect_uri={redirectUrl}&tenantId={tenantId}&state={State}&usePam={usePam}"
+                    "value": "?response_type=code&client_id={clientId}&scope={scopes}&redirect_uri={redirectUrl}&3eInstanceId={3eInstanceId}&state={State}&usePam={usePam}"
                   },
                   "tokenUrlTemplate": {
                     "value": "{ciamAuthority}oauth/token"
@@ -1500,19 +1840,19 @@
                 },
                 "description": "The APIM host domain.",
                 "displayName": "Host",
-                "tooltip": "Enter host domain, e.g. api.us.dev.3e.thomsonreuters.com"
+                "tooltip": "Enter host domain, e.g. api.us.nonprod.elite.com/dev"
               }
             },
-            "token:tenantId": {
+            "token:3eInstanceId": {
               "type": "string",
               "uiDefinition": {
                 "constraints": {
                   "required": "true",
                   "tabIndex": 2
                 },
-                "description": "The Tenant ID of the 3E instance.",
-                "displayName": "3E Tenant",
-                "tooltip": "Enter the 3E Instance TRS ID."
+                "description": "ID of the 3E instance.",
+                "displayName": "3E Instance ID",
+                "tooltip": "Enter the 3E Instance ID."
               }
             },
             "token:clientId": {
@@ -1536,7 +1876,7 @@
                 },
                 "description": "Client Secret.",
                 "displayName": "Client Secret",
-                "tooltip": "Enter CIAM Client Id"
+                "tooltip": "Enter CIAM Client Secret"
               }
             },
             "token:notes": {
@@ -1584,16 +1924,39 @@
         "templateId": "dynamichosturl",
         "title": "Set host for connection",
         "parameters": {
-          "x-ms-apimTemplateParameter.urlTemplate": "https://@connectionParameters('token:customHost')/webhook"
+          "x-ms-apimTemplateParameter.urlTemplate": "https://@connectionParameters('token:customHost')/3e/events/webhook"
         }
       },
       {
         "templateId": "setqueryparameter",
         "title": "Set Tenant ID",
         "parameters": {
-          "x-ms-apimTemplateParameter.name": "tenantId",
-          "x-ms-apimTemplateParameter.value": "@connectionParameters('token:tenantId')",
+          "x-ms-apimTemplateParameter.name": "3eInstanceId",
+          "x-ms-apimTemplateParameter.value": "@connectionParameters('token:3eInstanceId')",
           "x-ms-apimTemplateParameter.existsAction": "skip"
+        }
+      },
+      {
+        "templateId": "setheader",
+        "title": "Set Notes header",
+        "parameters": {
+          "x-ms-apimTemplateParameter.name": "X-notes",
+          "x-ms-apimTemplateParameter.value": "@connectionParameters('token:notes','')",
+          "x-ms-apimTemplateParameter.existsAction": "override",
+          "x-ms-apimTemplate-policySection": "Request",
+          "x-ms-apimTemplate-operationName": [
+            "DataObjectEventTrigger",
+            "DataObjectAttributeEventTrigger",
+            "WorkflowActionTrigger",
+            "MatterCreatedEventTrigger",
+            "MatterUpdatedEventTrigger",
+            "ClientCreatedEventTrigger",
+            "ClientUpdatedEventTrigger",
+            "TimekeeperUpdatedEventTrigger",
+            "RcptMasterCreatedEventTrigger",
+            "TrustReceiptCreatedEventTrigger",
+            "CdsDocumentTrigger"
+          ]
         }
       }
     ],

--- a/certified-connectors/3E Events/readme.md
+++ b/certified-connectors/3E Events/readme.md
@@ -11,7 +11,7 @@ You will need the following to proceed:
 Note: Please contact your IT administrator for any issues related to Power automate
 
 # How to get credentials
-Request access by contacting [Elite Support](https://legal.thomsonreuters.com/en/support)
+Request access by contacting [Elite Support](https://elite.com/en/support)
 
 When requesting access and to establish connection to the 3E Events Connector, the user will need access to the following 3E information.: :
 


### PR DESCRIPTION
- Added Elite ID login options.
- Deprecated CIAM login options.
- Changed routing to a new host: api.elite.com.
- Changed support URLs in the `contact` and `metadata` section.

---
### When submitting a connector, please make sure that you follow the requirements below, otherwise your PR might be rejected. We want to make you have a well-built connector, a smooth certification experience, and your users are happy :) 

If this is your first time submitting to GitHub and you need some help, please sign up for this [session](https://forms.office.com/pages/responsepage.aspx?id=KtIy2vgLW0SOgZbwvQuRaXDXyCl9DkBHq4A2OG7uLpdUMTFJWFFGVUxBNUFZQjZWRUdaOE5BMFkwNS4u). 

- [x] I attest that the connector doesn't exist on the Power Platform today. I've verified by checking the pull requests in GitHub and by searching for the connector on the platform or in the documentation. 
- [x] I attest that the connector works and I verified by deploying and testing all the operations. 
- [x] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [x] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [x] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [x] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.

