### PR TITLE
fix(assemblyai): Allow additional properties in AssemblyAI connector

### DIFF
--- a/certified-connectors/AssemblyAI/apiDefinition.swagger.json
+++ b/certified-connectors/AssemblyAI/apiDefinition.swagger.json
@@ -1026,7 +1026,6 @@
   "definitions": {
     "RedactedAudioResponse": {
       "type": "object",
-      "additionalProperties": false,
       "required": ["status", "redacted_audio_url"],
       "properties": {
         "status": {
@@ -1044,7 +1043,6 @@
     },
     "WordSearchResponse": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "id": {
           "description": "The ID of the transcript",
@@ -1063,7 +1061,6 @@
           "items": {
             "x-ms-summary": "Match",
             "type": "object",
-            "additionalProperties": false,
             "properties": {
               "text": {
                 "description": "The matched word",
@@ -1110,7 +1107,6 @@
     "TranscriptParams": {
       "description": "The parameters for creating a transcript",
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "audio_url": {
           "description": "The URL of the audio or video file to transcribe.",
@@ -1419,7 +1415,6 @@
             "x-ms-summary": "Custom Spelling",
             "description": "Object containing words or phrases to replace, and the word or phrase to replace with",
             "type": "object",
-            "additionalProperties": false,
             "properties": {
               "from": {
                 "description": "Words or phrases to replace",
@@ -1507,7 +1502,6 @@
     "Transcript": {
       "description": "A transcript object",
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "id": {
           "description": "The unique identifier of your transcript",
@@ -1657,7 +1651,6 @@
           "items": {
             "x-ms-summary": "Word",
             "type": "object",
-            "additionalProperties": false,
             "required": ["confidence", "start", "end", "text"],
             "properties": {
               "confidence": {
@@ -1694,7 +1687,6 @@
           "items": {
             "x-ms-summary": "Utterance",
             "type": "object",
-            "additionalProperties": false,
             "properties": {
               "confidence": {
                 "description": "The confidence score for the transcript of this utterance",
@@ -1725,7 +1717,6 @@
                 "items": {
                   "x-ms-summary": "Word",
                   "type": "object",
-                  "additionalProperties": false,
                   "required": ["confidence", "start", "end", "text"],
                   "properties": {
                     "confidence": {
@@ -1854,7 +1845,6 @@
               "items": {
                 "x-ms-summary": "Auto Highlight Result",
                 "type": "object",
-                "additionalProperties": false,
                 "required": ["count", "rank", "text", "timestamps"],
                 "properties": {
                   "count": {
@@ -1882,7 +1872,6 @@
                       "x-ms-summary": "Timestamp",
                       "description": "Timestamp containing a start and end property in milliseconds",
                       "type": "object",
-                      "additionalProperties": false,
                       "properties": {
                         "start": {
                           "description": "The start time in milliseconds",
@@ -2043,7 +2032,6 @@
               "items": {
                 "x-ms-summary": "Content Moderation Label Result",
                 "type": "object",
-                "additionalProperties": false,
                 "required": [
                   "text",
                   "labels",
@@ -2063,7 +2051,6 @@
                     "items": {
                       "x-ms-summary": "Label",
                       "type": "object",
-                      "additionalProperties": false,
                       "required": ["label", "confidence", "severity"],
                       "properties": {
                         "label": {
@@ -2105,7 +2092,6 @@
                     "description": "Timestamp containing a start and end property in milliseconds",
                     "x-ms-summary": "Timestamp",
                     "type": "object",
-                    "additionalProperties": false,
                     "properties": {
                       "start": {
                         "description": "The start time in milliseconds",
@@ -2169,7 +2155,6 @@
                 "x-ms-summary": "Topic Detection Result",
                 "description": "The result of the topic detection model",
                 "type": "object",
-                "additionalProperties": false,
                 "required": ["text"],
                 "properties": {
                   "text": {
@@ -2181,7 +2166,6 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "additionalProperties": false,
                       "required": ["relevance", "label"],
                       "properties": {
                         "relevance": {
@@ -2206,7 +2190,6 @@
                     "x-ms-summary": "Timestamp",
                     "description": "Timestamp containing a start and end property in milliseconds",
                     "type": "object",
-                    "additionalProperties": false,
                     "properties": {
                       "start": {
                         "description": "The start time in milliseconds",
@@ -2245,7 +2228,6 @@
             "x-ms-summary": "Custom Spelling",
             "description": "Object containing words or phrases to replace, and the word or phrase to replace with",
             "type": "object",
-            "additionalProperties": false,
             "properties": {
               "from": {
                 "description": "Words or phrases to replace",
@@ -2279,7 +2261,6 @@
             "x-ms-summary": "Chapter",
             "description": "Chapter of the audio file",
             "type": "object",
-            "additionalProperties": false,
             "required": ["gist", "headline", "summary", "start", "end"],
             "properties": {
               "gist": {
@@ -2357,7 +2338,6 @@
             "x-ms-summary": "Sentiment Analysis Result",
             "description": "The result of the Sentiment Analysis model",
             "type": "object",
-            "additionalProperties": false,
             "required": ["text", "start", "end", "sentiment", "confidence"],
             "properties": {
               "text": {
@@ -2409,7 +2389,6 @@
             "x-ms-summary": "Entity",
             "description": "A detected entity",
             "type": "object",
-            "additionalProperties": false,
             "required": ["entity_type", "text", "start", "end"],
             "properties": {
               "entity_type": {
@@ -2552,7 +2531,6 @@
     },
     "SentencesResponse": {
       "type": "object",
-      "additionalProperties": false,
       "required": ["id", "confidence", "audio_duration", "sentences"],
       "properties": {
         "id": {
@@ -2576,7 +2554,6 @@
           "items": {
             "x-ms-summary": "Sentence",
             "type": "object",
-            "additionalProperties": false,
             "required": ["text", "start", "end", "confidence", "words"],
             "properties": {
               "text": {
@@ -2603,7 +2580,6 @@
                 "items": {
                   "x-ms-summary": "Word",
                   "type": "object",
-                  "additionalProperties": false,
                   "required": ["confidence", "start", "end", "text"],
                   "properties": {
                     "confidence": {
@@ -2647,7 +2623,6 @@
     },
     "ParagraphsResponse": {
       "type": "object",
-      "additionalProperties": false,
       "required": ["id", "confidence", "audio_duration", "paragraphs"],
       "properties": {
         "id": {
@@ -2671,7 +2646,6 @@
           "items": {
             "x-ms-summary": "Paragraph",
             "type": "object",
-            "additionalProperties": false,
             "required": ["text", "start", "end", "confidence", "words"],
             "properties": {
               "text": {
@@ -2698,7 +2672,6 @@
                 "items": {
                   "x-ms-summary": "Word",
                   "type": "object",
-                  "additionalProperties": false,
                   "required": ["confidence", "start", "end", "text"],
                   "properties": {
                     "confidence": {
@@ -2743,14 +2716,12 @@
     "TranscriptList": {
       "description": "A list of transcripts. Transcripts are sorted from newest to oldest. The previous URL always points to a page with older transcripts.",
       "type": "object",
-      "additionalProperties": false,
       "required": ["page_details", "transcripts"],
       "properties": {
         "page_details": {
           "x-ms-summary": "Page Details",
           "description": "Details of the transcript page. Transcripts are sorted from newest to oldest. The previous URL always points to a page with older transcripts.",
           "type": "object",
-          "additionalProperties": false,
           "required": ["limit", "result_count", "current_url"],
           "properties": {
             "limit": {
@@ -2785,7 +2756,6 @@
           "items": {
             "x-ms-summary": "Transcript List Item",
             "type": "object",
-            "additionalProperties": false,
             "required": [
               "id",
               "resource_url",
@@ -2836,7 +2806,6 @@
     },
     "UploadedFile": {
       "type": "object",
-      "additionalProperties": false,
       "required": ["upload_url"],
       "properties": {
         "upload_url": {
@@ -2848,7 +2817,6 @@
     },
     "PurgeLemurRequestDataResponse": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "request_id": {
           "type": "string",
@@ -2888,7 +2856,6 @@
           "description": "The usage numbers for the LeMUR request",
           "x-ms-summary": "Usage",
           "type": "object",
-          "additionalProperties": false,
           "required": ["input_tokens", "output_tokens"],
           "properties": {
             "input_tokens": {
@@ -2926,7 +2893,6 @@
           "description": "The usage numbers for the LeMUR request",
           "x-ms-summary": "Usage",
           "type": "object",
-          "additionalProperties": false,
           "required": ["input_tokens", "output_tokens"],
           "properties": {
             "input_tokens": {
@@ -3015,7 +2981,6 @@
     },
     "Error": {
       "type": "object",
-      "additionalProperties": false,
       "required": ["error"],
       "properties": {
         "error": {


### PR DESCRIPTION
We're testing the updated connector for AssemblyAI and noticed validation errors because new properties started being returned from the API.
The spec has been updated to allow additional properties that aren't documented in the spec yet.

- [x] I attest that the connector doesn't exist on the Power Platform today. I've verified by checking the pull requests in GitHub and by searching for the connector on the platform or in the documentation. 
- [x] I attest that the connector works and I verified by deploying and testing all the operations. 
- [x] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [x] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [x] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [x] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.


