### PR TITLE
[paconn] Send success messages to stdout not stderr

### DIFF
--- a/tools/paconn-cli/.gitignore
+++ b/tools/paconn-cli/.gitignore
@@ -1,0 +1,160 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/tools/paconn-cli/paconn.pyproj
+++ b/tools/paconn-cli/paconn.pyproj
@@ -12,7 +12,7 @@
     <OutputPath>.</OutputPath>
     <ProjectTypeGuids>{888888a0-9f3d-457c-b088-3a5042f75d52}</ProjectTypeGuids>
     <LaunchProvider>Standard Python launcher</LaunchProvider>
-    <InterpreterId>Global|PythonCore|3.7</InterpreterId>
+    <InterpreterId>Global|PythonCore|3.12</InterpreterId>
     <CommandLineArguments>
     </CommandLineArguments>
     <EnableNativeCodeDebugging>False</EnableNativeCodeDebugging>
@@ -76,10 +76,10 @@
     <Content Include="paconn\config\cli.flake8" />
     <Content Include="paconn\config\cli_pylintrc" />
     <Content Include="paconn\paconn.completion.sh" />
-    <Content Include="README.md" />
   </ItemGroup>
   <ItemGroup>
     <InterpreterReference Include="Global|PythonCore|3.7" />
+    <InterpreterReference Include="Global|PythonCore|3.12" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Python Tools\Microsoft.PythonTools.targets" />
 </Project>

--- a/tools/paconn-cli/paconn.sln
+++ b/tools/paconn-cli/paconn.sln
@@ -1,9 +1,16 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28010.2016
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34728.123
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{888888A0-9F3D-457C-B088-3A5042F75D52}") = "paconn", "paconn.pyproj", "{6285073D-E427-48C1-9783-ABDDF33FA22C}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{68860382-686D-4AD6-8F0A-75BE67317FF5}"
+	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
+		LICENSE = LICENSE
+		README.md = README.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/tools/paconn-cli/paconn/apimanager/apimanager.py
+++ b/tools/paconn-cli/paconn/apimanager/apimanager.py
@@ -15,7 +15,7 @@ import requests
 from knack.util import CLIError
 from knack.log import get_logger
 
-from paconn.common.util import displayError, format_json
+from paconn.common.util import display_error, format_json
 from paconn.authentication.tokenmanager import (
     _ACCESS_TOKEN,
     _TOKEN_TYPE,
@@ -119,7 +119,7 @@ class APIManager:
                 LOGGER.debug(payload)
             LOGGER.debug('RESPONSE')
             LOGGER.debug(response_content)
-            displayError(response_content)
+            display_error(response_content)
             raise CLIError(exception_str)
 
         return response

--- a/tools/paconn-cli/paconn/apimanager/apimanager.py
+++ b/tools/paconn-cli/paconn/apimanager/apimanager.py
@@ -15,7 +15,7 @@ import requests
 from knack.util import CLIError
 from knack.log import get_logger
 
-from paconn.common.util import display, format_json
+from paconn.common.util import displayError, format_json
 from paconn.authentication.tokenmanager import (
     _ACCESS_TOKEN,
     _TOKEN_TYPE,
@@ -119,7 +119,7 @@ class APIManager:
                 LOGGER.debug(payload)
             LOGGER.debug('RESPONSE')
             LOGGER.debug(response_content)
-            display(response_content)
+            displayError(response_content)
             raise CLIError(exception_str)
 
         return response

--- a/tools/paconn-cli/paconn/authentication/profile.py
+++ b/tools/paconn-cli/paconn/authentication/profile.py
@@ -11,6 +11,7 @@ import adal
 from urllib.parse import urljoin
 # AADTokenCredentials for multi-factor authentication
 from msrestazure.azure_active_directory import AADTokenCredentials
+from paconn.common.util import displayMessage
 
 
 class Profile:
@@ -41,7 +42,7 @@ class Profile:
             resource=self.resource,
             client_id=self.client_id)
 
-        print(code['message'])
+        displayMessage(code['message'], flush=True)
 
         mgmt_token = context.acquire_token_with_device_code(
             resource=self.resource,

--- a/tools/paconn-cli/paconn/authentication/profile.py
+++ b/tools/paconn-cli/paconn/authentication/profile.py
@@ -11,7 +11,7 @@ import adal
 from urllib.parse import urljoin
 # AADTokenCredentials for multi-factor authentication
 from msrestazure.azure_active_directory import AADTokenCredentials
-from paconn.common.util import displayMessage
+from paconn.common.util import display_message
 
 
 class Profile:
@@ -42,7 +42,7 @@ class Profile:
             resource=self.resource,
             client_id=self.client_id)
 
-        displayMessage(code['message'], flush=True)
+        display_message(code['message'], flush=True)
 
         mgmt_token = context.acquire_token_with_device_code(
             resource=self.resource,

--- a/tools/paconn-cli/paconn/commands/create.py
+++ b/tools/paconn-cli/paconn/commands/create.py
@@ -9,7 +9,7 @@ Create command.
 """
 
 from paconn import _CREATE
-from paconn.common.util import displayMessage
+from paconn.common.util import display_message
 from paconn.settings.util import load_powerapps_and_flow_rp
 from paconn.operations.upsert import upsert
 from paconn.settings.settingsbuilder import SettingsBuilder
@@ -53,4 +53,4 @@ def create(
         is_update=False,
         overwrite_settings=overwrite_settings)
 
-    displayMessage('{} created successfully.'.format(connector_id))
+    display_message('{} created successfully.'.format(connector_id))

--- a/tools/paconn-cli/paconn/commands/create.py
+++ b/tools/paconn-cli/paconn/commands/create.py
@@ -9,7 +9,7 @@ Create command.
 """
 
 from paconn import _CREATE
-from paconn.common.util import display
+from paconn.common.util import displayMessage
 from paconn.settings.util import load_powerapps_and_flow_rp
 from paconn.operations.upsert import upsert
 from paconn.settings.settingsbuilder import SettingsBuilder
@@ -53,4 +53,4 @@ def create(
         is_update=False,
         overwrite_settings=overwrite_settings)
 
-    display('{} created successfully.'.format(connector_id))
+    displayMessage('{} created successfully.'.format(connector_id))

--- a/tools/paconn-cli/paconn/commands/download.py
+++ b/tools/paconn-cli/paconn/commands/download.py
@@ -9,7 +9,7 @@ Download command.
 
 from paconn import _DOWNLOAD
 
-from paconn.common.util import display
+from paconn.common.util import displayMessage
 from paconn.settings.util import load_powerapps_and_flow_rp
 from paconn.settings.settingsbuilder import SettingsBuilder
 
@@ -50,4 +50,4 @@ def download(
         destination=destination,
         overwrite=overwrite)
 
-    display('The connector is downloaded to {}.'.format(directory))
+    displayMessage('The connector is downloaded to {}.'.format(directory))

--- a/tools/paconn-cli/paconn/commands/download.py
+++ b/tools/paconn-cli/paconn/commands/download.py
@@ -9,7 +9,7 @@ Download command.
 
 from paconn import _DOWNLOAD
 
-from paconn.common.util import displayMessage
+from paconn.common.util import display_message
 from paconn.settings.util import load_powerapps_and_flow_rp
 from paconn.settings.settingsbuilder import SettingsBuilder
 
@@ -50,4 +50,4 @@ def download(
         destination=destination,
         overwrite=overwrite)
 
-    displayMessage('The connector is downloaded to {}.'.format(directory))
+    display_message('The connector is downloaded to {}.'.format(directory))

--- a/tools/paconn-cli/paconn/commands/login.py
+++ b/tools/paconn-cli/paconn/commands/login.py
@@ -8,7 +8,7 @@ Login command.
 """
 
 from paconn.authentication.auth import get_authentication
-from paconn.common.util import display
+from paconn.common.util import displayMessage
 from paconn.settings.settingsbuilder import SettingsBuilder
 
 
@@ -27,4 +27,4 @@ def login(client_id, tenant, authority_url, resource, settings_file, force):
     get_authentication(
         settings=settings,
         force_authenticate=force)
-    display('Login successful.')
+    displayMessage('Login successful.')

--- a/tools/paconn-cli/paconn/commands/login.py
+++ b/tools/paconn-cli/paconn/commands/login.py
@@ -8,7 +8,7 @@ Login command.
 """
 
 from paconn.authentication.auth import get_authentication
-from paconn.common.util import displayMessage
+from paconn.common.util import display_message
 from paconn.settings.settingsbuilder import SettingsBuilder
 
 
@@ -27,4 +27,4 @@ def login(client_id, tenant, authority_url, resource, settings_file, force):
     get_authentication(
         settings=settings,
         force_authenticate=force)
-    displayMessage('Login successful.')
+    display_message('Login successful.')

--- a/tools/paconn-cli/paconn/commands/logout.py
+++ b/tools/paconn-cli/paconn/commands/logout.py
@@ -8,7 +8,7 @@ Login command.
 """
 
 from paconn.authentication.auth import remove_authentication
-from paconn.common.util import displayMessage
+from paconn.common.util import display_message
 
 
 def logout():
@@ -16,4 +16,4 @@ def logout():
     Logout command.
     """
     remove_authentication()
-    displayMessage('Logout successful.')
+    display_message('Logout successful.')

--- a/tools/paconn-cli/paconn/commands/logout.py
+++ b/tools/paconn-cli/paconn/commands/logout.py
@@ -8,7 +8,7 @@ Login command.
 """
 
 from paconn.authentication.auth import remove_authentication
-from paconn.common.util import display
+from paconn.common.util import displayMessage
 
 
 def logout():
@@ -16,4 +16,4 @@ def logout():
     Logout command.
     """
     remove_authentication()
-    display('Logout successful.')
+    displayMessage('Logout successful.')

--- a/tools/paconn-cli/paconn/commands/update.py
+++ b/tools/paconn-cli/paconn/commands/update.py
@@ -8,7 +8,7 @@ Update command.
 """
 
 from paconn import _UPDATE
-from paconn.common.util import display
+from paconn.common.util import displayMessage
 from paconn.settings.util import load_powerapps_and_flow_rp
 from paconn.operations.upsert import upsert
 from paconn.settings.settingsbuilder import SettingsBuilder
@@ -52,4 +52,4 @@ def update(
         is_update=True,
         overwrite_settings=False)
 
-    display('{} updated successfully.'.format(connector_id))
+    displayMessage('{} updated successfully.'.format(connector_id))

--- a/tools/paconn-cli/paconn/commands/update.py
+++ b/tools/paconn-cli/paconn/commands/update.py
@@ -8,7 +8,7 @@ Update command.
 """
 
 from paconn import _UPDATE
-from paconn.common.util import displayMessage
+from paconn.common.util import display_message
 from paconn.settings.util import load_powerapps_and_flow_rp
 from paconn.operations.upsert import upsert
 from paconn.settings.settingsbuilder import SettingsBuilder
@@ -52,4 +52,4 @@ def update(
         is_update=True,
         overwrite_settings=False)
 
-    displayMessage('{} updated successfully.'.format(connector_id))
+    display_message('{} updated successfully.'.format(connector_id))

--- a/tools/paconn-cli/paconn/commands/validate.py
+++ b/tools/paconn-cli/paconn/commands/validate.py
@@ -9,7 +9,7 @@ Validate command.
 
 from paconn import _VALIDATE
 
-from paconn.common.util import display
+from paconn.common.util import displayMessage, displayError
 from paconn.settings.util import load_powerapps_and_flow_rp
 from paconn.settings.settingsbuilder import SettingsBuilder
 
@@ -45,6 +45,6 @@ def validate(
         settings=settings)
 
     if result:
-        display(result)
+        displayError(result)
     else:
-        display('{} validated successfully.'.format(settings.api_definition))
+        displayMessage('{} validated successfully.'.format(settings.api_definition))

--- a/tools/paconn-cli/paconn/commands/validate.py
+++ b/tools/paconn-cli/paconn/commands/validate.py
@@ -9,7 +9,7 @@ Validate command.
 
 from paconn import _VALIDATE
 
-from paconn.common.util import displayMessage, displayError
+from paconn.common.util import display_message, display_error
 from paconn.settings.util import load_powerapps_and_flow_rp
 from paconn.settings.settingsbuilder import SettingsBuilder
 
@@ -45,6 +45,6 @@ def validate(
         settings=settings)
 
     if result:
-        displayError(result)
+        display_error(result)
     else:
-        displayMessage('{} validated successfully.'.format(settings.api_definition))
+        display_message('{} validated successfully.'.format(settings.api_definition))

--- a/tools/paconn-cli/paconn/common/prompts.py
+++ b/tools/paconn-cli/paconn/common/prompts.py
@@ -9,7 +9,7 @@ Prompts the user for missing arguments
 """
 
 from knack.prompting import prompt_choice_list
-from paconn.common.util import displayMessage
+from paconn.common.util import display_message
 
 _PROPERTIES = 'properties'
 _VALUE = 'value'
@@ -35,7 +35,7 @@ def get_environment(flow_rp):
     sid = prompt_choice_list('Please select an environment:', environment_keys)
     environment = environments[environment_keys[sid]]
 
-    displayMessage('Environment selected: {}'.format(environment_keys[sid]))
+    display_message('Environment selected: {}'.format(environment_keys[sid]))
 
     return environment
 
@@ -57,6 +57,6 @@ def get_connector_id(powerapps_rp, environment):
     sid = prompt_choice_list('Please select a connector:', connectors_keys)
     connector_id = connectors[connectors_keys[sid]]
 
-    displayMessage('Connector selected: {}'.format(connectors_keys[sid]))
+    display_message('Connector selected: {}'.format(connectors_keys[sid]))
 
     return connector_id

--- a/tools/paconn-cli/paconn/common/prompts.py
+++ b/tools/paconn-cli/paconn/common/prompts.py
@@ -9,6 +9,7 @@ Prompts the user for missing arguments
 """
 
 from knack.prompting import prompt_choice_list
+from paconn.common.util import displayMessage
 
 _PROPERTIES = 'properties'
 _VALUE = 'value'
@@ -34,7 +35,7 @@ def get_environment(flow_rp):
     sid = prompt_choice_list('Please select an environment:', environment_keys)
     environment = environments[environment_keys[sid]]
 
-    print('Environment selected: {}'.format(environment_keys[sid]))
+    displayMessage('Environment selected: {}'.format(environment_keys[sid]))
 
     return environment
 
@@ -56,6 +57,6 @@ def get_connector_id(powerapps_rp, environment):
     sid = prompt_choice_list('Please select a connector:', connectors_keys)
     connector_id = connectors[connectors_keys[sid]]
 
-    print('Connector selected: {}'.format(connectors_keys[sid]))
+    displayMessage('Connector selected: {}'.format(connectors_keys[sid]))
 
     return connector_id

--- a/tools/paconn-cli/paconn/common/util.py
+++ b/tools/paconn-cli/paconn/common/util.py
@@ -22,11 +22,18 @@ def get_config_dir():
     return os.path.expanduser(os.path.join('~', '.{}'.format(__CLI_NAME__)))
 
 
-def display(txt):
+def displayError(errorMessage):
     """
-    Displayed the text to stderr stream.
+    Displays the message to stderr stream.
     """
-    print(txt, file=sys.stderr)
+    print(errorMessage, file=sys.stderr)
+
+
+def displayMessage(message, flush=False):
+    """
+    Displays the message to stdout stream.
+    """
+    print(message, file=sys.stdout, flush=flush)
 
 
 def format_json(content, sort_keys=False):

--- a/tools/paconn-cli/paconn/common/util.py
+++ b/tools/paconn-cli/paconn/common/util.py
@@ -22,14 +22,14 @@ def get_config_dir():
     return os.path.expanduser(os.path.join('~', '.{}'.format(__CLI_NAME__)))
 
 
-def displayError(errorMessage):
+def display_error(errorMessage):
     """
     Displays the message to stderr stream.
     """
     print(errorMessage, file=sys.stderr)
 
 
-def displayMessage(message, flush=False):
+def display_message(message, flush=False):
     """
     Displays the message to stdout stream.
     """


### PR DESCRIPTION
paconn sends success messages like `Login successful.` to the `stderr`. When integrating `paconn` into other tools/pipelines this causes strange behaviour. 

This PR changes:
- All messages are routed through the util helpers, either `DisplayMessage` or `DisplayError`
- Nowhere `Print()` is used directly
- Ability to force flush of a message, usefull when `login` displays the device code

