### PR TITLE
Encodian - April Release Bug Fix

### DIFF
--- a/certified-connectors/Encodian/apiDefinition.swagger.json
+++ b/certified-connectors/Encodian/apiDefinition.swagger.json
@@ -10701,7 +10701,10 @@
             "BASE64",
             "HEX"
           ],
-          "type": "string"
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "Input Type",
+          "description": "Set the data format of the encrypted string"
         },
         "key": {
           "type": "string",
@@ -10765,7 +10768,10 @@
             "BASE64",
             "HEX"
           ],
-          "type": "string"
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "Output Type",
+          "description": "Set the data format of the encrypted string"
         },
         "key": {
           "type": "string",


### PR DESCRIPTION
- [X] I attest that the connector works and I verified by deploying and testing all the operations. 
- [X] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [X] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [X] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [X] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.

Minor update for the 'Utility - AES Encryption' and 'Utility - AES Decryption' actions