### PR TITLE
Mailjet (Independent Publisher) v1.1 Update

### DIFF
--- a/independent-publisher-connectors/MailJet/apiDefinition.swagger.json
+++ b/independent-publisher-connectors/MailJet/apiDefinition.swagger.json
@@ -314,7 +314,7 @@
                       "Attachments": {
                         "type": "array",
                         "items": {
-                          "$ref": "#/definitions/Attachment"
+                          "$ref": "#/definitions/Attachmentv3.1"
                         },
                         "description": "Attachments"
                       }
@@ -1870,6 +1870,26 @@
           "x-ms-summary": "Content-type"
         },
         "Content": {
+          "type": "string",
+          "description": "Base64 encoded content of the attached file",
+          "x-ms-summary": "Content"
+        }
+      }
+    },
+    "Attachmentv3.1": {
+      "type": "object",
+      "properties": {
+        "Filename": {
+          "type": "string",
+          "description": "The full name of the file (including the file extension)",
+          "x-ms-summary": "Filename"
+        },
+        "Content-type": {
+          "type": "string",
+          "description": "Defines the type of content being sent out using a MIME type",
+          "x-ms-summary": "Content-type"
+        },
+        "Base64Content": {
           "type": "string",
           "description": "Base64 encoded content of the attached file",
           "x-ms-summary": "Content"

--- a/independent-publisher-connectors/MailJet/apiDefinition.swagger.json
+++ b/independent-publisher-connectors/MailJet/apiDefinition.swagger.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "MailJet",
     "description": "A complete collection of all publicly available endpoints and methods for the Mailjet API",
-    "version": "1.0",
+    "version": "1.1",
     "contact": {
       "email": "clement@carfup.com",
       "name": "Clement OLIVIER",


### PR DESCRIPTION
---
### When submitting a connector, please make sure that you follow the requirements below, otherwise your PR might be rejected. We want to make you have a well-built connector, a smooth certification experience, and your users are happy :) 

If this is your first time submitting to GitHub and you need some help, please sign up for this [session](https://forms.office.com/pages/responsepage.aspx?id=KtIy2vgLW0SOgZbwvQuRaXDXyCl9DkBHq4A2OG7uLpdUMTFJWFFGVUxBNUFZQjZWRUdaOE5BMFkwNS4u). 

- [ ] I attest that the connector doesn't exist on the Power Platform today. I've verified by checking the pull requests in GitHub and by searching for the connector on the platform or in the documentation. 
- [x] I attest that the connector works and I verified by deploying and testing all the operations. 
- [x] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [x] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [x] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [x] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.

If you are an Independent Publisher, you must also attest to the following to ensure a smooth publishing process:
- [x] I have named this PR after the pattern of "Connector Name (Independent Publisher)" ex: HubSpot Marketing (Independent Publisher)
- [ ] Within this PR markdown file, I have pasted screenshots that show: 3 unique operations (actions/triggers) working within a Flow. This can be in one flow or part of multiple flows. For each one of those flows, I have pasted in screenshots of the Flow succeeding. 
- [ ] Within this PR markdown file, I have pasted in a screenshot from the Test operations section within the Custom Connector UI.
- [ ] If the connector uses OAuth, I have provided detailed steps on how to create an app in the readme.md. 


