### PR TITLE
Handle unexpected Async responses better

### DIFF
--- a/certified-connectors/Snowflake v2/apiDefinition.swagger.json
+++ b/certified-connectors/Snowflake v2/apiDefinition.swagger.json
@@ -979,10 +979,6 @@
             "schema": {
               "type": "object",
               "properties": {
-                "DummyParam": {
-                  "type": "string",
-                  "description": "This is not used"
-                },
                 "DataSchema": {
                   "type": "array",
                   "items": {

--- a/certified-connectors/Snowflake v2/apiDefinition.swagger.json
+++ b/certified-connectors/Snowflake v2/apiDefinition.swagger.json
@@ -688,6 +688,10 @@
                   },
                   "description": "Data"
                 },
+                "StatementHandle": {
+                  "type": "string",
+                  "description": "StatementHandle"
+                },
                 "Metadata": {
                   "type": "object",
                   "properties": {
@@ -716,10 +720,6 @@
                       "type": "string",
                       "description": "SqlState"
                     },
-                    "StatementHandle": {
-                      "type": "string",
-                      "description": "StatementHandle"
-                    },
                     "CreatedOn": {
                       "type": "string",
                       "description": "CreatedOn"
@@ -735,31 +735,43 @@
             "schema": {
               "type": "object",
               "properties": {
-                "statementHandle": {
-                  "type": "string",
-                  "example": "GUID value"
-                },
-                "code": {
-                  "type": "string",
-                  "example": "000123"
-                },
-                "sqlState": {
-                  "type": "string",
-                  "example": "42601"
-                },
-                "message": {
-                  "type": "string",
-                  "example": "successfully executed"
-                },
-                "createdOn": {
-                  "type": "integer",
-                  "format": "int32",
-                  "description": "Timestamp that specifies when the statement execution started. The timestamp is expressed in milliseconds since the epoch",
-                  "example": 1597090533987
-                },
-                "statementStatusUrl": {
-                  "type": "string",
-                  "example": "/api/v2/statements/GUID value"
+                "Metadata": {
+                  "type": "object",
+                  "properties": {
+                    "Rows": {
+                      "type": "integer",
+                      "format": "int32",
+                      "description": "Rows"
+                    },
+                    "Format": {
+                      "type": "string",
+                      "description": "Format"
+                    },
+                    "Code": {
+                      "type": "string",
+                      "description": "Code"
+                    },
+                    "StatementStatusUrl": {
+                      "type": "string",
+                      "description": "StatementStatusUrl"
+                    },
+                    "RequestId": {
+                      "type": "string",
+                      "description": "RequestId"
+                    },
+                    "SqlState": {
+                      "type": "string",
+                      "description": "SqlState"
+                    },
+                    "CreatedOn": {
+                      "type": "string",
+                      "description": "CreatedOn"
+                    },
+                    "Message": {
+                      "type": "string",
+                      "description": "Message"
+                    }
+                  }
                 }
               }
             }

--- a/certified-connectors/Snowflake v2/apiDefinition.swagger.json
+++ b/certified-connectors/Snowflake v2/apiDefinition.swagger.json
@@ -975,9 +975,10 @@
           {
             "name": "body",
             "in": "body",
-            "required": false,
+            "required": true,
             "schema": {
               "type": "object",
+              "required": ["DataSchema"],
               "properties": {
                 "DataSchema": {
                   "type": "array",
@@ -1249,9 +1250,9 @@
         ]
       }
     },
-    "/api/v2/convert": {},
     "/convert": {
       "post": {
+        "deprecated": true,
         "responses": {
           "200": {
             "description": "default",

--- a/certified-connectors/Snowflake v2/apiDefinition.swagger.json
+++ b/certified-connectors/Snowflake v2/apiDefinition.swagger.json
@@ -558,7 +558,7 @@
       }
     },
     "/{statementHandle}": {
-      "get": {
+      "post": {
         "responses": {
           "200": {
             "description": "Success operation",
@@ -971,6 +971,74 @@
             "type": "integer",
             "description": "partition",
             "x-ms-summary": "partition"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": false,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "DummyParam": {
+                  "type": "string",
+                  "description": "This is not used"
+                },
+                "DataSchema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "description": "name"
+                      },
+                      "database": {
+                        "type": "string",
+                        "description": "database"
+                      },
+                      "schema": {
+                        "type": "string",
+                        "description": "schema"
+                      },
+                      "table": {
+                        "type": "string",
+                        "description": "table"
+                      },
+                      "nullable": {
+                        "type": "boolean",
+                        "description": "nullable"
+                      },
+                      "precision": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "precision"
+                      },
+                      "scale": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "scale"
+                      },
+                      "byteLength": {
+                        "type": "integer",
+                        "description": "byteLength"
+                      },
+                      "collation": {
+                        "type": "string",
+                        "description": "collation"
+                      },
+                      "length": {
+                        "type": "integer",
+                        "description": "length"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "type"
+                      }
+                    }
+                  }
+                }
+              }
+            }
           }
         ]
       }

--- a/certified-connectors/Snowflake v2/apiDefinition.swagger.json
+++ b/certified-connectors/Snowflake v2/apiDefinition.swagger.json
@@ -975,10 +975,9 @@
           {
             "name": "body",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "object",
-              "required": ["DataSchema"],
               "properties": {
                 "DataSchema": {
                   "type": "array",

--- a/certified-connectors/Snowflake v2/readme.md
+++ b/certified-connectors/Snowflake v2/readme.md
@@ -1,7 +1,6 @@
-# Snowflake 
+# Snowflake
 
 This connector is based on the [Snowflake SQL REST API](https://docs.snowflake.com/en/developer-guide/sql-api/index.html). Snowflake enables data storage, processing, and analytic solutions that are faster, easier to use, and more flexible than traditional offerings. The connector uses the Snowflake REST API V2 to submit synchronous and asynchronous queries and retrieve corresponding results.
-
 
 ## Publisher: Snowflake
 
@@ -14,30 +13,40 @@ This connector is based on the [Snowflake SQL REST API](https://docs.snowflake.c
 ## Supported Operations
 
 ### Submit SQL Statement for Execution
+
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Submit SQL statement for execution on snowflake.
+
 ### Check the Status and Get Results
+
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Check the status of the execution and get the results, by providing the statementHandle.
+
 ### Cancel the Execution of a Statement
+
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Cancels the execution of a statement, by providing the statementHandle.
+
 ### Convert result set rows from array to objects
+
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Converts result set rows from array of string to JSON object.
 
 ## Obtaining Credentials
+
 Set up Azure AD authentication for Snowflake by following these steps:
+
 1. In [Step 1: Configure the OAuth Resource in Azure AD](https://docs.snowflake.com/en/user-guide/oauth-azure.html#configure-the-oauth-resource-in-azure-ad), follow steps 1-10 and define the scope as `SESSION:ROLE-ANY` by following these [instructions](https://docs.snowflake.com/en/user-guide/oauth-azure.html#using-any-role-with-external-oauth).
 2. In [Step 2: Create an OAuth Client in Azure AD](https://docs.snowflake.com/en/user-guide/oauth-azure.html#create-an-oauth-client-in-azure-ad), follow steps 1-13.
 3. Navigate to **Authentication** -> **Platform configurations** -> **Add a platform** -> **Add** "https://global.consent.azure-apim.net/redirect/snowflakepa" -> Click **Save**. Ensure that the redirect URL is set in the Snowflake OAuth Client and not the Snowflake OAuth Resource.
 4. Go to the resource created in Step 1 and go to **Expose an API** -> **Add a client application** -> **Add** your `APPLICATION_CLIENT_ID` from earlier in step 3 above -> Click **Save**
 5. Follow [Step 3: Collect Azure AD Information for Snowflake](https://docs.snowflake.com/en/user-guide/oauth-azure.html#collect-azure-ad-information-for-snowflake) entirely. 
 6. Copy and paste the text below into your Snowflake worksheet, which is where you execute your queries in Snowflake. Before you execute the query, make sure you make the following replacements so that your query succeeds.
-    * In Microsoft Azure, go to your Snowflake OAuth Resource app and click on **Endpoints**. 
-    * To get the AZURE_AD_ISSUER in line 5, copy the link in the **Federation metadata document** field and open the link in a new tab. Copy the entityID link which should something look like this: `https://sts.windows.net/90288a9b-97df-4c6d-b025-95713f21cef9/`. Paste it into the query  and make sure you have a `/` before the last quotation mark and that you keep the quotation marks. 
-    * To get the Keys URL in line 6, copy the link in the **OpenID Connect metadata document** field and open the link in a new tab. Copy the jwks_uri which should look something like this: `https://login.microsoftonline.com/90288a9b-97df-4c6d-b025-95713f21cef9/discovery/v2.0/keys`. Paste it into the query and make sure you keep the quotation marks.
-    * Replace the Audience List URL in line 7 with `Application ID URI` from Step 1. Keep the quotation marks.   
-    * If your Snowflake account uses the same email address as your Microsoft Azure account, then replace `login_name` in line 9 with `email_address`. If not, keep it as is and do not type in your login name. Keep the quotation marks.
-    * Make sure you've set your role as `ACCOUNTADMIN`. Now you can execute your query. 
 
-```
+    - In Microsoft Azure, go to your Snowflake OAuth Resource app and click on **Endpoints**. 
+    - To get the AZURE_AD_ISSUER in line 5, copy the link in the **Federation metadata document** field and open the link in a new tab. Copy the entityID link which should something look like this: `https://sts.windows.net/90288a9b-97df-4c6d-b025-95713f21cef9/`. Paste it into the query  and make sure you have a `/` before the last quotation mark and that you keep the quotation marks. 
+    - To get the Keys URL in line 6, copy the link in the **OpenID Connect metadata document** field and open the link in a new tab. Copy the jwks_uri which should look something like this: `https://login.microsoftonline.com/90288a9b-97df-4c6d-b025-95713f21cef9/discovery/v2.0/keys`. Paste it into the query and make sure you keep the quotation marks.
+    - Replace the Audience List URL in line 7 with `Application ID URI` from Step 1. Keep the quotation marks.   
+    - If your Snowflake account uses the same email address as your Microsoft Azure account, then replace `login_name` in line 9 with `email_address`. If not, keep it as is and do not type in your login name. Keep the quotation marks.
+    - Make sure you've set your role as `ACCOUNTADMIN`. Now you can execute your query. 
+
+``` text
 CREATE SECURITY INTEGRATION <integration name>
        type = external_oauth
        enabled = true
@@ -49,26 +58,46 @@ CREATE SECURITY INTEGRATION <integration name>
        external_oauth_snowflake_user_mapping_attribute = 'login_name'
        external_oauth_any_role_mode = 'ENABLE';
 ```
+
 ## Getting Started
+
 1. Add Snowflake connector in the Power App or Flow.
 2. Enter connection credentials as below:\
-       * Client Id: Snowflake OAuth Client ID from registered client app in Azure.\
-       * Client Secret: Snowflake OAuth Client secret from registered client app in Azure.\
-       * Resource URL: Application ID URI from registered resource app in Azure.
+       - Client Id: Snowflake OAuth Client ID from registered client app in Azure.\
+       - Client Secret: Snowflake OAuth Client secret from registered client app in Azure.\
+       - Resource URL: Application ID URI from registered resource app in Azure.
 3. Click on Sign in button and provider user credentials.
 
 ## Known Issues and Limitations
+
 1. If you get a 500 response when creating a new connection, that is a transient error. Please wait a few minutes and try again.
 2. If you get a 401 response and your Host field in Step 1 follows this format "orgname-accountname," replace the Host field with your "locator" URL.
 3. The connector may time out with large query results. 
 
 ## Frequently Asked Questions
+
 1. How can the connector be used within Power Apps?
 Currently, Power Apps does not support dynamic schema. You can still use the connector from Power Apps by calling a flow from the app instead of directly from an  app. 
 
 ## Deployment Instructions
+
 1. Download the connector source code from GitHub repository.
 2. Follow the instructions provided in [Create a New Custom Connector](https://learn.microsoft.com/en-us/connectors/custom-connectors/paconn-cli#create-a-new-custom-connector) to deploy the connector in your favourite Power Platform Environment.
-3. Follow the steps metnioned in [Obtaining Credentials](#obtaining-credentials) section to get credentials.
-4. Test the connector with the above obtained credentials.
+3. Once the connector is deployed, follow the instructions in [Update an existing custom connector](https://learn.microsoft.com/en-us/connectors/custom-connectors/paconn-cli#update-an-existing-custom-connector) to update the connector with the latest changes.
+4. Follow the steps metnioned in [Obtaining Credentials](#obtaining-credentials) section to get credentials.
+5. Test the connector with the above obtained credentials.
 
+## Version History
+
+### August 2024
+
+#### Fixes
+
+- Resolve issue where null values for numeric columns would result in an error when calling **Submit SQL Statement for Execution** action or the **Convert result set rows from array to objects** action.
+- Resolve issue where multi-partition results are not properly converted to JSON objects when calling the **Convert result set rows from array to objects** action. 
+- Resolve issue where the **Convert result set rows from array to objects** action would not properly convert the result set rows to JSON objects.
+
+#### Breaking Changes
+
+- The **Convert result set rows from array to objects** action is deprecated. This behavior has been integrated into the **Submit SQL Statement for Execution** and **Check the Status and Get Results** actions.
+- The **Check the Status and Get Results** action now requires the **DataSchema** input parameter to be provided

--- a/certified-connectors/Snowflake v2/script.csx
+++ b/certified-connectors/Snowflake v2/script.csx
@@ -35,7 +35,7 @@ public class Script : ScriptBase
     private const string Snowflake_Type_Time = "time";
 
     private const string QueryString_Partition = "partition";
-+    private const string QueryString_FetchAllPartitions = "fetchAllPartitions"
+    private const string QueryString_FetchAllPartitions = "fetchAllPartitions"
     #endregion
 
     public HttpResponseMessage TestConvert(string content, string operationId)
@@ -337,7 +337,7 @@ public class Script : ScriptBase
         public string ErrorMessage { get ;set; }
         public HttpStatusCode ErrorStatusCode { get; set; }
 
-        public GetAsResponse()
+        public HttpResponseMessage GetAsResponse()
         {
             if(Success)
             {

--- a/certified-connectors/Snowflake v2/script.csx
+++ b/certified-connectors/Snowflake v2/script.csx
@@ -104,15 +104,10 @@ public class Script : ScriptBase
 
     private bool IsTransformable()
     {
-        if (Context.OperationId == OP_EXECUTE_SQL)
+        if (Context.OperationId == OP_EXECUTE_SQL
+            || Context.OperationId == OP_GET_RESULTS)
         {
             return true;
-        }
-        else if (Context.OperationId == OP_GET_RESULTS)
-        {
-            var query = HttpUtility.ParseQueryString(Context.Request.RequestUri.Query);
-
-            return (query == null || query[QueryString_Partition] == null || query[QueryString_Partition] == "0");
         }
         else
         {

--- a/certified-connectors/Snowflake v2/script.csx
+++ b/certified-connectors/Snowflake v2/script.csx
@@ -69,37 +69,35 @@ public class Script : ScriptBase
         Context.Request.RequestUri = uriBuilder.Uri;
 
         HttpResponseMessage response = await Context.SendAsync(Context.Request, CancellationToken).ConfigureAwait(continueOnCapturedContext: false);
-        var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-        return ConvertToObjects(responseContent, Context.OperationId).GetAsResponse();
 
-        //if (response.IsSuccessStatusCode && IsTransformable())
-        //{
-        //    var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-        //    var converted = ConvertToObjects(responseContent, Context.OperationId);
+        if (response.IsSuccessStatusCode && IsTransformable())
+        {
+            var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var converted = ConvertToObjects(responseContent, Context.OperationId);
 
-        //    // if this parameter is set in PowerApps then fetch all partitions, instead of making them page manually.
-        //    if (GetQueryStringParam(QueryString_FetchAllPartitions) == "true")
-        //    {
-        //        // yes, this starts at 1 because we've already fetched the first partition.
-        //        for (var i = 1; i < converted.Response.Partitions.Count(); i++)
-        //        {
-        //            SetQueryStringParam(QueryString_Partition, $"{i}");
-        //            response = await Context.SendAsync(Context.Request, CancellationToken).ConfigureAwait(continueOnCapturedContext: false);
-        //            responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-        //            var partitionResult = ConvertToObjects(responseContent, Context.OperationId);
-        //            foreach (var item in partitionResult.Response.Data)
-        //            {
-        //                converted.Response.Data.Add(item);
-        //            }
-        //        }
-        //    }
+            // if this parameter is set in PowerApps then fetch all partitions, instead of making them page manually.
+            if (GetQueryStringParam(QueryString_FetchAllPartitions) == "true")
+            {
+                // yes, this starts at 1 because we've already fetched the first partition.
+                for (var i = 1; i < converted.Response.Partitions.Count(); i++)
+                {
+                    SetQueryStringParam(QueryString_Partition, $"{i}");
+                    response = await Context.SendAsync(Context.Request, CancellationToken).ConfigureAwait(continueOnCapturedContext: false);
+                    responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var partitionResult = ConvertToObjects(responseContent, Context.OperationId);
+                    foreach (var item in partitionResult.Response.Data)
+                    {
+                        converted.Response.Data.Add(item);
+                    }
+                }
+            }
 
-        //    return converted.GetAsResponse();
-        //}
-        //else
-        //{
-        //    return response;
-        //}
+            return converted.GetAsResponse();
+        }
+        else
+        {
+            return response;
+        }
     }
     private Dictionary<string, string> GetQueryString()
     {

--- a/certified-connectors/Snowflake v2/script.csx
+++ b/certified-connectors/Snowflake v2/script.csx
@@ -8,7 +8,6 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Threading;
 using System.Web;
-using System.Linq;
 
 public class Script : ScriptBase
 {

--- a/certified-connectors/Snowflake v2/script.csx
+++ b/certified-connectors/Snowflake v2/script.csx
@@ -68,6 +68,10 @@ public class Script : ScriptBase
         uriBuilder.Host = snowflakeInstanceURL;
         Context.Request.RequestUri = uriBuilder.Uri;
 
+        if(Context.OperationId == OP_GET_RESULTS)
+        {
+            Context.Request.Method = HttpMethod.Get;
+        }
         HttpResponseMessage response = await Context.SendAsync(Context.Request, CancellationToken).ConfigureAwait(continueOnCapturedContext: false);
 
         if (response.IsSuccessStatusCode && IsTransformable())
@@ -75,22 +79,22 @@ public class Script : ScriptBase
             var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             var converted = ConvertToObjects(responseContent, Context.OperationId);
 
-            // if this parameter is set in PowerApps then fetch all partitions, instead of making them page manually.
-            if (GetQueryStringParam(QueryString_FetchAllPartitions) == "true")
-            {
-                // yes, this starts at 1 because we've already fetched the first partition.
-                for (var i = 1; i < converted.Response.Partitions.Count(); i++)
-                {
-                    SetQueryStringParam(QueryString_Partition, $"{i}");
-                    response = await Context.SendAsync(Context.Request, CancellationToken).ConfigureAwait(continueOnCapturedContext: false);
-                    responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var partitionResult = ConvertToObjects(responseContent, Context.OperationId);
-                    foreach (var item in partitionResult.Response.Data)
-                    {
-                        converted.Response.Data.Add(item);
-                    }
-                }
-            }
+            // // if this parameter is set in PowerApps then fetch all partitions, instead of making them page manually.
+            // if (GetQueryStringParam(QueryString_FetchAllPartitions) == "true")
+            // {
+            //     // yes, this starts at 1 because we've already fetched the first partition.
+            //     for (var i = 1; i < converted.Response.Partitions.Count(); i++)
+            //     {
+            //         SetQueryStringParam(QueryString_Partition, $"{i}");
+            //         response = await Context.SendAsync(Context.Request, CancellationToken).ConfigureAwait(continueOnCapturedContext: false);
+            //         responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            //         var partitionResult = ConvertToObjects(responseContent, Context.OperationId);
+            //         foreach (var item in partitionResult.Response.Data)
+            //         {
+            //             converted.Response.Data.Add(item);
+            //         }
+            //     }
+            // }
 
             return converted.GetAsResponse();
         }

--- a/certified-connectors/Snowflake v2/script.csx
+++ b/certified-connectors/Snowflake v2/script.csx
@@ -82,14 +82,14 @@ public class Script : ScriptBase
             HttpResponseMessage response = await Context.SendAsync(Context.Request, CancellationToken).ConfigureAwait(continueOnCapturedContext: false);
             if (response.IsSuccessStatusCode)
             {
-                if(IsFullResponseWithData())
+                if(IsFullResponseWithData(response))
                 {
                     var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                     var converted = ConvertToObjects_FullReponseWithData(responseContent, Context.OperationId, originalContent);
 
                     return converted.GetAsResponse();
                 }
-                else if(IsAsyncResponse())
+                else if(IsAsyncResponse(response))
                 {
                     var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                     var converted = ConvertToObjects_AsyncResponse(responseContent, Context.OperationId);
@@ -154,16 +154,16 @@ public class Script : ScriptBase
         return (nullable == "true");
     }
 
-    private bool IsFullResponseWithData()
+    private bool IsFullResponseWithData(HttpResponseMessage response)
     {
-        return (Context.OperationId == OP_EXECUTE_SQL || Context.OperationId == OP_GET_RESULTS)
-            && GetQueryStringParam(QueryString_Async) != "true";
+        return (Context.OperationId == OP_EXECUTE_SQL || Context.OperationId == OP_GET_RESULTS) &&
+            response.StatusCode == HttpStatusCode.OK;
     }
 
-    private bool IsAsyncResponse()
+    private bool IsAsyncResponse(HttpResponseMessage response)
     {
-        return Context.OperationId == OP_EXECUTE_SQL &&
-            GetQueryStringParam(QueryString_Async) == "true";
+        return (Context.OperationId == OP_EXECUTE_SQL || Context.OperationId == OP_GET_RESULTS) &&
+            response.StatusCode == HttpStatusCode.Accepted;
     }
 
     private ConvertObjectResult ConvertToObjects_AsyncResponse(string content, string operationId)
@@ -447,6 +447,17 @@ public class Script : ScriptBase
                 return createErrorResponse(ErrorStatusCode, ErrorMessage);
             }
         }
+    }
+
+    public class PerformanceData
+    {
+        public DateTimeOffset BeingFetch {get;set;}
+        public DateTimeOffset EndFetch {get;set;}
+        public int FetchDurationSeconds {get;set;}
+
+        public DateTimeOffset? BeginConvert {get;set;}
+        public DateTimeOffset? EndConvert {get;set;}
+        public int? ConvertDurationSeconds {get;set;}
     }
 
     public class SnowflakeResponseMetadata

--- a/certified-connectors/Snowflake v2/script.csx
+++ b/certified-connectors/Snowflake v2/script.csx
@@ -8,6 +8,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Threading;
 using System.Web;
+using System.Collections.Specialized;
 
 public class Script : ScriptBase
 {
@@ -35,7 +36,7 @@ public class Script : ScriptBase
     private const string Snowflake_Type_Time = "time";
 
     private const string QueryString_Partition = "partition";
-    private const string QueryString_FetchAllPartitions = "fetchAllPartitions"
+    private const string QueryString_FetchAllPartitions = "fetchAllPartitions";
     #endregion
 
     public HttpResponseMessage TestConvert(string content, string operationId)
@@ -72,18 +73,18 @@ public class Script : ScriptBase
         {
             var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             var results = ConvertToObjects(responseContent, Context.OperationId);
-            
+
             // if this parameter is set in PowerApps then fetch all partitions, instead of making them page manually.
-            if(GetQueryStringParam(QueryString_FetchAllPartitions))
+            if (GetQueryStringParam(QueryString_FetchAllPartitions))
             {
                 // yes, this starts at 1 because we've already fetched the first partition.
-                for(var i = 1;i < results.Partitions;i++)
+                for (var i = 1; i < results.Partitions; i++)
                 {
                     SetQueryStringParam(QueryString_Partition) = i;
                     response = await Context.SendAsync(Context.Request, CancellationToken).ConfigureAwait(continueOnCapturedContext: false);
                     responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                     var partitionResult = ConvertObjectResult(responseContent, Context.OperationId);
-                    foreach(var item in partitionResult.Data)
+                    foreach (var item in partitionResult.Data)
                     {
                         results.Data.Add(item);
                     }
@@ -110,7 +111,7 @@ public class Script : ScriptBase
 
         Context.Request.RequestUri.Query = parms.ToString();
     }
-    
+
     private bool IsUrlValid(string url)
     {
         string patternAccount;
@@ -288,7 +289,7 @@ public class Script : ScriptBase
     {
         return new HttpResponseMessage(code)
         {
-            Content = CreateJsonContent(JsonConvert.SerializeObject(payload,Newtonsoft.Json.Formatting.None, new JsonSerializerSettings { NullValueHandling = Newtonsoft.Json.NullValueHandling.Include}))
+            Content = CreateJsonContent(JsonConvert.SerializeObject(payload, Newtonsoft.Json.Formatting.None, new JsonSerializerSettings { NullValueHandling = Newtonsoft.Json.NullValueHandling.Include }))
         };
     }
 
@@ -330,24 +331,26 @@ public class Script : ScriptBase
 
     #region Sub classes
 
-    public class ConvertObjectResult()
+    public class ConvertObjectResult
     {
         public SnowflakeResponse ResponseContent { get; set; }
         public bool Success { get; set; }
-        public string ErrorMessage { get ;set; }
+        public string ErrorMessage { get; set; }
         public HttpStatusCode ErrorStatusCode { get; set; }
 
         public HttpResponseMessage GetAsResponse()
         {
-            if(Success)
+            if (Success)
             {
                 return createResponse(HttpStatusCode.OK, ResponseContent);
             }
-            else{
-                return createErrorResponse(ErrorStatusCode,ErrorMessage);
+            else
+            {
+                return createErrorResponse(ErrorStatusCode, ErrorMessage);
             }
         }
     }
+
     public class SnowflakeResponseMetadata
     {
         public long Rows { get; set; }

--- a/certified-connectors/Snowflake v2/script.csx
+++ b/certified-connectors/Snowflake v2/script.csx
@@ -36,7 +36,6 @@ public class Script : ScriptBase
     private const string Snowflake_Type_Time = "time";
 
     private const string QueryString_Partition = "partition";
-    private const string QueryString_FetchAllPartitions = "fetchAllPartitions";
     #endregion
 
     public HttpResponseMessage TestConvert(string content, string operationId)
@@ -48,7 +47,6 @@ public class Script : ScriptBase
     {
         try
         {
-            
             var originalContent = await Context.Request.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             if (Context.OperationId == OP_CONVERT)
@@ -175,7 +173,7 @@ public class Script : ScriptBase
 
                     if(schema is null)
                     {
-                        throw new Exception($"['{Attr_Metadata}'] values are missing, very likely because you are fetching a non-zero partition. If that is the case then you are required to pass ['DataSchema'] in the request body.");
+                        throw new Exception($"['{Attr_Metadata}']['{Attr_RowType}'] values are missing from response, very likely because you are fetching a non-zero partition. If that is the case then you are required to pass ['DataSchema'] in the request body.");
                     }
                 }
             }

--- a/certified-connectors/Snowflake v2/script.csx
+++ b/certified-connectors/Snowflake v2/script.csx
@@ -116,7 +116,6 @@ public class Script : ScriptBase
         var parms = GetQueryString();
         parms[paramName] = value;
 
-        //Context.Request.RequestUri.Query = parms.ToString();
         Context.Request.RequestUri = new Uri(Context.Request.RequestUri.AbsolutePath + parms.ToString());
     }
 


### PR DESCRIPTION
- The previous Async fixes assumed that the shape of the response would always match what was requested. That is not always true. If you make a Sync request, but it runs too long snowflake may choose to return an Async response to check back later for the results. Also if you run GetResults and the data isn't ready yet, it needs to be able to handle yet another Async status response without data.