### PR TITLE
Added support for asynchronous pattern when executing a flow.

### DIFF
--- a/certified-connectors/Experlogix Smart Flows/apiDefinition.swagger.json
+++ b/certified-connectors/Experlogix Smart Flows/apiDefinition.swagger.json
@@ -439,6 +439,12 @@
                             "$ref": "#/definitions/FlowExecutionResponse"
                         }
                     },
+                    "202": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/FlowExecutionResponse"
+                        }
+                    },
                     "400": {
                         "description": "Bad Request"
                     },
@@ -450,6 +456,60 @@
                 "tags": [
                     "Flows"
                 ]
+            }
+        },
+        "/api/ExecutionProgress": {
+            "get": {
+                "description": "Get the progress of an execution.",
+                "operationId": "GetExecutionProgress",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "executionId",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "query",
+                        "name": "timeout",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "in": "query",
+                        "name": "startTime",
+                        "required": false,
+                        "type": "string"
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/FlowExecutionResponse"
+                        }
+                    },
+                    "202": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/FlowExecutionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Get Flow Schema",
+                "tags": [
+                    "Flows"
+                ],
+                "x-ms-visibility": "internal"
             }
         },
         "/api/Flows": {


### PR DESCRIPTION
---
### When submitting a connector, please make sure that you follow the requirements below, otherwise your PR might be rejected. We want to make you have a well-built connector, a smooth certification experience, and your users are happy :) 

If this is your first time submitting to GitHub and you need some help, please sign up for this [session](https://forms.office.com/pages/responsepage.aspx?id=KtIy2vgLW0SOgZbwvQuRaXDXyCl9DkBHq4A2OG7uLpdUMTFJWFFGVUxBNUFZQjZWRUdaOE5BMFkwNS4u). 

- [X ] I attest that the connector doesn't exist on the Power Platform today. I've verified by checking the pull requests in GitHub and by searching for the connector on the platform or in the documentation. 
- [ X] I attest that the connector works and I verified by deploying and testing all the operations. 
- [ X] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [ X] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [ X] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [ X] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.

If you are an Independent Publisher, you must also attest to the following to ensure a smooth publishing process:
- [ ] I have named this PR after the pattern of "Connector Name (Independent Publisher)" ex: HubSpot Marketing (Independent Publisher)
- [ ] Within this PR markdown file, I have pasted screenshots that show: 3 unique operations (actions/triggers) working within a Flow. This can be in one flow or part of multiple flows. For each one of those flows, I have pasted in screenshots of the Flow succeeding. 
- [ ] Within this PR markdown file, I have pasted in a screenshot from the Test operations section within the Custom Connector UI.
- [ ] If the connector uses OAuth, I have provided detailed steps on how to create an app in the readme.md. 


