### PR TITLE
fix: touchsms connector name

### DIFF
--- a/certified-connectors/touchSMS/apiDefinition.swagger.json
+++ b/certified-connectors/touchSMS/apiDefinition.swagger.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "touchSMS V2 Documentation",
+    "title": "touchSMS",
     "version": "1.0.0",
     "description": "Add SMS to your workflows with touchSMS. Have an inbound SMS to your Virtual Number initiate a workflow, or trigger an SMS to be sent based on workflow parameters.",
     "termsOfService": "https://www.touchsms.com.au/legal/",


### PR DESCRIPTION
Connector "title" was wrong, had name from original API docs. This corrects is for ISV centre submission.