### PR TITLE
Gravity Forms Power Automate Professional: Adds Dynamic Schema for attachments

### DIFF
--- a/certified-connectors/Gravity Forms Professional/apiDefinition.swagger.json
+++ b/certified-connectors/Gravity Forms Professional/apiDefinition.swagger.json
@@ -533,7 +533,7 @@
       },
       "post": {
         "operationId": "TriggerOnFormSubmission",
-        "summary": "When a new Gravity Forms form is submitted",
+        "summary": "When a Gravity Forms form is submitted",
         "description": "Trigger a flow when a new Gravity Forms entry is submitted",
         "x-ms-visibility": "important",
         "x-ms-trigger": "single",
@@ -1512,14 +1512,44 @@
       }
     },
     "/resources/entries/{entry_id}/attachments/download": {
+      "options": {
+        "operationId": "GetEntryAttachmentSchema",
+        "summary": "Get the schema for an entry's attachments. Internal use only",
+        "description": "Get the schema for an entry's attachments. Internal use only",
+        "x-ms-visibility": "internal",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "entry_id",
+            "x-ms-summary": "Entry ID",
+            "description": "Entry ID",
+            "required": true,
+            "type": "string",
+            "x-ms-url-encoding": "single"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "get": {
+                  "type": "object"
+                },
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      },
       "get": {
         "operationId": "DownloadEntryAttachment",
         "summary": "Download an attachment for a Gravity Forms entry",
         "description": "Download an attachment for a Gravity Forms entry",
         "x-ms-visibility": "important",
-        "produces": [
-          "application/octet-stream"
-        ],
         "parameters": [
           {
             "name": "entry_id",
@@ -1541,7 +1571,18 @@
         ],
         "responses": {
           "200": {
-            "description": "The attachment content"
+            "description": "The attachment content",
+            "schema": {
+              "x-ms-dynamic-properties": {
+                "operationId": "GetEntryAttachmentSchema",
+                "itemValuePath": "schema",
+                "parameters": {
+                  "entry_id": {
+                    "value": "1"
+                  }
+                }
+              }
+            }
           }
         },
         "x-ms-openai-data": {


### PR DESCRIPTION
## Gravity Forms Power Automate Professional Update 1
### Add Dynamic Schema to Attachment Download

> Minor Update

Our download action didn't have a schema and it made it impossible to get the file contents. We added a dynamic schema and validated it's working in our test environment.

---
### When submitting a connector, please make sure that you follow the requirements below, otherwise your PR might be rejected. We want to make you have a well-built connector, a smooth certification experience, and your users are happy :) 

If this is your first time submitting to GitHub and you need some help, please sign up for this [session](https://forms.office.com/pages/responsepage.aspx?id=KtIy2vgLW0SOgZbwvQuRaXDXyCl9DkBHq4A2OG7uLpdUMTFJWFFGVUxBNUFZQjZWRUdaOE5BMFkwNS4u). 

- [x] I attest that the connector doesn't exist on the Power Platform today. I've verified by checking the pull requests in GitHub and by searching for the connector on the platform or in the documentation. 
- [x] I attest that the connector works and I verified by deploying and testing all the operations. 
- [x] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [x] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [x] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [x] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.
