### PR TITLE
Add support for empty formId include itemId field

### DIFF
--- a/certified-connectors/Team Forms/apiDefinition.swagger.json
+++ b/certified-connectors/Team Forms/apiDefinition.swagger.json
@@ -235,7 +235,22 @@
             "$ref": "#/parameters/groupId"
           },
           {
-            "$ref": "#/parameters/formId"
+            "name": "formId",
+            "in": "query",
+            "type": "string",
+            "description": "Unique id for the form. Leave blank to trigger for all forms in the selected team.",
+            "x-ms-summary": "Form",
+            "x-ms-visibility": "important",
+            "x-ms-dynamic-values": {
+              "operationId": "Forms",
+              "value-path": "fields/tfFormId",
+              "value-title": "fields/tfTitle",
+              "parameters": {
+                "groupId": {
+                  "parameter": "groupId"
+                }
+              }
+            }
           },
           {
             "$ref": "#/parameters/environment"
@@ -292,7 +307,6 @@
           {
             "name": "formId",
             "in": "query",
-            "required": true,
             "type": "string"
           },
           {

--- a/certified-connectors/Team Forms/apiDefinition.swagger.json
+++ b/certified-connectors/Team Forms/apiDefinition.swagger.json
@@ -619,6 +619,9 @@
         },
         "webUrl": {
           "type": "string"
+        },
+        "itemId": {
+          "description": "The SharePoint item id"
         }
       }
     },


### PR DESCRIPTION
The PR adds the following:

- Adds support for triggering "When a form response is submitted" form any form in a team by leaving formId blank.
- Adds new itemId field to file schema 
---

- [x] I attest that the connector doesn't exist on the Power Platform today. I've verified by checking the pull requests in GitHub and by searching for the connector on the platform or in the documentation. 
- [x] I attest that the connector works and I verified by deploying and testing all the operations. 
- [x] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [x] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [x] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [x] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.