### PR TITLE
Qdrant (Independent Publisher)

### DIFF
--- a/independent-publisher-connectors/Qdrant/apiDefinition.swagger.json
+++ b/independent-publisher-connectors/Qdrant/apiDefinition.swagger.json
@@ -1,0 +1,20302 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Qdrant",
+    "description": "Qdrant (read: quadrant ) is a vector similarity search engine. It provides a production-ready service with a convenient API to store, search, and manage vectors with additional payload and extended filtering support. It makes it useful for all sorts of neural network or semantic-based matching, faceted search, and other applications.",
+    "contact": {
+      "name": "Anush008",
+      "url": "https://github.com/anush008",
+      "email": "anush.shetty@qdrant.com"
+    }
+  },
+  "host": "xyz-example.eu-central.aws.cloud.qdrant.io:6333",
+  "basePath": "/",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/collections/{collection_name}/index/{field_name}": {
+      "delete": {
+        "summary": "Delete index for field in collection",
+        "description": "Delete field index for collection",
+        "operationId": "DeleteIndexForFieldInCollection",
+        "parameters": [
+          {
+            "name": "wait",
+            "default": "<boolean>",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "Wait",
+            "x-ms-summary": "Wait"
+          },
+          {
+            "name": "ordering",
+            "default": "strong",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "Ordering",
+            "x-ms-summary": "Ordering"
+          },
+          {
+            "name": "collection_name",
+            "default": "<string>",
+            "in": "path",
+            "x-ms-url-encoding": "single",
+            "type": "string",
+            "required": true,
+            "x-ms-summary": "Collection Name",
+            "description": "Collection Name"
+          },
+          {
+            "name": "field_name",
+            "default": "<string>",
+            "in": "path",
+            "x-ms-url-encoding": "single",
+            "type": "string",
+            "required": true,
+            "x-ms-summary": "Field Name",
+            "description": "Field Name"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Accept",
+            "x-ms-summary": "Accept"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "string",
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "description": "status"
+                    },
+                    "operation_id": {
+                      "type": "string",
+                      "description": "operation_id"
+                    }
+                  },
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "500",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/collections/{collection_name}/index": {
+      "put": {
+        "summary": "Create index for field in collection",
+        "description": "Create index for field in collection",
+        "operationId": "CreateIndexForFieldInCollection",
+        "parameters": [
+          {
+            "name": "wait",
+            "default": "<boolean>",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "Wait",
+            "x-ms-summary": "Wait"
+          },
+          {
+            "name": "ordering",
+            "default": "strong",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "Ordering",
+            "x-ms-summary": "Ordering"
+          },
+          {
+            "name": "collection_name",
+            "default": "<string>",
+            "in": "path",
+            "x-ms-url-encoding": "single",
+            "type": "string",
+            "required": true,
+            "description": "Collection Name",
+            "x-ms-summary": "Collection Name"
+          },
+          {
+            "name": "Content-Type",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Content-Type",
+            "x-ms-summary": "Content-Type"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Accept",
+            "x-ms-summary": "Accept"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "field_name": {
+                  "type": "string",
+                  "description": "field_name"
+                },
+                "field_schema": {
+                  "type": "string",
+                  "description": "field_schema"
+                }
+              },
+              "default": {
+                "field_name": "<string>",
+                "field_schema": "bool"
+              }
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "string",
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "description": "status"
+                    },
+                    "operation_id": {
+                      "type": "string",
+                      "description": "operation_id"
+                    }
+                  },
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "500",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/collections/{collection_name}/exists": {
+      "get": {
+        "summary": "Check the existence of a collection",
+        "description": "Returns \"true\" if the given collection name exists, and \"false\" otherwise",
+        "operationId": "CheckTheExistenceOfACollection",
+        "parameters": [
+          {
+            "name": "collection_name",
+            "default": "<string>",
+            "in": "path",
+            "x-ms-url-encoding": "single",
+            "type": "string",
+            "required": true,
+            "description": "Collection Name",
+            "x-ms-summary": "Collection Name"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Accept",
+            "x-ms-summary": "Accept"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "string",
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {
+                    "exists": {
+                      "type": "string",
+                      "description": "exists"
+                    }
+                  },
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "500",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/collections/{collection_name}/points/delete": {
+      "post": {
+        "summary": "Delete points",
+        "description": "Delete points",
+        "operationId": "DeletePoints",
+        "parameters": [
+          {
+            "name": "wait",
+            "default": "<boolean>",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "Wait",
+            "x-ms-summary": "Wait"
+          },
+          {
+            "name": "ordering",
+            "default": "strong",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "Ordering",
+            "x-ms-summary": "Ordering"
+          },
+          {
+            "name": "collection_name",
+            "default": "<string>",
+            "in": "path",
+            "x-ms-url-encoding": "single",
+            "type": "string",
+            "required": true,
+            "description": "Collection Name",
+            "x-ms-summary": "Collection Name"
+          },
+          {
+            "name": "Content-Type",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Content-Type",
+            "x-ms-summary": "Content-Type"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Accept",
+            "x-ms-summary": "Accept"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "points": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "points"
+                },
+                "shard_key": {
+                  "type": "string",
+                  "description": "shard_key"
+                }
+              },
+              "default": {
+                "points": [
+                  "<integer>",
+                  "<integer>"
+                ],
+                "shard_key": "<string>"
+              }
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "string",
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "description": "status"
+                    },
+                    "operation_id": {
+                      "type": "string",
+                      "description": "operation_id"
+                    }
+                  },
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "500",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/collections/{collection_name}/points/vectors/delete": {
+      "post": {
+        "summary": "Delete vectors",
+        "description": "Delete named vectors from the given points.",
+        "operationId": "DeleteVectors",
+        "parameters": [
+          {
+            "name": "wait",
+            "default": "<boolean>",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "Wait",
+            "x-ms-summary": "Wait"
+          },
+          {
+            "name": "ordering",
+            "default": "strong",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "Ordering",
+            "x-ms-summary": "Ordering"
+          },
+          {
+            "name": "collection_name",
+            "default": "<string>",
+            "in": "path",
+            "x-ms-url-encoding": "single",
+            "type": "string",
+            "required": true,
+            "description": "Collection Name",
+            "x-ms-summary": "Collection Name"
+          },
+          {
+            "name": "Content-Type",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Content-Type",
+            "x-ms-summary": "Content-Type"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Accept",
+            "x-ms-summary": "Accept"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "vector": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "vector"
+                },
+                "points": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "points"
+                },
+                "filter": {
+                  "type": "object",
+                  "properties": {
+                    "should": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string",
+                          "description": "key"
+                        },
+                        "match": {
+                          "type": "object",
+                          "properties": {
+                            "value": {
+                              "type": "string",
+                              "description": "value"
+                            }
+                          },
+                          "description": "match"
+                        },
+                        "range": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "range"
+                        },
+                        "geo_bounding_box": {
+                          "type": "object",
+                          "properties": {
+                            "bottom_right": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "bottom_right"
+                            },
+                            "top_left": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "top_left"
+                            }
+                          },
+                          "description": "geo_bounding_box"
+                        },
+                        "geo_radius": {
+                          "type": "object",
+                          "properties": {
+                            "center": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "center"
+                            },
+                            "radius": {
+                              "type": "string",
+                              "description": "radius"
+                            }
+                          },
+                          "description": "geo_radius"
+                        },
+                        "geo_polygon": {
+                          "type": "object",
+                          "properties": {
+                            "exterior": {
+                              "type": "object",
+                              "properties": {
+                                "points": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    }
+                                  },
+                                  "description": "points"
+                                }
+                              },
+                              "description": "exterior"
+                            },
+                            "interiors": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "points": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "lat": {
+                                          "type": "string",
+                                          "description": "lat"
+                                        },
+                                        "lon": {
+                                          "type": "string",
+                                          "description": "lon"
+                                        }
+                                      }
+                                    },
+                                    "description": "points"
+                                  }
+                                }
+                              },
+                              "description": "interiors"
+                            }
+                          },
+                          "description": "geo_polygon"
+                        },
+                        "values_count": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "values_count"
+                        }
+                      },
+                      "description": "should"
+                    },
+                    "min_should": {
+                      "type": "object",
+                      "properties": {
+                        "conditions": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "key": {
+                                "type": "string",
+                                "description": "key"
+                              },
+                              "match": {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "string",
+                                    "description": "value"
+                                  }
+                                },
+                                "description": "match"
+                              },
+                              "range": {
+                                "type": "object",
+                                "properties": {
+                                  "lt": {
+                                    "type": "string",
+                                    "description": "lt"
+                                  },
+                                  "gt": {
+                                    "type": "string",
+                                    "description": "gt"
+                                  },
+                                  "gte": {
+                                    "type": "string",
+                                    "description": "gte"
+                                  },
+                                  "lte": {
+                                    "type": "string",
+                                    "description": "lte"
+                                  }
+                                },
+                                "description": "range"
+                              },
+                              "geo_bounding_box": {
+                                "type": "object",
+                                "properties": {
+                                  "bottom_right": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    },
+                                    "description": "bottom_right"
+                                  },
+                                  "top_left": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    },
+                                    "description": "top_left"
+                                  }
+                                },
+                                "description": "geo_bounding_box"
+                              },
+                              "geo_radius": {
+                                "type": "object",
+                                "properties": {
+                                  "center": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    },
+                                    "description": "center"
+                                  },
+                                  "radius": {
+                                    "type": "string",
+                                    "description": "radius"
+                                  }
+                                },
+                                "description": "geo_radius"
+                              },
+                              "geo_polygon": {
+                                "type": "object",
+                                "properties": {
+                                  "exterior": {
+                                    "type": "object",
+                                    "properties": {
+                                      "points": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "lat": {
+                                              "type": "string",
+                                              "description": "lat"
+                                            },
+                                            "lon": {
+                                              "type": "string",
+                                              "description": "lon"
+                                            }
+                                          }
+                                        },
+                                        "description": "points"
+                                      }
+                                    },
+                                    "description": "exterior"
+                                  },
+                                  "interiors": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "points": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "lat": {
+                                                "type": "string",
+                                                "description": "lat"
+                                              },
+                                              "lon": {
+                                                "type": "string",
+                                                "description": "lon"
+                                              }
+                                            }
+                                          },
+                                          "description": "points"
+                                        }
+                                      }
+                                    },
+                                    "description": "interiors"
+                                  }
+                                },
+                                "description": "geo_polygon"
+                              },
+                              "values_count": {
+                                "type": "object",
+                                "properties": {
+                                  "lt": {
+                                    "type": "string",
+                                    "description": "lt"
+                                  },
+                                  "gt": {
+                                    "type": "string",
+                                    "description": "gt"
+                                  },
+                                  "gte": {
+                                    "type": "string",
+                                    "description": "gte"
+                                  },
+                                  "lte": {
+                                    "type": "string",
+                                    "description": "lte"
+                                  }
+                                },
+                                "description": "values_count"
+                              }
+                            }
+                          },
+                          "description": "conditions"
+                        },
+                        "min_count": {
+                          "type": "string",
+                          "description": "min_count"
+                        }
+                      },
+                      "description": "min_should"
+                    },
+                    "must": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string",
+                          "description": "key"
+                        },
+                        "match": {
+                          "type": "object",
+                          "properties": {
+                            "value": {
+                              "type": "string",
+                              "description": "value"
+                            }
+                          },
+                          "description": "match"
+                        },
+                        "range": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "range"
+                        },
+                        "geo_bounding_box": {
+                          "type": "object",
+                          "properties": {
+                            "bottom_right": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "bottom_right"
+                            },
+                            "top_left": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "top_left"
+                            }
+                          },
+                          "description": "geo_bounding_box"
+                        },
+                        "geo_radius": {
+                          "type": "object",
+                          "properties": {
+                            "center": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "center"
+                            },
+                            "radius": {
+                              "type": "string",
+                              "description": "radius"
+                            }
+                          },
+                          "description": "geo_radius"
+                        },
+                        "geo_polygon": {
+                          "type": "object",
+                          "properties": {
+                            "exterior": {
+                              "type": "object",
+                              "properties": {
+                                "points": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    }
+                                  },
+                                  "description": "points"
+                                }
+                              },
+                              "description": "exterior"
+                            },
+                            "interiors": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "points": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "lat": {
+                                          "type": "string",
+                                          "description": "lat"
+                                        },
+                                        "lon": {
+                                          "type": "string",
+                                          "description": "lon"
+                                        }
+                                      }
+                                    },
+                                    "description": "points"
+                                  }
+                                }
+                              },
+                              "description": "interiors"
+                            }
+                          },
+                          "description": "geo_polygon"
+                        },
+                        "values_count": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "values_count"
+                        }
+                      },
+                      "description": "must"
+                    },
+                    "must_not": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string",
+                          "description": "key"
+                        },
+                        "match": {
+                          "type": "object",
+                          "properties": {
+                            "value": {
+                              "type": "string",
+                              "description": "value"
+                            }
+                          },
+                          "description": "match"
+                        },
+                        "range": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "range"
+                        },
+                        "geo_bounding_box": {
+                          "type": "object",
+                          "properties": {
+                            "bottom_right": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "bottom_right"
+                            },
+                            "top_left": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "top_left"
+                            }
+                          },
+                          "description": "geo_bounding_box"
+                        },
+                        "geo_radius": {
+                          "type": "object",
+                          "properties": {
+                            "center": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "center"
+                            },
+                            "radius": {
+                              "type": "string",
+                              "description": "radius"
+                            }
+                          },
+                          "description": "geo_radius"
+                        },
+                        "geo_polygon": {
+                          "type": "object",
+                          "properties": {
+                            "exterior": {
+                              "type": "object",
+                              "properties": {
+                                "points": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    }
+                                  },
+                                  "description": "points"
+                                }
+                              },
+                              "description": "exterior"
+                            },
+                            "interiors": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "points": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "lat": {
+                                          "type": "string",
+                                          "description": "lat"
+                                        },
+                                        "lon": {
+                                          "type": "string",
+                                          "description": "lon"
+                                        }
+                                      }
+                                    },
+                                    "description": "points"
+                                  }
+                                }
+                              },
+                              "description": "interiors"
+                            }
+                          },
+                          "description": "geo_polygon"
+                        },
+                        "values_count": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "values_count"
+                        }
+                      },
+                      "description": "must_not"
+                    }
+                  },
+                  "description": "filter"
+                },
+                "shard_key": {
+                  "type": "string",
+                  "description": "shard_key"
+                }
+              },
+              "default": {
+                "vector": [
+                  "<string>"
+                ],
+                "points": [
+                  "<integer>",
+                  "<integer>"
+                ],
+                "filter": {
+                  "should": {
+                    "key": "<string>",
+                    "match": {
+                      "value": "<string>"
+                    },
+                    "range": {
+                      "lt": "<double>",
+                      "gt": "<double>",
+                      "gte": "<double>",
+                      "lte": "<double>"
+                    },
+                    "geo_bounding_box": {
+                      "bottom_right": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "top_left": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      }
+                    },
+                    "geo_radius": {
+                      "center": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "radius": "<double>"
+                    },
+                    "geo_polygon": {
+                      "exterior": {
+                        "points": [
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        ]
+                      },
+                      "interiors": [
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        },
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "values_count": {
+                      "lt": "<integer>",
+                      "gt": "<integer>",
+                      "gte": "<integer>",
+                      "lte": "<integer>"
+                    }
+                  },
+                  "min_should": {
+                    "conditions": [
+                      {
+                        "key": "<string>",
+                        "match": {
+                          "value": "<string>"
+                        },
+                        "range": {
+                          "lt": "<double>",
+                          "gt": "<double>",
+                          "gte": "<double>",
+                          "lte": "<double>"
+                        },
+                        "geo_bounding_box": {
+                          "bottom_right": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "top_left": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        },
+                        "geo_radius": {
+                          "center": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "radius": "<double>"
+                        },
+                        "geo_polygon": {
+                          "exterior": {
+                            "points": [
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            ]
+                          },
+                          "interiors": [
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            },
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "values_count": {
+                          "lt": "<integer>",
+                          "gt": "<integer>",
+                          "gte": "<integer>",
+                          "lte": "<integer>"
+                        }
+                      },
+                      {
+                        "key": "<string>",
+                        "match": {
+                          "value": "<string>"
+                        },
+                        "range": {
+                          "lt": "<double>",
+                          "gt": "<double>",
+                          "gte": "<double>",
+                          "lte": "<double>"
+                        },
+                        "geo_bounding_box": {
+                          "bottom_right": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "top_left": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        },
+                        "geo_radius": {
+                          "center": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "radius": "<double>"
+                        },
+                        "geo_polygon": {
+                          "exterior": {
+                            "points": [
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            ]
+                          },
+                          "interiors": [
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            },
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "values_count": {
+                          "lt": "<integer>",
+                          "gt": "<integer>",
+                          "gte": "<integer>",
+                          "lte": "<integer>"
+                        }
+                      }
+                    ],
+                    "min_count": "<integer>"
+                  },
+                  "must": {
+                    "key": "<string>",
+                    "match": {
+                      "value": "<string>"
+                    },
+                    "range": {
+                      "lt": "<double>",
+                      "gt": "<double>",
+                      "gte": "<double>",
+                      "lte": "<double>"
+                    },
+                    "geo_bounding_box": {
+                      "bottom_right": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "top_left": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      }
+                    },
+                    "geo_radius": {
+                      "center": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "radius": "<double>"
+                    },
+                    "geo_polygon": {
+                      "exterior": {
+                        "points": [
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        ]
+                      },
+                      "interiors": [
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        },
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "values_count": {
+                      "lt": "<integer>",
+                      "gt": "<integer>",
+                      "gte": "<integer>",
+                      "lte": "<integer>"
+                    }
+                  },
+                  "must_not": {
+                    "key": "<string>",
+                    "match": {
+                      "value": "<string>"
+                    },
+                    "range": {
+                      "lt": "<double>",
+                      "gt": "<double>",
+                      "gte": "<double>",
+                      "lte": "<double>"
+                    },
+                    "geo_bounding_box": {
+                      "bottom_right": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "top_left": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      }
+                    },
+                    "geo_radius": {
+                      "center": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "radius": "<double>"
+                    },
+                    "geo_polygon": {
+                      "exterior": {
+                        "points": [
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        ]
+                      },
+                      "interiors": [
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        },
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "values_count": {
+                      "lt": "<integer>",
+                      "gt": "<integer>",
+                      "gte": "<integer>",
+                      "lte": "<integer>"
+                    }
+                  }
+                },
+                "shard_key": "<string>"
+              }
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "string",
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "description": "status"
+                    },
+                    "operation_id": {
+                      "type": "string",
+                      "description": "operation_id"
+                    }
+                  },
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "500",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/collections/{collection_name}/points/vectors": {
+      "put": {
+        "summary": "Update vectors",
+        "description": "Update specified named vectors on points, keep unspecified vectors intact.",
+        "operationId": "UpdateVectors",
+        "parameters": [
+          {
+            "name": "wait",
+            "default": "<boolean>",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "Wait",
+            "x-ms-summary": "Wait"
+          },
+          {
+            "name": "ordering",
+            "default": "strong",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "Ordering",
+            "x-ms-summary": "Ordering"
+          },
+          {
+            "name": "collection_name",
+            "default": "<string>",
+            "in": "path",
+            "x-ms-url-encoding": "single",
+            "type": "string",
+            "required": true,
+            "description": "Collection Name",
+            "x-ms-summary": "Collection Name"
+          },
+          {
+            "name": "Content-Type",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Content-Type",
+            "x-ms-summary": "Content-Type"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Accept",
+            "x-ms-summary": "Accept"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "points": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "description": "id"
+                      },
+                      "vector": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "vector"
+                      }
+                    }
+                  },
+                  "description": "points"
+                },
+                "shard_key": {
+                  "type": "string",
+                  "description": "shard_key"
+                }
+              },
+              "default": {
+                "points": [
+                  {
+                    "id": "<integer>",
+                    "vector": [
+                      "<float>",
+                      "<float>"
+                    ]
+                  }
+                ],
+                "shard_key": "<string>"
+              }
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "string",
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "description": "status"
+                    },
+                    "operation_id": {
+                      "type": "string",
+                      "description": "operation_id"
+                    }
+                  },
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "500",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/collections/{collection_name}/points/payload/delete": {
+      "post": {
+        "summary": "Delete payload",
+        "description": "Delete specified key payload for points",
+        "operationId": "DeletePayload",
+        "parameters": [
+          {
+            "name": "wait",
+            "default": "<boolean>",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "Wait",
+            "x-ms-summary": "Wait"
+          },
+          {
+            "name": "ordering",
+            "default": "strong",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "Ordering",
+            "x-ms-summary": "Ordering"
+          },
+          {
+            "name": "collection_name",
+            "default": "<string>",
+            "in": "path",
+            "x-ms-url-encoding": "single",
+            "type": "string",
+            "required": true,
+            "description": "Collection Name",
+            "x-ms-summary": "Collection Name"
+          },
+          {
+            "name": "Content-Type",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Content-Type",
+            "x-ms-summary": "Content-Type"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Accept",
+            "x-ms-summary": "Accept"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "keys": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "keys"
+                },
+                "points": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "points"
+                },
+                "filter": {
+                  "type": "object",
+                  "properties": {
+                    "should": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string",
+                          "description": "key"
+                        },
+                        "match": {
+                          "type": "object",
+                          "properties": {
+                            "value": {
+                              "type": "string",
+                              "description": "value"
+                            }
+                          },
+                          "description": "match"
+                        },
+                        "range": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "range"
+                        },
+                        "geo_bounding_box": {
+                          "type": "object",
+                          "properties": {
+                            "bottom_right": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "bottom_right"
+                            },
+                            "top_left": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "top_left"
+                            }
+                          },
+                          "description": "geo_bounding_box"
+                        },
+                        "geo_radius": {
+                          "type": "object",
+                          "properties": {
+                            "center": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "center"
+                            },
+                            "radius": {
+                              "type": "string",
+                              "description": "radius"
+                            }
+                          },
+                          "description": "geo_radius"
+                        },
+                        "geo_polygon": {
+                          "type": "object",
+                          "properties": {
+                            "exterior": {
+                              "type": "object",
+                              "properties": {
+                                "points": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    }
+                                  },
+                                  "description": "points"
+                                }
+                              },
+                              "description": "exterior"
+                            },
+                            "interiors": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "points": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "lat": {
+                                          "type": "string",
+                                          "description": "lat"
+                                        },
+                                        "lon": {
+                                          "type": "string",
+                                          "description": "lon"
+                                        }
+                                      }
+                                    },
+                                    "description": "points"
+                                  }
+                                }
+                              },
+                              "description": "interiors"
+                            }
+                          },
+                          "description": "geo_polygon"
+                        },
+                        "values_count": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "values_count"
+                        }
+                      },
+                      "description": "should"
+                    },
+                    "min_should": {
+                      "type": "object",
+                      "properties": {
+                        "conditions": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "key": {
+                                "type": "string",
+                                "description": "key"
+                              },
+                              "match": {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "string",
+                                    "description": "value"
+                                  }
+                                },
+                                "description": "match"
+                              },
+                              "range": {
+                                "type": "object",
+                                "properties": {
+                                  "lt": {
+                                    "type": "string",
+                                    "description": "lt"
+                                  },
+                                  "gt": {
+                                    "type": "string",
+                                    "description": "gt"
+                                  },
+                                  "gte": {
+                                    "type": "string",
+                                    "description": "gte"
+                                  },
+                                  "lte": {
+                                    "type": "string",
+                                    "description": "lte"
+                                  }
+                                },
+                                "description": "range"
+                              },
+                              "geo_bounding_box": {
+                                "type": "object",
+                                "properties": {
+                                  "bottom_right": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    },
+                                    "description": "bottom_right"
+                                  },
+                                  "top_left": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    },
+                                    "description": "top_left"
+                                  }
+                                },
+                                "description": "geo_bounding_box"
+                              },
+                              "geo_radius": {
+                                "type": "object",
+                                "properties": {
+                                  "center": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    },
+                                    "description": "center"
+                                  },
+                                  "radius": {
+                                    "type": "string",
+                                    "description": "radius"
+                                  }
+                                },
+                                "description": "geo_radius"
+                              },
+                              "geo_polygon": {
+                                "type": "object",
+                                "properties": {
+                                  "exterior": {
+                                    "type": "object",
+                                    "properties": {
+                                      "points": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "lat": {
+                                              "type": "string",
+                                              "description": "lat"
+                                            },
+                                            "lon": {
+                                              "type": "string",
+                                              "description": "lon"
+                                            }
+                                          }
+                                        },
+                                        "description": "points"
+                                      }
+                                    },
+                                    "description": "exterior"
+                                  },
+                                  "interiors": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "points": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "lat": {
+                                                "type": "string",
+                                                "description": "lat"
+                                              },
+                                              "lon": {
+                                                "type": "string",
+                                                "description": "lon"
+                                              }
+                                            }
+                                          },
+                                          "description": "points"
+                                        }
+                                      }
+                                    },
+                                    "description": "interiors"
+                                  }
+                                },
+                                "description": "geo_polygon"
+                              },
+                              "values_count": {
+                                "type": "object",
+                                "properties": {
+                                  "lt": {
+                                    "type": "string",
+                                    "description": "lt"
+                                  },
+                                  "gt": {
+                                    "type": "string",
+                                    "description": "gt"
+                                  },
+                                  "gte": {
+                                    "type": "string",
+                                    "description": "gte"
+                                  },
+                                  "lte": {
+                                    "type": "string",
+                                    "description": "lte"
+                                  }
+                                },
+                                "description": "values_count"
+                              }
+                            }
+                          },
+                          "description": "conditions"
+                        },
+                        "min_count": {
+                          "type": "string",
+                          "description": "min_count"
+                        }
+                      },
+                      "description": "min_should"
+                    },
+                    "must": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string",
+                          "description": "key"
+                        },
+                        "match": {
+                          "type": "object",
+                          "properties": {
+                            "value": {
+                              "type": "string",
+                              "description": "value"
+                            }
+                          },
+                          "description": "match"
+                        },
+                        "range": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "range"
+                        },
+                        "geo_bounding_box": {
+                          "type": "object",
+                          "properties": {
+                            "bottom_right": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "bottom_right"
+                            },
+                            "top_left": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "top_left"
+                            }
+                          },
+                          "description": "geo_bounding_box"
+                        },
+                        "geo_radius": {
+                          "type": "object",
+                          "properties": {
+                            "center": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "center"
+                            },
+                            "radius": {
+                              "type": "string",
+                              "description": "radius"
+                            }
+                          },
+                          "description": "geo_radius"
+                        },
+                        "geo_polygon": {
+                          "type": "object",
+                          "properties": {
+                            "exterior": {
+                              "type": "object",
+                              "properties": {
+                                "points": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    }
+                                  },
+                                  "description": "points"
+                                }
+                              },
+                              "description": "exterior"
+                            },
+                            "interiors": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "points": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "lat": {
+                                          "type": "string",
+                                          "description": "lat"
+                                        },
+                                        "lon": {
+                                          "type": "string",
+                                          "description": "lon"
+                                        }
+                                      }
+                                    },
+                                    "description": "points"
+                                  }
+                                }
+                              },
+                              "description": "interiors"
+                            }
+                          },
+                          "description": "geo_polygon"
+                        },
+                        "values_count": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "values_count"
+                        }
+                      },
+                      "description": "must"
+                    },
+                    "must_not": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string",
+                          "description": "key"
+                        },
+                        "match": {
+                          "type": "object",
+                          "properties": {
+                            "value": {
+                              "type": "string",
+                              "description": "value"
+                            }
+                          },
+                          "description": "match"
+                        },
+                        "range": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "range"
+                        },
+                        "geo_bounding_box": {
+                          "type": "object",
+                          "properties": {
+                            "bottom_right": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "bottom_right"
+                            },
+                            "top_left": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "top_left"
+                            }
+                          },
+                          "description": "geo_bounding_box"
+                        },
+                        "geo_radius": {
+                          "type": "object",
+                          "properties": {
+                            "center": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "center"
+                            },
+                            "radius": {
+                              "type": "string",
+                              "description": "radius"
+                            }
+                          },
+                          "description": "geo_radius"
+                        },
+                        "geo_polygon": {
+                          "type": "object",
+                          "properties": {
+                            "exterior": {
+                              "type": "object",
+                              "properties": {
+                                "points": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    }
+                                  },
+                                  "description": "points"
+                                }
+                              },
+                              "description": "exterior"
+                            },
+                            "interiors": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "points": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "lat": {
+                                          "type": "string",
+                                          "description": "lat"
+                                        },
+                                        "lon": {
+                                          "type": "string",
+                                          "description": "lon"
+                                        }
+                                      }
+                                    },
+                                    "description": "points"
+                                  }
+                                }
+                              },
+                              "description": "interiors"
+                            }
+                          },
+                          "description": "geo_polygon"
+                        },
+                        "values_count": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "values_count"
+                        }
+                      },
+                      "description": "must_not"
+                    }
+                  },
+                  "description": "filter"
+                },
+                "shard_key": {
+                  "type": "string",
+                  "description": "shard_key"
+                }
+              },
+              "default": {
+                "keys": [
+                  "<string>",
+                  "<string>"
+                ],
+                "points": [
+                  "<integer>",
+                  "<integer>"
+                ],
+                "filter": {
+                  "should": {
+                    "key": "<string>",
+                    "match": {
+                      "value": "<string>"
+                    },
+                    "range": {
+                      "lt": "<double>",
+                      "gt": "<double>",
+                      "gte": "<double>",
+                      "lte": "<double>"
+                    },
+                    "geo_bounding_box": {
+                      "bottom_right": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "top_left": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      }
+                    },
+                    "geo_radius": {
+                      "center": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "radius": "<double>"
+                    },
+                    "geo_polygon": {
+                      "exterior": {
+                        "points": [
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        ]
+                      },
+                      "interiors": [
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        },
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "values_count": {
+                      "lt": "<integer>",
+                      "gt": "<integer>",
+                      "gte": "<integer>",
+                      "lte": "<integer>"
+                    }
+                  },
+                  "min_should": {
+                    "conditions": [
+                      {
+                        "key": "<string>",
+                        "match": {
+                          "value": "<string>"
+                        },
+                        "range": {
+                          "lt": "<double>",
+                          "gt": "<double>",
+                          "gte": "<double>",
+                          "lte": "<double>"
+                        },
+                        "geo_bounding_box": {
+                          "bottom_right": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "top_left": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        },
+                        "geo_radius": {
+                          "center": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "radius": "<double>"
+                        },
+                        "geo_polygon": {
+                          "exterior": {
+                            "points": [
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            ]
+                          },
+                          "interiors": [
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            },
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "values_count": {
+                          "lt": "<integer>",
+                          "gt": "<integer>",
+                          "gte": "<integer>",
+                          "lte": "<integer>"
+                        }
+                      },
+                      {
+                        "key": "<string>",
+                        "match": {
+                          "value": "<string>"
+                        },
+                        "range": {
+                          "lt": "<double>",
+                          "gt": "<double>",
+                          "gte": "<double>",
+                          "lte": "<double>"
+                        },
+                        "geo_bounding_box": {
+                          "bottom_right": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "top_left": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        },
+                        "geo_radius": {
+                          "center": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "radius": "<double>"
+                        },
+                        "geo_polygon": {
+                          "exterior": {
+                            "points": [
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            ]
+                          },
+                          "interiors": [
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            },
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "values_count": {
+                          "lt": "<integer>",
+                          "gt": "<integer>",
+                          "gte": "<integer>",
+                          "lte": "<integer>"
+                        }
+                      }
+                    ],
+                    "min_count": "<integer>"
+                  },
+                  "must": {
+                    "key": "<string>",
+                    "match": {
+                      "value": "<string>"
+                    },
+                    "range": {
+                      "lt": "<double>",
+                      "gt": "<double>",
+                      "gte": "<double>",
+                      "lte": "<double>"
+                    },
+                    "geo_bounding_box": {
+                      "bottom_right": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "top_left": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      }
+                    },
+                    "geo_radius": {
+                      "center": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "radius": "<double>"
+                    },
+                    "geo_polygon": {
+                      "exterior": {
+                        "points": [
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        ]
+                      },
+                      "interiors": [
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        },
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "values_count": {
+                      "lt": "<integer>",
+                      "gt": "<integer>",
+                      "gte": "<integer>",
+                      "lte": "<integer>"
+                    }
+                  },
+                  "must_not": {
+                    "key": "<string>",
+                    "match": {
+                      "value": "<string>"
+                    },
+                    "range": {
+                      "lt": "<double>",
+                      "gt": "<double>",
+                      "gte": "<double>",
+                      "lte": "<double>"
+                    },
+                    "geo_bounding_box": {
+                      "bottom_right": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "top_left": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      }
+                    },
+                    "geo_radius": {
+                      "center": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "radius": "<double>"
+                    },
+                    "geo_polygon": {
+                      "exterior": {
+                        "points": [
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        ]
+                      },
+                      "interiors": [
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        },
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "values_count": {
+                      "lt": "<integer>",
+                      "gt": "<integer>",
+                      "gte": "<integer>",
+                      "lte": "<integer>"
+                    }
+                  }
+                },
+                "shard_key": "<string>"
+              }
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "string",
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "description": "status"
+                    },
+                    "operation_id": {
+                      "type": "string",
+                      "description": "operation_id"
+                    }
+                  },
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "500",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/collections/{collection_name}/points/payload/clear": {
+      "post": {
+        "summary": "Clear payload",
+        "description": "Remove all payload for specified points",
+        "operationId": "ClearPayload",
+        "parameters": [
+          {
+            "name": "wait",
+            "default": "<boolean>",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "Wait",
+            "x-ms-summary": "Wait"
+          },
+          {
+            "name": "ordering",
+            "default": "strong",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "Ordering",
+            "x-ms-summary": "Ordering"
+          },
+          {
+            "name": "collection_name",
+            "default": "<string>",
+            "in": "path",
+            "x-ms-url-encoding": "single",
+            "type": "string",
+            "required": true,
+            "description": "Collection Name",
+            "x-ms-summary": "Collection Name"
+          },
+          {
+            "name": "Content-Type",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Content-Type",
+            "x-ms-summary": "Content-Type"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Accept",
+            "x-ms-summary": "Accept"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "points": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "points"
+                },
+                "shard_key": {
+                  "type": "string",
+                  "description": "shard_key"
+                }
+              },
+              "default": {
+                "points": [
+                  "<integer>",
+                  "<integer>"
+                ],
+                "shard_key": "<string>"
+              }
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "string",
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "description": "status"
+                    },
+                    "operation_id": {
+                      "type": "string",
+                      "description": "operation_id"
+                    }
+                  },
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "500",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/collections/{collection_name}/points/payload": {
+      "post": {
+        "summary": "Set payload",
+        "description": "Set payload values for points",
+        "operationId": "SetPayload",
+        "parameters": [
+          {
+            "name": "wait",
+            "default": "<boolean>",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "Wait",
+            "x-ms-summary": "Wait"
+          },
+          {
+            "name": "ordering",
+            "default": "strong",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "Ordering",
+            "x-ms-summary": "Ordering"
+          },
+          {
+            "name": "collection_name",
+            "default": "<string>",
+            "in": "path",
+            "x-ms-url-encoding": "single",
+            "type": "string",
+            "required": true,
+            "description": "Collection Name",
+            "x-ms-summary": "Collection Name"
+          },
+          {
+            "name": "Content-Type",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Content-Type",
+            "x-ms-summary": "Content-Type"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Accept",
+            "x-ms-summary": "Accept"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "payload": {
+                  "type": "object",
+                  "properties": {
+                    "Excepteur_ff1": {
+                      "type": "boolean",
+                      "description": "Excepteur_ff1"
+                    }
+                  },
+                  "description": "payload"
+                },
+                "points": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "points"
+                },
+                "filter": {
+                  "type": "object",
+                  "properties": {
+                    "should": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string",
+                          "description": "key"
+                        },
+                        "match": {
+                          "type": "object",
+                          "properties": {
+                            "value": {
+                              "type": "string",
+                              "description": "value"
+                            }
+                          },
+                          "description": "match"
+                        },
+                        "range": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "range"
+                        },
+                        "geo_bounding_box": {
+                          "type": "object",
+                          "properties": {
+                            "bottom_right": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "bottom_right"
+                            },
+                            "top_left": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "top_left"
+                            }
+                          },
+                          "description": "geo_bounding_box"
+                        },
+                        "geo_radius": {
+                          "type": "object",
+                          "properties": {
+                            "center": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "center"
+                            },
+                            "radius": {
+                              "type": "string",
+                              "description": "radius"
+                            }
+                          },
+                          "description": "geo_radius"
+                        },
+                        "geo_polygon": {
+                          "type": "object",
+                          "properties": {
+                            "exterior": {
+                              "type": "object",
+                              "properties": {
+                                "points": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    }
+                                  },
+                                  "description": "points"
+                                }
+                              },
+                              "description": "exterior"
+                            },
+                            "interiors": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "points": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "lat": {
+                                          "type": "string",
+                                          "description": "lat"
+                                        },
+                                        "lon": {
+                                          "type": "string",
+                                          "description": "lon"
+                                        }
+                                      }
+                                    },
+                                    "description": "points"
+                                  }
+                                }
+                              },
+                              "description": "interiors"
+                            }
+                          },
+                          "description": "geo_polygon"
+                        },
+                        "values_count": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "values_count"
+                        }
+                      },
+                      "description": "should"
+                    },
+                    "min_should": {
+                      "type": "object",
+                      "properties": {
+                        "conditions": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "key": {
+                                "type": "string",
+                                "description": "key"
+                              },
+                              "match": {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "string",
+                                    "description": "value"
+                                  }
+                                },
+                                "description": "match"
+                              },
+                              "range": {
+                                "type": "object",
+                                "properties": {
+                                  "lt": {
+                                    "type": "string",
+                                    "description": "lt"
+                                  },
+                                  "gt": {
+                                    "type": "string",
+                                    "description": "gt"
+                                  },
+                                  "gte": {
+                                    "type": "string",
+                                    "description": "gte"
+                                  },
+                                  "lte": {
+                                    "type": "string",
+                                    "description": "lte"
+                                  }
+                                },
+                                "description": "range"
+                              },
+                              "geo_bounding_box": {
+                                "type": "object",
+                                "properties": {
+                                  "bottom_right": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    },
+                                    "description": "bottom_right"
+                                  },
+                                  "top_left": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    },
+                                    "description": "top_left"
+                                  }
+                                },
+                                "description": "geo_bounding_box"
+                              },
+                              "geo_radius": {
+                                "type": "object",
+                                "properties": {
+                                  "center": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    },
+                                    "description": "center"
+                                  },
+                                  "radius": {
+                                    "type": "string",
+                                    "description": "radius"
+                                  }
+                                },
+                                "description": "geo_radius"
+                              },
+                              "geo_polygon": {
+                                "type": "object",
+                                "properties": {
+                                  "exterior": {
+                                    "type": "object",
+                                    "properties": {
+                                      "points": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "lat": {
+                                              "type": "string",
+                                              "description": "lat"
+                                            },
+                                            "lon": {
+                                              "type": "string",
+                                              "description": "lon"
+                                            }
+                                          }
+                                        },
+                                        "description": "points"
+                                      }
+                                    },
+                                    "description": "exterior"
+                                  },
+                                  "interiors": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "points": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "lat": {
+                                                "type": "string",
+                                                "description": "lat"
+                                              },
+                                              "lon": {
+                                                "type": "string",
+                                                "description": "lon"
+                                              }
+                                            }
+                                          },
+                                          "description": "points"
+                                        }
+                                      }
+                                    },
+                                    "description": "interiors"
+                                  }
+                                },
+                                "description": "geo_polygon"
+                              },
+                              "values_count": {
+                                "type": "object",
+                                "properties": {
+                                  "lt": {
+                                    "type": "string",
+                                    "description": "lt"
+                                  },
+                                  "gt": {
+                                    "type": "string",
+                                    "description": "gt"
+                                  },
+                                  "gte": {
+                                    "type": "string",
+                                    "description": "gte"
+                                  },
+                                  "lte": {
+                                    "type": "string",
+                                    "description": "lte"
+                                  }
+                                },
+                                "description": "values_count"
+                              }
+                            }
+                          },
+                          "description": "conditions"
+                        },
+                        "min_count": {
+                          "type": "string",
+                          "description": "min_count"
+                        }
+                      },
+                      "description": "min_should"
+                    },
+                    "must": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string",
+                          "description": "key"
+                        },
+                        "match": {
+                          "type": "object",
+                          "properties": {
+                            "value": {
+                              "type": "string",
+                              "description": "value"
+                            }
+                          },
+                          "description": "match"
+                        },
+                        "range": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "range"
+                        },
+                        "geo_bounding_box": {
+                          "type": "object",
+                          "properties": {
+                            "bottom_right": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "bottom_right"
+                            },
+                            "top_left": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "top_left"
+                            }
+                          },
+                          "description": "geo_bounding_box"
+                        },
+                        "geo_radius": {
+                          "type": "object",
+                          "properties": {
+                            "center": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "center"
+                            },
+                            "radius": {
+                              "type": "string",
+                              "description": "radius"
+                            }
+                          },
+                          "description": "geo_radius"
+                        },
+                        "geo_polygon": {
+                          "type": "object",
+                          "properties": {
+                            "exterior": {
+                              "type": "object",
+                              "properties": {
+                                "points": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    }
+                                  },
+                                  "description": "points"
+                                }
+                              },
+                              "description": "exterior"
+                            },
+                            "interiors": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "points": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "lat": {
+                                          "type": "string",
+                                          "description": "lat"
+                                        },
+                                        "lon": {
+                                          "type": "string",
+                                          "description": "lon"
+                                        }
+                                      }
+                                    },
+                                    "description": "points"
+                                  }
+                                }
+                              },
+                              "description": "interiors"
+                            }
+                          },
+                          "description": "geo_polygon"
+                        },
+                        "values_count": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "values_count"
+                        }
+                      },
+                      "description": "must"
+                    },
+                    "must_not": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string",
+                          "description": "key"
+                        },
+                        "match": {
+                          "type": "object",
+                          "properties": {
+                            "value": {
+                              "type": "string",
+                              "description": "value"
+                            }
+                          },
+                          "description": "match"
+                        },
+                        "range": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "range"
+                        },
+                        "geo_bounding_box": {
+                          "type": "object",
+                          "properties": {
+                            "bottom_right": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "bottom_right"
+                            },
+                            "top_left": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "top_left"
+                            }
+                          },
+                          "description": "geo_bounding_box"
+                        },
+                        "geo_radius": {
+                          "type": "object",
+                          "properties": {
+                            "center": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "center"
+                            },
+                            "radius": {
+                              "type": "string",
+                              "description": "radius"
+                            }
+                          },
+                          "description": "geo_radius"
+                        },
+                        "geo_polygon": {
+                          "type": "object",
+                          "properties": {
+                            "exterior": {
+                              "type": "object",
+                              "properties": {
+                                "points": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    }
+                                  },
+                                  "description": "points"
+                                }
+                              },
+                              "description": "exterior"
+                            },
+                            "interiors": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "points": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "lat": {
+                                          "type": "string",
+                                          "description": "lat"
+                                        },
+                                        "lon": {
+                                          "type": "string",
+                                          "description": "lon"
+                                        }
+                                      }
+                                    },
+                                    "description": "points"
+                                  }
+                                }
+                              },
+                              "description": "interiors"
+                            }
+                          },
+                          "description": "geo_polygon"
+                        },
+                        "values_count": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "values_count"
+                        }
+                      },
+                      "description": "must_not"
+                    }
+                  },
+                  "description": "filter"
+                },
+                "shard_key": {
+                  "type": "string",
+                  "description": "shard_key"
+                },
+                "key": {
+                  "type": "string",
+                  "description": "key"
+                }
+              },
+              "default": {
+                "payload": {
+                  "Excepteur_ff1": false
+                },
+                "points": [
+                  "<integer>",
+                  "<integer>"
+                ],
+                "filter": {
+                  "should": {
+                    "key": "<string>",
+                    "match": {
+                      "value": "<string>"
+                    },
+                    "range": {
+                      "lt": "<double>",
+                      "gt": "<double>",
+                      "gte": "<double>",
+                      "lte": "<double>"
+                    },
+                    "geo_bounding_box": {
+                      "bottom_right": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "top_left": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      }
+                    },
+                    "geo_radius": {
+                      "center": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "radius": "<double>"
+                    },
+                    "geo_polygon": {
+                      "exterior": {
+                        "points": [
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        ]
+                      },
+                      "interiors": [
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        },
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "values_count": {
+                      "lt": "<integer>",
+                      "gt": "<integer>",
+                      "gte": "<integer>",
+                      "lte": "<integer>"
+                    }
+                  },
+                  "min_should": {
+                    "conditions": [
+                      {
+                        "key": "<string>",
+                        "match": {
+                          "value": "<string>"
+                        },
+                        "range": {
+                          "lt": "<double>",
+                          "gt": "<double>",
+                          "gte": "<double>",
+                          "lte": "<double>"
+                        },
+                        "geo_bounding_box": {
+                          "bottom_right": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "top_left": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        },
+                        "geo_radius": {
+                          "center": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "radius": "<double>"
+                        },
+                        "geo_polygon": {
+                          "exterior": {
+                            "points": [
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            ]
+                          },
+                          "interiors": [
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            },
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "values_count": {
+                          "lt": "<integer>",
+                          "gt": "<integer>",
+                          "gte": "<integer>",
+                          "lte": "<integer>"
+                        }
+                      },
+                      {
+                        "key": "<string>",
+                        "match": {
+                          "value": "<string>"
+                        },
+                        "range": {
+                          "lt": "<double>",
+                          "gt": "<double>",
+                          "gte": "<double>",
+                          "lte": "<double>"
+                        },
+                        "geo_bounding_box": {
+                          "bottom_right": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "top_left": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        },
+                        "geo_radius": {
+                          "center": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "radius": "<double>"
+                        },
+                        "geo_polygon": {
+                          "exterior": {
+                            "points": [
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            ]
+                          },
+                          "interiors": [
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            },
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "values_count": {
+                          "lt": "<integer>",
+                          "gt": "<integer>",
+                          "gte": "<integer>",
+                          "lte": "<integer>"
+                        }
+                      }
+                    ],
+                    "min_count": "<integer>"
+                  },
+                  "must": {
+                    "key": "<string>",
+                    "match": {
+                      "value": "<string>"
+                    },
+                    "range": {
+                      "lt": "<double>",
+                      "gt": "<double>",
+                      "gte": "<double>",
+                      "lte": "<double>"
+                    },
+                    "geo_bounding_box": {
+                      "bottom_right": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "top_left": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      }
+                    },
+                    "geo_radius": {
+                      "center": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "radius": "<double>"
+                    },
+                    "geo_polygon": {
+                      "exterior": {
+                        "points": [
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        ]
+                      },
+                      "interiors": [
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        },
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "values_count": {
+                      "lt": "<integer>",
+                      "gt": "<integer>",
+                      "gte": "<integer>",
+                      "lte": "<integer>"
+                    }
+                  },
+                  "must_not": {
+                    "key": "<string>",
+                    "match": {
+                      "value": "<string>"
+                    },
+                    "range": {
+                      "lt": "<double>",
+                      "gt": "<double>",
+                      "gte": "<double>",
+                      "lte": "<double>"
+                    },
+                    "geo_bounding_box": {
+                      "bottom_right": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "top_left": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      }
+                    },
+                    "geo_radius": {
+                      "center": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "radius": "<double>"
+                    },
+                    "geo_polygon": {
+                      "exterior": {
+                        "points": [
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        ]
+                      },
+                      "interiors": [
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        },
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "values_count": {
+                      "lt": "<integer>",
+                      "gt": "<integer>",
+                      "gte": "<integer>",
+                      "lte": "<integer>"
+                    }
+                  }
+                },
+                "shard_key": "<string>",
+                "key": "<string>"
+              }
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "string",
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "description": "status"
+                    },
+                    "operation_id": {
+                      "type": "string",
+                      "description": "operation_id"
+                    }
+                  },
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "500",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "Overwrite payload",
+        "description": "Replace full payload of points with new one",
+        "operationId": "OverwritePayload",
+        "parameters": [
+          {
+            "name": "wait",
+            "default": "<boolean>",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "Wait",
+            "x-ms-summary": "Wait"
+          },
+          {
+            "name": "ordering",
+            "default": "strong",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "Ordering",
+            "x-ms-summary": "Ordering"
+          },
+          {
+            "name": "collection_name",
+            "default": "<string>",
+            "in": "path",
+            "x-ms-url-encoding": "single",
+            "type": "string",
+            "required": true,
+            "description": "Collection Name",
+            "x-ms-summary": "Collection Name"
+          },
+          {
+            "name": "Content-Type",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Content-Type",
+            "x-ms-summary": "Content-Type"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Accept",
+            "x-ms-summary": "Accept"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "payload": {
+                  "type": "object",
+                  "properties": {
+                    "Excepteur_ff1": {
+                      "type": "boolean",
+                      "description": "Excepteur_ff1"
+                    }
+                  },
+                  "description": "payload"
+                },
+                "points": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "points"
+                },
+                "filter": {
+                  "type": "object",
+                  "properties": {
+                    "should": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string",
+                          "description": "key"
+                        },
+                        "match": {
+                          "type": "object",
+                          "properties": {
+                            "value": {
+                              "type": "string",
+                              "description": "value"
+                            }
+                          },
+                          "description": "match"
+                        },
+                        "range": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "range"
+                        },
+                        "geo_bounding_box": {
+                          "type": "object",
+                          "properties": {
+                            "bottom_right": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "bottom_right"
+                            },
+                            "top_left": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "top_left"
+                            }
+                          },
+                          "description": "geo_bounding_box"
+                        },
+                        "geo_radius": {
+                          "type": "object",
+                          "properties": {
+                            "center": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "center"
+                            },
+                            "radius": {
+                              "type": "string",
+                              "description": "radius"
+                            }
+                          },
+                          "description": "geo_radius"
+                        },
+                        "geo_polygon": {
+                          "type": "object",
+                          "properties": {
+                            "exterior": {
+                              "type": "object",
+                              "properties": {
+                                "points": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    }
+                                  },
+                                  "description": "points"
+                                }
+                              },
+                              "description": "exterior"
+                            },
+                            "interiors": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "points": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "lat": {
+                                          "type": "string",
+                                          "description": "lat"
+                                        },
+                                        "lon": {
+                                          "type": "string",
+                                          "description": "lon"
+                                        }
+                                      }
+                                    },
+                                    "description": "points"
+                                  }
+                                }
+                              },
+                              "description": "interiors"
+                            }
+                          },
+                          "description": "geo_polygon"
+                        },
+                        "values_count": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "values_count"
+                        }
+                      },
+                      "description": "should"
+                    },
+                    "min_should": {
+                      "type": "object",
+                      "properties": {
+                        "conditions": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "key": {
+                                "type": "string",
+                                "description": "key"
+                              },
+                              "match": {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "string",
+                                    "description": "value"
+                                  }
+                                },
+                                "description": "match"
+                              },
+                              "range": {
+                                "type": "object",
+                                "properties": {
+                                  "lt": {
+                                    "type": "string",
+                                    "description": "lt"
+                                  },
+                                  "gt": {
+                                    "type": "string",
+                                    "description": "gt"
+                                  },
+                                  "gte": {
+                                    "type": "string",
+                                    "description": "gte"
+                                  },
+                                  "lte": {
+                                    "type": "string",
+                                    "description": "lte"
+                                  }
+                                },
+                                "description": "range"
+                              },
+                              "geo_bounding_box": {
+                                "type": "object",
+                                "properties": {
+                                  "bottom_right": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    },
+                                    "description": "bottom_right"
+                                  },
+                                  "top_left": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    },
+                                    "description": "top_left"
+                                  }
+                                },
+                                "description": "geo_bounding_box"
+                              },
+                              "geo_radius": {
+                                "type": "object",
+                                "properties": {
+                                  "center": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    },
+                                    "description": "center"
+                                  },
+                                  "radius": {
+                                    "type": "string",
+                                    "description": "radius"
+                                  }
+                                },
+                                "description": "geo_radius"
+                              },
+                              "geo_polygon": {
+                                "type": "object",
+                                "properties": {
+                                  "exterior": {
+                                    "type": "object",
+                                    "properties": {
+                                      "points": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "lat": {
+                                              "type": "string",
+                                              "description": "lat"
+                                            },
+                                            "lon": {
+                                              "type": "string",
+                                              "description": "lon"
+                                            }
+                                          }
+                                        },
+                                        "description": "points"
+                                      }
+                                    },
+                                    "description": "exterior"
+                                  },
+                                  "interiors": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "points": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "lat": {
+                                                "type": "string",
+                                                "description": "lat"
+                                              },
+                                              "lon": {
+                                                "type": "string",
+                                                "description": "lon"
+                                              }
+                                            }
+                                          },
+                                          "description": "points"
+                                        }
+                                      }
+                                    },
+                                    "description": "interiors"
+                                  }
+                                },
+                                "description": "geo_polygon"
+                              },
+                              "values_count": {
+                                "type": "object",
+                                "properties": {
+                                  "lt": {
+                                    "type": "string",
+                                    "description": "lt"
+                                  },
+                                  "gt": {
+                                    "type": "string",
+                                    "description": "gt"
+                                  },
+                                  "gte": {
+                                    "type": "string",
+                                    "description": "gte"
+                                  },
+                                  "lte": {
+                                    "type": "string",
+                                    "description": "lte"
+                                  }
+                                },
+                                "description": "values_count"
+                              }
+                            }
+                          },
+                          "description": "conditions"
+                        },
+                        "min_count": {
+                          "type": "string",
+                          "description": "min_count"
+                        }
+                      },
+                      "description": "min_should"
+                    },
+                    "must": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string",
+                          "description": "key"
+                        },
+                        "match": {
+                          "type": "object",
+                          "properties": {
+                            "value": {
+                              "type": "string",
+                              "description": "value"
+                            }
+                          },
+                          "description": "match"
+                        },
+                        "range": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "range"
+                        },
+                        "geo_bounding_box": {
+                          "type": "object",
+                          "properties": {
+                            "bottom_right": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "bottom_right"
+                            },
+                            "top_left": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "top_left"
+                            }
+                          },
+                          "description": "geo_bounding_box"
+                        },
+                        "geo_radius": {
+                          "type": "object",
+                          "properties": {
+                            "center": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "center"
+                            },
+                            "radius": {
+                              "type": "string",
+                              "description": "radius"
+                            }
+                          },
+                          "description": "geo_radius"
+                        },
+                        "geo_polygon": {
+                          "type": "object",
+                          "properties": {
+                            "exterior": {
+                              "type": "object",
+                              "properties": {
+                                "points": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    }
+                                  },
+                                  "description": "points"
+                                }
+                              },
+                              "description": "exterior"
+                            },
+                            "interiors": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "points": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "lat": {
+                                          "type": "string",
+                                          "description": "lat"
+                                        },
+                                        "lon": {
+                                          "type": "string",
+                                          "description": "lon"
+                                        }
+                                      }
+                                    },
+                                    "description": "points"
+                                  }
+                                }
+                              },
+                              "description": "interiors"
+                            }
+                          },
+                          "description": "geo_polygon"
+                        },
+                        "values_count": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "values_count"
+                        }
+                      },
+                      "description": "must"
+                    },
+                    "must_not": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string",
+                          "description": "key"
+                        },
+                        "match": {
+                          "type": "object",
+                          "properties": {
+                            "value": {
+                              "type": "string",
+                              "description": "value"
+                            }
+                          },
+                          "description": "match"
+                        },
+                        "range": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "range"
+                        },
+                        "geo_bounding_box": {
+                          "type": "object",
+                          "properties": {
+                            "bottom_right": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "bottom_right"
+                            },
+                            "top_left": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "top_left"
+                            }
+                          },
+                          "description": "geo_bounding_box"
+                        },
+                        "geo_radius": {
+                          "type": "object",
+                          "properties": {
+                            "center": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "center"
+                            },
+                            "radius": {
+                              "type": "string",
+                              "description": "radius"
+                            }
+                          },
+                          "description": "geo_radius"
+                        },
+                        "geo_polygon": {
+                          "type": "object",
+                          "properties": {
+                            "exterior": {
+                              "type": "object",
+                              "properties": {
+                                "points": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    }
+                                  },
+                                  "description": "points"
+                                }
+                              },
+                              "description": "exterior"
+                            },
+                            "interiors": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "points": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "lat": {
+                                          "type": "string",
+                                          "description": "lat"
+                                        },
+                                        "lon": {
+                                          "type": "string",
+                                          "description": "lon"
+                                        }
+                                      }
+                                    },
+                                    "description": "points"
+                                  }
+                                }
+                              },
+                              "description": "interiors"
+                            }
+                          },
+                          "description": "geo_polygon"
+                        },
+                        "values_count": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "values_count"
+                        }
+                      },
+                      "description": "must_not"
+                    }
+                  },
+                  "description": "filter"
+                },
+                "shard_key": {
+                  "type": "string",
+                  "description": "shard_key"
+                },
+                "key": {
+                  "type": "string",
+                  "description": "key"
+                }
+              },
+              "default": {
+                "payload": {
+                  "Excepteur_ff1": false
+                },
+                "points": [
+                  "<integer>",
+                  "<integer>"
+                ],
+                "filter": {
+                  "should": {
+                    "key": "<string>",
+                    "match": {
+                      "value": "<string>"
+                    },
+                    "range": {
+                      "lt": "<double>",
+                      "gt": "<double>",
+                      "gte": "<double>",
+                      "lte": "<double>"
+                    },
+                    "geo_bounding_box": {
+                      "bottom_right": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "top_left": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      }
+                    },
+                    "geo_radius": {
+                      "center": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "radius": "<double>"
+                    },
+                    "geo_polygon": {
+                      "exterior": {
+                        "points": [
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        ]
+                      },
+                      "interiors": [
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        },
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "values_count": {
+                      "lt": "<integer>",
+                      "gt": "<integer>",
+                      "gte": "<integer>",
+                      "lte": "<integer>"
+                    }
+                  },
+                  "min_should": {
+                    "conditions": [
+                      {
+                        "key": "<string>",
+                        "match": {
+                          "value": "<string>"
+                        },
+                        "range": {
+                          "lt": "<double>",
+                          "gt": "<double>",
+                          "gte": "<double>",
+                          "lte": "<double>"
+                        },
+                        "geo_bounding_box": {
+                          "bottom_right": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "top_left": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        },
+                        "geo_radius": {
+                          "center": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "radius": "<double>"
+                        },
+                        "geo_polygon": {
+                          "exterior": {
+                            "points": [
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            ]
+                          },
+                          "interiors": [
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            },
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "values_count": {
+                          "lt": "<integer>",
+                          "gt": "<integer>",
+                          "gte": "<integer>",
+                          "lte": "<integer>"
+                        }
+                      },
+                      {
+                        "key": "<string>",
+                        "match": {
+                          "value": "<string>"
+                        },
+                        "range": {
+                          "lt": "<double>",
+                          "gt": "<double>",
+                          "gte": "<double>",
+                          "lte": "<double>"
+                        },
+                        "geo_bounding_box": {
+                          "bottom_right": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "top_left": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        },
+                        "geo_radius": {
+                          "center": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "radius": "<double>"
+                        },
+                        "geo_polygon": {
+                          "exterior": {
+                            "points": [
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            ]
+                          },
+                          "interiors": [
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            },
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "values_count": {
+                          "lt": "<integer>",
+                          "gt": "<integer>",
+                          "gte": "<integer>",
+                          "lte": "<integer>"
+                        }
+                      }
+                    ],
+                    "min_count": "<integer>"
+                  },
+                  "must": {
+                    "key": "<string>",
+                    "match": {
+                      "value": "<string>"
+                    },
+                    "range": {
+                      "lt": "<double>",
+                      "gt": "<double>",
+                      "gte": "<double>",
+                      "lte": "<double>"
+                    },
+                    "geo_bounding_box": {
+                      "bottom_right": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "top_left": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      }
+                    },
+                    "geo_radius": {
+                      "center": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "radius": "<double>"
+                    },
+                    "geo_polygon": {
+                      "exterior": {
+                        "points": [
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        ]
+                      },
+                      "interiors": [
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        },
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "values_count": {
+                      "lt": "<integer>",
+                      "gt": "<integer>",
+                      "gte": "<integer>",
+                      "lte": "<integer>"
+                    }
+                  },
+                  "must_not": {
+                    "key": "<string>",
+                    "match": {
+                      "value": "<string>"
+                    },
+                    "range": {
+                      "lt": "<double>",
+                      "gt": "<double>",
+                      "gte": "<double>",
+                      "lte": "<double>"
+                    },
+                    "geo_bounding_box": {
+                      "bottom_right": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "top_left": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      }
+                    },
+                    "geo_radius": {
+                      "center": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "radius": "<double>"
+                    },
+                    "geo_polygon": {
+                      "exterior": {
+                        "points": [
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        ]
+                      },
+                      "interiors": [
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        },
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "values_count": {
+                      "lt": "<integer>",
+                      "gt": "<integer>",
+                      "gte": "<integer>",
+                      "lte": "<integer>"
+                    }
+                  }
+                },
+                "shard_key": "<string>",
+                "key": "<string>"
+              }
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "string",
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "description": "status"
+                    },
+                    "operation_id": {
+                      "type": "string",
+                      "description": "operation_id"
+                    }
+                  },
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "500",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/collections/{collection_name}/points/batch": {
+      "post": {
+        "summary": "Batch update points",
+        "description": "Apply a series of update operations for points, vectors and payloads",
+        "operationId": "BatchUpdatePoints",
+        "parameters": [
+          {
+            "name": "wait",
+            "default": "<boolean>",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "Wait",
+            "x-ms-summary": "Wait"
+          },
+          {
+            "name": "ordering",
+            "default": "strong",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "Ordering",
+            "x-ms-summary": "Ordering"
+          },
+          {
+            "name": "collection_name",
+            "default": "<string>",
+            "in": "path",
+            "x-ms-url-encoding": "single",
+            "type": "string",
+            "required": true,
+            "description": "Collection Name",
+            "x-ms-summary": "Collection Name"
+          },
+          {
+            "name": "Content-Type",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Content-Type",
+            "x-ms-summary": "Content-Type"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Accept",
+            "x-ms-summary": "Accept"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "operations": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "upsert": {
+                        "type": "object",
+                        "properties": {
+                          "batch": {
+                            "type": "object",
+                            "properties": {
+                              "ids": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "description": "ids"
+                              },
+                              "vectors": {
+                                "type": "array",
+                                "items": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "description": "vectors"
+                              },
+                              "payloads": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "deserunt97": {
+                                      "type": "boolean",
+                                      "description": "deserunt97"
+                                    },
+                                    "doa1": {
+                                      "type": "string",
+                                      "description": "doa1"
+                                    },
+                                    "cupidatat_20e": {
+                                      "type": "number",
+                                      "format": "float",
+                                      "description": "cupidatat_20e"
+                                    },
+                                    "ut8": {
+                                      "type": "integer",
+                                      "format": "int32",
+                                      "description": "ut8"
+                                    },
+                                    "anim91f": {
+                                      "type": "boolean",
+                                      "description": "anim91f"
+                                    },
+                                    "fugiat54": {
+                                      "type": "number",
+                                      "format": "float",
+                                      "description": "fugiat54"
+                                    }
+                                  }
+                                },
+                                "description": "payloads"
+                              }
+                            },
+                            "description": "batch"
+                          },
+                          "shard_key": {
+                            "type": "string",
+                            "description": "shard_key"
+                          }
+                        },
+                        "description": "upsert"
+                      }
+                    }
+                  },
+                  "description": "operations"
+                }
+              },
+              "default": {
+                "operations": [
+                  {
+                    "upsert": {
+                      "batch": {
+                        "ids": [
+                          "<integer>",
+                          "<integer>"
+                        ],
+                        "vectors": [
+                          [
+                            "<float>",
+                            "<float>"
+                          ],
+                          [
+                            "<float>",
+                            "<float>"
+                          ]
+                        ],
+                        "payloads": [
+                          {
+                            "deserunt97": true,
+                            "doa1": "magna",
+                            "cupidatat_20e": -50112368.924633086,
+                            "ut8": 9309192,
+                            "anim91f": true,
+                            "fugiat54": -80448362.4723647
+                          },
+                          {
+                            "ut8": 9309192,
+                            "anim91f": true,
+                            "fugiat54": -80448362.4723647
+                          }
+                        ]
+                      },
+                      "shard_key": "<string>"
+                    }
+                  },
+                  {
+                    "upsert": {
+                      "batch": {
+                        "ids": [
+                          "<integer>",
+                          "<integer>"
+                        ],
+                        "vectors": [
+                          [
+                            "<float>",
+                            "<float>"
+                          ],
+                          [
+                            "<float>",
+                            "<float>"
+                          ]
+                        ],
+                        "payloads": [
+                          {
+                            "cupidatat_20e": -50112368.924633086
+                          },
+                          {
+                            "fugiat54": -80448362.4723647
+                          }
+                        ]
+                      },
+                      "shard_key": "<string>"
+                    }
+                  }
+                ]
+              }
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "string",
+                  "description": "status"
+                },
+                "result": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "status": {
+                        "type": "string",
+                        "description": "status"
+                      },
+                      "operation_id": {
+                        "type": "string",
+                        "description": "operation_id"
+                      }
+                    }
+                  },
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "500",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/collections/{collection_name}/points/scroll": {
+      "post": {
+        "summary": "Scroll points",
+        "description": "Scroll request - paginate over all points which matches given filtering condition",
+        "operationId": "ScrollPoints",
+        "parameters": [
+          {
+            "name": "consistency",
+            "default": "<integer>",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "Consistency",
+            "x-ms-summary": "Consistency"
+          },
+          {
+            "name": "timeout",
+            "default": "<integer>",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "Timeout",
+            "x-ms-summary": "Timeout"
+          },
+          {
+            "name": "collection_name",
+            "default": "<string>",
+            "in": "path",
+            "x-ms-url-encoding": "single",
+            "type": "string",
+            "required": true,
+            "description": "Collection Name",
+            "x-ms-summary": "Collection Name"
+          },
+          {
+            "name": "Content-Type",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Content-Type",
+            "x-ms-summary": "Content-Type"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Accept",
+            "x-ms-summary": "Accept"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "shard_key": {
+                  "type": "string",
+                  "description": "shard_key"
+                },
+                "offset": {
+                  "type": "string",
+                  "description": "offset"
+                },
+                "limit": {
+                  "type": "string",
+                  "description": "limit"
+                },
+                "filter": {
+                  "type": "object",
+                  "properties": {
+                    "should": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string",
+                          "description": "key"
+                        },
+                        "match": {
+                          "type": "object",
+                          "properties": {
+                            "value": {
+                              "type": "string",
+                              "description": "value"
+                            }
+                          },
+                          "description": "match"
+                        },
+                        "range": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "range"
+                        },
+                        "geo_bounding_box": {
+                          "type": "object",
+                          "properties": {
+                            "bottom_right": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "bottom_right"
+                            },
+                            "top_left": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "top_left"
+                            }
+                          },
+                          "description": "geo_bounding_box"
+                        },
+                        "geo_radius": {
+                          "type": "object",
+                          "properties": {
+                            "center": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "center"
+                            },
+                            "radius": {
+                              "type": "string",
+                              "description": "radius"
+                            }
+                          },
+                          "description": "geo_radius"
+                        },
+                        "geo_polygon": {
+                          "type": "object",
+                          "properties": {
+                            "exterior": {
+                              "type": "object",
+                              "properties": {
+                                "points": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    }
+                                  },
+                                  "description": "points"
+                                }
+                              },
+                              "description": "exterior"
+                            },
+                            "interiors": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "points": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "lat": {
+                                          "type": "string",
+                                          "description": "lat"
+                                        },
+                                        "lon": {
+                                          "type": "string",
+                                          "description": "lon"
+                                        }
+                                      }
+                                    },
+                                    "description": "points"
+                                  }
+                                }
+                              },
+                              "description": "interiors"
+                            }
+                          },
+                          "description": "geo_polygon"
+                        },
+                        "values_count": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "values_count"
+                        }
+                      },
+                      "description": "should"
+                    },
+                    "min_should": {
+                      "type": "object",
+                      "properties": {
+                        "conditions": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "key": {
+                                "type": "string",
+                                "description": "key"
+                              },
+                              "match": {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "string",
+                                    "description": "value"
+                                  }
+                                },
+                                "description": "match"
+                              },
+                              "range": {
+                                "type": "object",
+                                "properties": {
+                                  "lt": {
+                                    "type": "string",
+                                    "description": "lt"
+                                  },
+                                  "gt": {
+                                    "type": "string",
+                                    "description": "gt"
+                                  },
+                                  "gte": {
+                                    "type": "string",
+                                    "description": "gte"
+                                  },
+                                  "lte": {
+                                    "type": "string",
+                                    "description": "lte"
+                                  }
+                                },
+                                "description": "range"
+                              },
+                              "geo_bounding_box": {
+                                "type": "object",
+                                "properties": {
+                                  "bottom_right": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    },
+                                    "description": "bottom_right"
+                                  },
+                                  "top_left": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    },
+                                    "description": "top_left"
+                                  }
+                                },
+                                "description": "geo_bounding_box"
+                              },
+                              "geo_radius": {
+                                "type": "object",
+                                "properties": {
+                                  "center": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    },
+                                    "description": "center"
+                                  },
+                                  "radius": {
+                                    "type": "string",
+                                    "description": "radius"
+                                  }
+                                },
+                                "description": "geo_radius"
+                              },
+                              "geo_polygon": {
+                                "type": "object",
+                                "properties": {
+                                  "exterior": {
+                                    "type": "object",
+                                    "properties": {
+                                      "points": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "lat": {
+                                              "type": "string",
+                                              "description": "lat"
+                                            },
+                                            "lon": {
+                                              "type": "string",
+                                              "description": "lon"
+                                            }
+                                          }
+                                        },
+                                        "description": "points"
+                                      }
+                                    },
+                                    "description": "exterior"
+                                  },
+                                  "interiors": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "points": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "lat": {
+                                                "type": "string",
+                                                "description": "lat"
+                                              },
+                                              "lon": {
+                                                "type": "string",
+                                                "description": "lon"
+                                              }
+                                            }
+                                          },
+                                          "description": "points"
+                                        }
+                                      }
+                                    },
+                                    "description": "interiors"
+                                  }
+                                },
+                                "description": "geo_polygon"
+                              },
+                              "values_count": {
+                                "type": "object",
+                                "properties": {
+                                  "lt": {
+                                    "type": "string",
+                                    "description": "lt"
+                                  },
+                                  "gt": {
+                                    "type": "string",
+                                    "description": "gt"
+                                  },
+                                  "gte": {
+                                    "type": "string",
+                                    "description": "gte"
+                                  },
+                                  "lte": {
+                                    "type": "string",
+                                    "description": "lte"
+                                  }
+                                },
+                                "description": "values_count"
+                              }
+                            }
+                          },
+                          "description": "conditions"
+                        },
+                        "min_count": {
+                          "type": "string",
+                          "description": "min_count"
+                        }
+                      },
+                      "description": "min_should"
+                    },
+                    "must": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string",
+                          "description": "key"
+                        },
+                        "match": {
+                          "type": "object",
+                          "properties": {
+                            "value": {
+                              "type": "string",
+                              "description": "value"
+                            }
+                          },
+                          "description": "match"
+                        },
+                        "range": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "range"
+                        },
+                        "geo_bounding_box": {
+                          "type": "object",
+                          "properties": {
+                            "bottom_right": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "bottom_right"
+                            },
+                            "top_left": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "top_left"
+                            }
+                          },
+                          "description": "geo_bounding_box"
+                        },
+                        "geo_radius": {
+                          "type": "object",
+                          "properties": {
+                            "center": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "center"
+                            },
+                            "radius": {
+                              "type": "string",
+                              "description": "radius"
+                            }
+                          },
+                          "description": "geo_radius"
+                        },
+                        "geo_polygon": {
+                          "type": "object",
+                          "properties": {
+                            "exterior": {
+                              "type": "object",
+                              "properties": {
+                                "points": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    }
+                                  },
+                                  "description": "points"
+                                }
+                              },
+                              "description": "exterior"
+                            },
+                            "interiors": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "points": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "lat": {
+                                          "type": "string",
+                                          "description": "lat"
+                                        },
+                                        "lon": {
+                                          "type": "string",
+                                          "description": "lon"
+                                        }
+                                      }
+                                    },
+                                    "description": "points"
+                                  }
+                                }
+                              },
+                              "description": "interiors"
+                            }
+                          },
+                          "description": "geo_polygon"
+                        },
+                        "values_count": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "values_count"
+                        }
+                      },
+                      "description": "must"
+                    },
+                    "must_not": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string",
+                          "description": "key"
+                        },
+                        "match": {
+                          "type": "object",
+                          "properties": {
+                            "value": {
+                              "type": "string",
+                              "description": "value"
+                            }
+                          },
+                          "description": "match"
+                        },
+                        "range": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "range"
+                        },
+                        "geo_bounding_box": {
+                          "type": "object",
+                          "properties": {
+                            "bottom_right": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "bottom_right"
+                            },
+                            "top_left": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "top_left"
+                            }
+                          },
+                          "description": "geo_bounding_box"
+                        },
+                        "geo_radius": {
+                          "type": "object",
+                          "properties": {
+                            "center": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "center"
+                            },
+                            "radius": {
+                              "type": "string",
+                              "description": "radius"
+                            }
+                          },
+                          "description": "geo_radius"
+                        },
+                        "geo_polygon": {
+                          "type": "object",
+                          "properties": {
+                            "exterior": {
+                              "type": "object",
+                              "properties": {
+                                "points": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    }
+                                  },
+                                  "description": "points"
+                                }
+                              },
+                              "description": "exterior"
+                            },
+                            "interiors": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "points": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "lat": {
+                                          "type": "string",
+                                          "description": "lat"
+                                        },
+                                        "lon": {
+                                          "type": "string",
+                                          "description": "lon"
+                                        }
+                                      }
+                                    },
+                                    "description": "points"
+                                  }
+                                }
+                              },
+                              "description": "interiors"
+                            }
+                          },
+                          "description": "geo_polygon"
+                        },
+                        "values_count": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "values_count"
+                        }
+                      },
+                      "description": "must_not"
+                    }
+                  },
+                  "description": "filter"
+                },
+                "with_payload": {
+                  "type": "string",
+                  "description": "with_payload"
+                },
+                "with_vector": {
+                  "type": "string",
+                  "description": "with_vector"
+                },
+                "order_by": {
+                  "type": "string",
+                  "description": "order_by"
+                }
+              },
+              "default": {
+                "shard_key": "<string>",
+                "offset": "<integer>",
+                "limit": "<integer>",
+                "filter": {
+                  "should": {
+                    "key": "<string>",
+                    "match": {
+                      "value": "<string>"
+                    },
+                    "range": {
+                      "lt": "<double>",
+                      "gt": "<double>",
+                      "gte": "<double>",
+                      "lte": "<double>"
+                    },
+                    "geo_bounding_box": {
+                      "bottom_right": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "top_left": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      }
+                    },
+                    "geo_radius": {
+                      "center": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "radius": "<double>"
+                    },
+                    "geo_polygon": {
+                      "exterior": {
+                        "points": [
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        ]
+                      },
+                      "interiors": [
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        },
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "values_count": {
+                      "lt": "<integer>",
+                      "gt": "<integer>",
+                      "gte": "<integer>",
+                      "lte": "<integer>"
+                    }
+                  },
+                  "min_should": {
+                    "conditions": [
+                      {
+                        "key": "<string>",
+                        "match": {
+                          "value": "<string>"
+                        },
+                        "range": {
+                          "lt": "<double>",
+                          "gt": "<double>",
+                          "gte": "<double>",
+                          "lte": "<double>"
+                        },
+                        "geo_bounding_box": {
+                          "bottom_right": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "top_left": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        },
+                        "geo_radius": {
+                          "center": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "radius": "<double>"
+                        },
+                        "geo_polygon": {
+                          "exterior": {
+                            "points": [
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            ]
+                          },
+                          "interiors": [
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            },
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "values_count": {
+                          "lt": "<integer>",
+                          "gt": "<integer>",
+                          "gte": "<integer>",
+                          "lte": "<integer>"
+                        }
+                      },
+                      {
+                        "key": "<string>",
+                        "match": {
+                          "value": "<string>"
+                        },
+                        "range": {
+                          "lt": "<double>",
+                          "gt": "<double>",
+                          "gte": "<double>",
+                          "lte": "<double>"
+                        },
+                        "geo_bounding_box": {
+                          "bottom_right": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "top_left": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        },
+                        "geo_radius": {
+                          "center": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "radius": "<double>"
+                        },
+                        "geo_polygon": {
+                          "exterior": {
+                            "points": [
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            ]
+                          },
+                          "interiors": [
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            },
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "values_count": {
+                          "lt": "<integer>",
+                          "gt": "<integer>",
+                          "gte": "<integer>",
+                          "lte": "<integer>"
+                        }
+                      }
+                    ],
+                    "min_count": "<integer>"
+                  },
+                  "must": {
+                    "key": "<string>",
+                    "match": {
+                      "value": "<string>"
+                    },
+                    "range": {
+                      "lt": "<double>",
+                      "gt": "<double>",
+                      "gte": "<double>",
+                      "lte": "<double>"
+                    },
+                    "geo_bounding_box": {
+                      "bottom_right": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "top_left": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      }
+                    },
+                    "geo_radius": {
+                      "center": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "radius": "<double>"
+                    },
+                    "geo_polygon": {
+                      "exterior": {
+                        "points": [
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        ]
+                      },
+                      "interiors": [
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        },
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "values_count": {
+                      "lt": "<integer>",
+                      "gt": "<integer>",
+                      "gte": "<integer>",
+                      "lte": "<integer>"
+                    }
+                  },
+                  "must_not": {
+                    "key": "<string>",
+                    "match": {
+                      "value": "<string>"
+                    },
+                    "range": {
+                      "lt": "<double>",
+                      "gt": "<double>",
+                      "gte": "<double>",
+                      "lte": "<double>"
+                    },
+                    "geo_bounding_box": {
+                      "bottom_right": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "top_left": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      }
+                    },
+                    "geo_radius": {
+                      "center": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "radius": "<double>"
+                    },
+                    "geo_polygon": {
+                      "exterior": {
+                        "points": [
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        ]
+                      },
+                      "interiors": [
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        },
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "values_count": {
+                      "lt": "<integer>",
+                      "gt": "<integer>",
+                      "gte": "<integer>",
+                      "lte": "<integer>"
+                    }
+                  }
+                },
+                "with_payload": "<boolean>",
+                "with_vector": "<boolean>",
+                "order_by": "<string>"
+              }
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "string",
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {
+                    "points": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "id"
+                          },
+                          "payload": {
+                            "type": "object",
+                            "properties": {
+                              "nostrud_9": {
+                                "type": "string",
+                                "description": "nostrud_9"
+                              },
+                              "incididunt667": {
+                                "type": "integer",
+                                "format": "int32",
+                                "description": "incididunt667"
+                              },
+                              "elit014": {
+                                "type": "integer",
+                                "format": "int32",
+                                "description": "elit014"
+                              },
+                              "Duis62d": {
+                                "type": "number",
+                                "format": "float",
+                                "description": "Duis62d"
+                              },
+                              "in_f": {
+                                "type": "boolean",
+                                "description": "in_f"
+                              }
+                            },
+                            "description": "payload"
+                          },
+                          "vector": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "description": "vector"
+                          },
+                          "shard_key": {
+                            "type": "string",
+                            "description": "shard_key"
+                          },
+                          "order_value": {
+                            "type": "string",
+                            "description": "order_value"
+                          }
+                        }
+                      },
+                      "description": "points"
+                    },
+                    "next_page_offset": {
+                      "type": "string",
+                      "description": "next_page_offset"
+                    }
+                  },
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "500",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/collections/{collection_name}/points/count": {
+      "post": {
+        "summary": "Count points",
+        "description": "Count points which matches given filtering condition",
+        "operationId": "CountPoints",
+        "parameters": [
+          {
+            "name": "timeout",
+            "default": "<integer>",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "Timeout",
+            "x-ms-summary": "Timeout"
+          },
+          {
+            "name": "collection_name",
+            "default": "<string>",
+            "in": "path",
+            "x-ms-url-encoding": "single",
+            "type": "string",
+            "required": true,
+            "description": "Collection Name",
+            "x-ms-summary": "Collection Name"
+          },
+          {
+            "name": "Content-Type",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Content-Type",
+            "x-ms-summary": "Content-Type"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Accept",
+            "x-ms-summary": "Accept"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "shard_key": {
+                  "type": "string",
+                  "description": "shard_key"
+                },
+                "filter": {
+                  "type": "object",
+                  "properties": {
+                    "should": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string",
+                          "description": "key"
+                        },
+                        "match": {
+                          "type": "object",
+                          "properties": {
+                            "value": {
+                              "type": "string",
+                              "description": "value"
+                            }
+                          },
+                          "description": "match"
+                        },
+                        "range": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "range"
+                        },
+                        "geo_bounding_box": {
+                          "type": "object",
+                          "properties": {
+                            "bottom_right": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "bottom_right"
+                            },
+                            "top_left": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "top_left"
+                            }
+                          },
+                          "description": "geo_bounding_box"
+                        },
+                        "geo_radius": {
+                          "type": "object",
+                          "properties": {
+                            "center": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "center"
+                            },
+                            "radius": {
+                              "type": "string",
+                              "description": "radius"
+                            }
+                          },
+                          "description": "geo_radius"
+                        },
+                        "geo_polygon": {
+                          "type": "object",
+                          "properties": {
+                            "exterior": {
+                              "type": "object",
+                              "properties": {
+                                "points": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    }
+                                  },
+                                  "description": "points"
+                                }
+                              },
+                              "description": "exterior"
+                            },
+                            "interiors": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "points": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "lat": {
+                                          "type": "string",
+                                          "description": "lat"
+                                        },
+                                        "lon": {
+                                          "type": "string",
+                                          "description": "lon"
+                                        }
+                                      }
+                                    },
+                                    "description": "points"
+                                  }
+                                }
+                              },
+                              "description": "interiors"
+                            }
+                          },
+                          "description": "geo_polygon"
+                        },
+                        "values_count": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "values_count"
+                        }
+                      },
+                      "description": "should"
+                    },
+                    "min_should": {
+                      "type": "object",
+                      "properties": {
+                        "conditions": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "key": {
+                                "type": "string",
+                                "description": "key"
+                              },
+                              "match": {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "string",
+                                    "description": "value"
+                                  }
+                                },
+                                "description": "match"
+                              },
+                              "range": {
+                                "type": "object",
+                                "properties": {
+                                  "lt": {
+                                    "type": "string",
+                                    "description": "lt"
+                                  },
+                                  "gt": {
+                                    "type": "string",
+                                    "description": "gt"
+                                  },
+                                  "gte": {
+                                    "type": "string",
+                                    "description": "gte"
+                                  },
+                                  "lte": {
+                                    "type": "string",
+                                    "description": "lte"
+                                  }
+                                },
+                                "description": "range"
+                              },
+                              "geo_bounding_box": {
+                                "type": "object",
+                                "properties": {
+                                  "bottom_right": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    },
+                                    "description": "bottom_right"
+                                  },
+                                  "top_left": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    },
+                                    "description": "top_left"
+                                  }
+                                },
+                                "description": "geo_bounding_box"
+                              },
+                              "geo_radius": {
+                                "type": "object",
+                                "properties": {
+                                  "center": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    },
+                                    "description": "center"
+                                  },
+                                  "radius": {
+                                    "type": "string",
+                                    "description": "radius"
+                                  }
+                                },
+                                "description": "geo_radius"
+                              },
+                              "geo_polygon": {
+                                "type": "object",
+                                "properties": {
+                                  "exterior": {
+                                    "type": "object",
+                                    "properties": {
+                                      "points": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "lat": {
+                                              "type": "string",
+                                              "description": "lat"
+                                            },
+                                            "lon": {
+                                              "type": "string",
+                                              "description": "lon"
+                                            }
+                                          }
+                                        },
+                                        "description": "points"
+                                      }
+                                    },
+                                    "description": "exterior"
+                                  },
+                                  "interiors": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "points": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "lat": {
+                                                "type": "string",
+                                                "description": "lat"
+                                              },
+                                              "lon": {
+                                                "type": "string",
+                                                "description": "lon"
+                                              }
+                                            }
+                                          },
+                                          "description": "points"
+                                        }
+                                      }
+                                    },
+                                    "description": "interiors"
+                                  }
+                                },
+                                "description": "geo_polygon"
+                              },
+                              "values_count": {
+                                "type": "object",
+                                "properties": {
+                                  "lt": {
+                                    "type": "string",
+                                    "description": "lt"
+                                  },
+                                  "gt": {
+                                    "type": "string",
+                                    "description": "gt"
+                                  },
+                                  "gte": {
+                                    "type": "string",
+                                    "description": "gte"
+                                  },
+                                  "lte": {
+                                    "type": "string",
+                                    "description": "lte"
+                                  }
+                                },
+                                "description": "values_count"
+                              }
+                            }
+                          },
+                          "description": "conditions"
+                        },
+                        "min_count": {
+                          "type": "string",
+                          "description": "min_count"
+                        }
+                      },
+                      "description": "min_should"
+                    },
+                    "must": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string",
+                          "description": "key"
+                        },
+                        "match": {
+                          "type": "object",
+                          "properties": {
+                            "value": {
+                              "type": "string",
+                              "description": "value"
+                            }
+                          },
+                          "description": "match"
+                        },
+                        "range": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "range"
+                        },
+                        "geo_bounding_box": {
+                          "type": "object",
+                          "properties": {
+                            "bottom_right": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "bottom_right"
+                            },
+                            "top_left": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "top_left"
+                            }
+                          },
+                          "description": "geo_bounding_box"
+                        },
+                        "geo_radius": {
+                          "type": "object",
+                          "properties": {
+                            "center": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "center"
+                            },
+                            "radius": {
+                              "type": "string",
+                              "description": "radius"
+                            }
+                          },
+                          "description": "geo_radius"
+                        },
+                        "geo_polygon": {
+                          "type": "object",
+                          "properties": {
+                            "exterior": {
+                              "type": "object",
+                              "properties": {
+                                "points": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    }
+                                  },
+                                  "description": "points"
+                                }
+                              },
+                              "description": "exterior"
+                            },
+                            "interiors": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "points": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "lat": {
+                                          "type": "string",
+                                          "description": "lat"
+                                        },
+                                        "lon": {
+                                          "type": "string",
+                                          "description": "lon"
+                                        }
+                                      }
+                                    },
+                                    "description": "points"
+                                  }
+                                }
+                              },
+                              "description": "interiors"
+                            }
+                          },
+                          "description": "geo_polygon"
+                        },
+                        "values_count": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "values_count"
+                        }
+                      },
+                      "description": "must"
+                    },
+                    "must_not": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string",
+                          "description": "key"
+                        },
+                        "match": {
+                          "type": "object",
+                          "properties": {
+                            "value": {
+                              "type": "string",
+                              "description": "value"
+                            }
+                          },
+                          "description": "match"
+                        },
+                        "range": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "range"
+                        },
+                        "geo_bounding_box": {
+                          "type": "object",
+                          "properties": {
+                            "bottom_right": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "bottom_right"
+                            },
+                            "top_left": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "top_left"
+                            }
+                          },
+                          "description": "geo_bounding_box"
+                        },
+                        "geo_radius": {
+                          "type": "object",
+                          "properties": {
+                            "center": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "center"
+                            },
+                            "radius": {
+                              "type": "string",
+                              "description": "radius"
+                            }
+                          },
+                          "description": "geo_radius"
+                        },
+                        "geo_polygon": {
+                          "type": "object",
+                          "properties": {
+                            "exterior": {
+                              "type": "object",
+                              "properties": {
+                                "points": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    }
+                                  },
+                                  "description": "points"
+                                }
+                              },
+                              "description": "exterior"
+                            },
+                            "interiors": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "points": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "lat": {
+                                          "type": "string",
+                                          "description": "lat"
+                                        },
+                                        "lon": {
+                                          "type": "string",
+                                          "description": "lon"
+                                        }
+                                      }
+                                    },
+                                    "description": "points"
+                                  }
+                                }
+                              },
+                              "description": "interiors"
+                            }
+                          },
+                          "description": "geo_polygon"
+                        },
+                        "values_count": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "values_count"
+                        }
+                      },
+                      "description": "must_not"
+                    }
+                  },
+                  "description": "filter"
+                },
+                "exact": {
+                  "type": "boolean",
+                  "description": "exact"
+                }
+              },
+              "default": {
+                "shard_key": "<string>",
+                "filter": {
+                  "should": {
+                    "key": "<string>",
+                    "match": {
+                      "value": "<string>"
+                    },
+                    "range": {
+                      "lt": "<double>",
+                      "gt": "<double>",
+                      "gte": "<double>",
+                      "lte": "<double>"
+                    },
+                    "geo_bounding_box": {
+                      "bottom_right": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "top_left": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      }
+                    },
+                    "geo_radius": {
+                      "center": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "radius": "<double>"
+                    },
+                    "geo_polygon": {
+                      "exterior": {
+                        "points": [
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        ]
+                      },
+                      "interiors": [
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        },
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "values_count": {
+                      "lt": "<integer>",
+                      "gt": "<integer>",
+                      "gte": "<integer>",
+                      "lte": "<integer>"
+                    }
+                  },
+                  "min_should": {
+                    "conditions": [
+                      {
+                        "key": "<string>",
+                        "match": {
+                          "value": "<string>"
+                        },
+                        "range": {
+                          "lt": "<double>",
+                          "gt": "<double>",
+                          "gte": "<double>",
+                          "lte": "<double>"
+                        },
+                        "geo_bounding_box": {
+                          "bottom_right": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "top_left": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        },
+                        "geo_radius": {
+                          "center": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "radius": "<double>"
+                        },
+                        "geo_polygon": {
+                          "exterior": {
+                            "points": [
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            ]
+                          },
+                          "interiors": [
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            },
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "values_count": {
+                          "lt": "<integer>",
+                          "gt": "<integer>",
+                          "gte": "<integer>",
+                          "lte": "<integer>"
+                        }
+                      },
+                      {
+                        "key": "<string>",
+                        "match": {
+                          "value": "<string>"
+                        },
+                        "range": {
+                          "lt": "<double>",
+                          "gt": "<double>",
+                          "gte": "<double>",
+                          "lte": "<double>"
+                        },
+                        "geo_bounding_box": {
+                          "bottom_right": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "top_left": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        },
+                        "geo_radius": {
+                          "center": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "radius": "<double>"
+                        },
+                        "geo_polygon": {
+                          "exterior": {
+                            "points": [
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            ]
+                          },
+                          "interiors": [
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            },
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "values_count": {
+                          "lt": "<integer>",
+                          "gt": "<integer>",
+                          "gte": "<integer>",
+                          "lte": "<integer>"
+                        }
+                      }
+                    ],
+                    "min_count": "<integer>"
+                  },
+                  "must": {
+                    "key": "<string>",
+                    "match": {
+                      "value": "<string>"
+                    },
+                    "range": {
+                      "lt": "<double>",
+                      "gt": "<double>",
+                      "gte": "<double>",
+                      "lte": "<double>"
+                    },
+                    "geo_bounding_box": {
+                      "bottom_right": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "top_left": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      }
+                    },
+                    "geo_radius": {
+                      "center": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "radius": "<double>"
+                    },
+                    "geo_polygon": {
+                      "exterior": {
+                        "points": [
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        ]
+                      },
+                      "interiors": [
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        },
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "values_count": {
+                      "lt": "<integer>",
+                      "gt": "<integer>",
+                      "gte": "<integer>",
+                      "lte": "<integer>"
+                    }
+                  },
+                  "must_not": {
+                    "key": "<string>",
+                    "match": {
+                      "value": "<string>"
+                    },
+                    "range": {
+                      "lt": "<double>",
+                      "gt": "<double>",
+                      "gte": "<double>",
+                      "lte": "<double>"
+                    },
+                    "geo_bounding_box": {
+                      "bottom_right": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "top_left": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      }
+                    },
+                    "geo_radius": {
+                      "center": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "radius": "<double>"
+                    },
+                    "geo_polygon": {
+                      "exterior": {
+                        "points": [
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        ]
+                      },
+                      "interiors": [
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        },
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "values_count": {
+                      "lt": "<integer>",
+                      "gt": "<integer>",
+                      "gte": "<integer>",
+                      "lte": "<integer>"
+                    }
+                  }
+                },
+                "exact": true
+              }
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "string",
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {
+                    "count": {
+                      "type": "string",
+                      "description": "count"
+                    }
+                  },
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "500",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/collections/{collection_name}/points/query/batch": {
+      "post": {
+        "summary": "Query points in batch",
+        "description": "Universally query points in batch. This endpoint covers all capabilities of search, recommend, discover, filters. But also enables hybrid and multi-stage queries.",
+        "operationId": "QueryPointsInBatch",
+        "parameters": [
+          {
+            "name": "consistency",
+            "default": "<integer>",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "Consistency",
+            "x-ms-summary": "Consistency"
+          },
+          {
+            "name": "timeout",
+            "default": "<integer>",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "Timeout",
+            "x-ms-summary": "Timeout"
+          },
+          {
+            "name": "collection_name",
+            "default": "<string>",
+            "in": "path",
+            "x-ms-url-encoding": "single",
+            "type": "string",
+            "required": true,
+            "description": "Collection Name",
+            "x-ms-summary": "Collection Name"
+          },
+          {
+            "name": "Content-Type",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Content-Type",
+            "x-ms-summary": "Content-Type"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Accept",
+            "x-ms-summary": "Accept"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "searches": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "shard_key": {
+                        "type": "string",
+                        "description": "shard_key"
+                      },
+                      "prefetch": {
+                        "type": "object",
+                        "properties": {
+                          "prefetch": {
+                            "type": "object",
+                            "properties": {
+                              "value": {
+                                "type": "string",
+                                "description": "value"
+                              }
+                            },
+                            "description": "prefetch"
+                          },
+                          "query": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "description": "query"
+                          },
+                          "using": {
+                            "type": "string",
+                            "description": "using"
+                          },
+                          "filter": {
+                            "type": "object",
+                            "properties": {
+                              "should": {
+                                "type": "object",
+                                "properties": {
+                                  "key": {
+                                    "type": "string",
+                                    "description": "key"
+                                  },
+                                  "match": {
+                                    "type": "object",
+                                    "properties": {
+                                      "value": {
+                                        "type": "string",
+                                        "description": "value"
+                                      }
+                                    },
+                                    "description": "match"
+                                  },
+                                  "range": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lt": {
+                                        "type": "string",
+                                        "description": "lt"
+                                      },
+                                      "gt": {
+                                        "type": "string",
+                                        "description": "gt"
+                                      },
+                                      "gte": {
+                                        "type": "string",
+                                        "description": "gte"
+                                      },
+                                      "lte": {
+                                        "type": "string",
+                                        "description": "lte"
+                                      }
+                                    },
+                                    "description": "range"
+                                  },
+                                  "geo_bounding_box": {
+                                    "type": "object",
+                                    "properties": {
+                                      "bottom_right": {
+                                        "type": "object",
+                                        "properties": {
+                                          "lat": {
+                                            "type": "string",
+                                            "description": "lat"
+                                          },
+                                          "lon": {
+                                            "type": "string",
+                                            "description": "lon"
+                                          }
+                                        },
+                                        "description": "bottom_right"
+                                      },
+                                      "top_left": {
+                                        "type": "object",
+                                        "properties": {
+                                          "lat": {
+                                            "type": "string",
+                                            "description": "lat"
+                                          },
+                                          "lon": {
+                                            "type": "string",
+                                            "description": "lon"
+                                          }
+                                        },
+                                        "description": "top_left"
+                                      }
+                                    },
+                                    "description": "geo_bounding_box"
+                                  },
+                                  "geo_radius": {
+                                    "type": "object",
+                                    "properties": {
+                                      "center": {
+                                        "type": "object",
+                                        "properties": {
+                                          "lat": {
+                                            "type": "string",
+                                            "description": "lat"
+                                          },
+                                          "lon": {
+                                            "type": "string",
+                                            "description": "lon"
+                                          }
+                                        },
+                                        "description": "center"
+                                      },
+                                      "radius": {
+                                        "type": "string",
+                                        "description": "radius"
+                                      }
+                                    },
+                                    "description": "geo_radius"
+                                  },
+                                  "geo_polygon": {
+                                    "type": "object",
+                                    "properties": {
+                                      "exterior": {
+                                        "type": "object",
+                                        "properties": {
+                                          "points": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "lat": {
+                                                  "type": "string",
+                                                  "description": "lat"
+                                                },
+                                                "lon": {
+                                                  "type": "string",
+                                                  "description": "lon"
+                                                }
+                                              }
+                                            },
+                                            "description": "points"
+                                          }
+                                        },
+                                        "description": "exterior"
+                                      },
+                                      "interiors": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "points": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "lat": {
+                                                    "type": "string",
+                                                    "description": "lat"
+                                                  },
+                                                  "lon": {
+                                                    "type": "string",
+                                                    "description": "lon"
+                                                  }
+                                                }
+                                              },
+                                              "description": "points"
+                                            }
+                                          }
+                                        },
+                                        "description": "interiors"
+                                      }
+                                    },
+                                    "description": "geo_polygon"
+                                  },
+                                  "values_count": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lt": {
+                                        "type": "string",
+                                        "description": "lt"
+                                      },
+                                      "gt": {
+                                        "type": "string",
+                                        "description": "gt"
+                                      },
+                                      "gte": {
+                                        "type": "string",
+                                        "description": "gte"
+                                      },
+                                      "lte": {
+                                        "type": "string",
+                                        "description": "lte"
+                                      }
+                                    },
+                                    "description": "values_count"
+                                  }
+                                },
+                                "description": "should"
+                              },
+                              "min_should": {
+                                "type": "object",
+                                "properties": {
+                                  "conditions": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "key": {
+                                          "type": "string",
+                                          "description": "key"
+                                        },
+                                        "match": {
+                                          "type": "object",
+                                          "properties": {
+                                            "value": {
+                                              "type": "string",
+                                              "description": "value"
+                                            }
+                                          },
+                                          "description": "match"
+                                        },
+                                        "range": {
+                                          "type": "object",
+                                          "properties": {
+                                            "lt": {
+                                              "type": "string",
+                                              "description": "lt"
+                                            },
+                                            "gt": {
+                                              "type": "string",
+                                              "description": "gt"
+                                            },
+                                            "gte": {
+                                              "type": "string",
+                                              "description": "gte"
+                                            },
+                                            "lte": {
+                                              "type": "string",
+                                              "description": "lte"
+                                            }
+                                          },
+                                          "description": "range"
+                                        },
+                                        "geo_bounding_box": {
+                                          "type": "object",
+                                          "properties": {
+                                            "bottom_right": {
+                                              "type": "object",
+                                              "properties": {
+                                                "lat": {
+                                                  "type": "string",
+                                                  "description": "lat"
+                                                },
+                                                "lon": {
+                                                  "type": "string",
+                                                  "description": "lon"
+                                                }
+                                              },
+                                              "description": "bottom_right"
+                                            },
+                                            "top_left": {
+                                              "type": "object",
+                                              "properties": {
+                                                "lat": {
+                                                  "type": "string",
+                                                  "description": "lat"
+                                                },
+                                                "lon": {
+                                                  "type": "string",
+                                                  "description": "lon"
+                                                }
+                                              },
+                                              "description": "top_left"
+                                            }
+                                          },
+                                          "description": "geo_bounding_box"
+                                        },
+                                        "geo_radius": {
+                                          "type": "object",
+                                          "properties": {
+                                            "center": {
+                                              "type": "object",
+                                              "properties": {
+                                                "lat": {
+                                                  "type": "string",
+                                                  "description": "lat"
+                                                },
+                                                "lon": {
+                                                  "type": "string",
+                                                  "description": "lon"
+                                                }
+                                              },
+                                              "description": "center"
+                                            },
+                                            "radius": {
+                                              "type": "string",
+                                              "description": "radius"
+                                            }
+                                          },
+                                          "description": "geo_radius"
+                                        },
+                                        "geo_polygon": {
+                                          "type": "object",
+                                          "properties": {
+                                            "exterior": {
+                                              "type": "object",
+                                              "properties": {
+                                                "points": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "lat": {
+                                                        "type": "string",
+                                                        "description": "lat"
+                                                      },
+                                                      "lon": {
+                                                        "type": "string",
+                                                        "description": "lon"
+                                                      }
+                                                    }
+                                                  },
+                                                  "description": "points"
+                                                }
+                                              },
+                                              "description": "exterior"
+                                            },
+                                            "interiors": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "points": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "lat": {
+                                                          "type": "string",
+                                                          "description": "lat"
+                                                        },
+                                                        "lon": {
+                                                          "type": "string",
+                                                          "description": "lon"
+                                                        }
+                                                      }
+                                                    },
+                                                    "description": "points"
+                                                  }
+                                                }
+                                              },
+                                              "description": "interiors"
+                                            }
+                                          },
+                                          "description": "geo_polygon"
+                                        },
+                                        "values_count": {
+                                          "type": "object",
+                                          "properties": {
+                                            "lt": {
+                                              "type": "string",
+                                              "description": "lt"
+                                            },
+                                            "gt": {
+                                              "type": "string",
+                                              "description": "gt"
+                                            },
+                                            "gte": {
+                                              "type": "string",
+                                              "description": "gte"
+                                            },
+                                            "lte": {
+                                              "type": "string",
+                                              "description": "lte"
+                                            }
+                                          },
+                                          "description": "values_count"
+                                        }
+                                      }
+                                    },
+                                    "description": "conditions"
+                                  },
+                                  "min_count": {
+                                    "type": "string",
+                                    "description": "min_count"
+                                  }
+                                },
+                                "description": "min_should"
+                              },
+                              "must": {
+                                "type": "object",
+                                "properties": {
+                                  "key": {
+                                    "type": "string",
+                                    "description": "key"
+                                  },
+                                  "match": {
+                                    "type": "object",
+                                    "properties": {
+                                      "value": {
+                                        "type": "string",
+                                        "description": "value"
+                                      }
+                                    },
+                                    "description": "match"
+                                  },
+                                  "range": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lt": {
+                                        "type": "string",
+                                        "description": "lt"
+                                      },
+                                      "gt": {
+                                        "type": "string",
+                                        "description": "gt"
+                                      },
+                                      "gte": {
+                                        "type": "string",
+                                        "description": "gte"
+                                      },
+                                      "lte": {
+                                        "type": "string",
+                                        "description": "lte"
+                                      }
+                                    },
+                                    "description": "range"
+                                  },
+                                  "geo_bounding_box": {
+                                    "type": "object",
+                                    "properties": {
+                                      "bottom_right": {
+                                        "type": "object",
+                                        "properties": {
+                                          "lat": {
+                                            "type": "string",
+                                            "description": "lat"
+                                          },
+                                          "lon": {
+                                            "type": "string",
+                                            "description": "lon"
+                                          }
+                                        },
+                                        "description": "bottom_right"
+                                      },
+                                      "top_left": {
+                                        "type": "object",
+                                        "properties": {
+                                          "lat": {
+                                            "type": "string",
+                                            "description": "lat"
+                                          },
+                                          "lon": {
+                                            "type": "string",
+                                            "description": "lon"
+                                          }
+                                        },
+                                        "description": "top_left"
+                                      }
+                                    },
+                                    "description": "geo_bounding_box"
+                                  },
+                                  "geo_radius": {
+                                    "type": "object",
+                                    "properties": {
+                                      "center": {
+                                        "type": "object",
+                                        "properties": {
+                                          "lat": {
+                                            "type": "string",
+                                            "description": "lat"
+                                          },
+                                          "lon": {
+                                            "type": "string",
+                                            "description": "lon"
+                                          }
+                                        },
+                                        "description": "center"
+                                      },
+                                      "radius": {
+                                        "type": "string",
+                                        "description": "radius"
+                                      }
+                                    },
+                                    "description": "geo_radius"
+                                  },
+                                  "geo_polygon": {
+                                    "type": "object",
+                                    "properties": {
+                                      "exterior": {
+                                        "type": "object",
+                                        "properties": {
+                                          "points": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "lat": {
+                                                  "type": "string",
+                                                  "description": "lat"
+                                                },
+                                                "lon": {
+                                                  "type": "string",
+                                                  "description": "lon"
+                                                }
+                                              }
+                                            },
+                                            "description": "points"
+                                          }
+                                        },
+                                        "description": "exterior"
+                                      },
+                                      "interiors": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "points": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "lat": {
+                                                    "type": "string",
+                                                    "description": "lat"
+                                                  },
+                                                  "lon": {
+                                                    "type": "string",
+                                                    "description": "lon"
+                                                  }
+                                                }
+                                              },
+                                              "description": "points"
+                                            }
+                                          }
+                                        },
+                                        "description": "interiors"
+                                      }
+                                    },
+                                    "description": "geo_polygon"
+                                  },
+                                  "values_count": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lt": {
+                                        "type": "string",
+                                        "description": "lt"
+                                      },
+                                      "gt": {
+                                        "type": "string",
+                                        "description": "gt"
+                                      },
+                                      "gte": {
+                                        "type": "string",
+                                        "description": "gte"
+                                      },
+                                      "lte": {
+                                        "type": "string",
+                                        "description": "lte"
+                                      }
+                                    },
+                                    "description": "values_count"
+                                  }
+                                },
+                                "description": "must"
+                              },
+                              "must_not": {
+                                "type": "object",
+                                "properties": {
+                                  "key": {
+                                    "type": "string",
+                                    "description": "key"
+                                  },
+                                  "match": {
+                                    "type": "object",
+                                    "properties": {
+                                      "value": {
+                                        "type": "string",
+                                        "description": "value"
+                                      }
+                                    },
+                                    "description": "match"
+                                  },
+                                  "range": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lt": {
+                                        "type": "string",
+                                        "description": "lt"
+                                      },
+                                      "gt": {
+                                        "type": "string",
+                                        "description": "gt"
+                                      },
+                                      "gte": {
+                                        "type": "string",
+                                        "description": "gte"
+                                      },
+                                      "lte": {
+                                        "type": "string",
+                                        "description": "lte"
+                                      }
+                                    },
+                                    "description": "range"
+                                  },
+                                  "geo_bounding_box": {
+                                    "type": "object",
+                                    "properties": {
+                                      "bottom_right": {
+                                        "type": "object",
+                                        "properties": {
+                                          "lat": {
+                                            "type": "string",
+                                            "description": "lat"
+                                          },
+                                          "lon": {
+                                            "type": "string",
+                                            "description": "lon"
+                                          }
+                                        },
+                                        "description": "bottom_right"
+                                      },
+                                      "top_left": {
+                                        "type": "object",
+                                        "properties": {
+                                          "lat": {
+                                            "type": "string",
+                                            "description": "lat"
+                                          },
+                                          "lon": {
+                                            "type": "string",
+                                            "description": "lon"
+                                          }
+                                        },
+                                        "description": "top_left"
+                                      }
+                                    },
+                                    "description": "geo_bounding_box"
+                                  },
+                                  "geo_radius": {
+                                    "type": "object",
+                                    "properties": {
+                                      "center": {
+                                        "type": "object",
+                                        "properties": {
+                                          "lat": {
+                                            "type": "string",
+                                            "description": "lat"
+                                          },
+                                          "lon": {
+                                            "type": "string",
+                                            "description": "lon"
+                                          }
+                                        },
+                                        "description": "center"
+                                      },
+                                      "radius": {
+                                        "type": "string",
+                                        "description": "radius"
+                                      }
+                                    },
+                                    "description": "geo_radius"
+                                  },
+                                  "geo_polygon": {
+                                    "type": "object",
+                                    "properties": {
+                                      "exterior": {
+                                        "type": "object",
+                                        "properties": {
+                                          "points": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "lat": {
+                                                  "type": "string",
+                                                  "description": "lat"
+                                                },
+                                                "lon": {
+                                                  "type": "string",
+                                                  "description": "lon"
+                                                }
+                                              }
+                                            },
+                                            "description": "points"
+                                          }
+                                        },
+                                        "description": "exterior"
+                                      },
+                                      "interiors": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "points": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "lat": {
+                                                    "type": "string",
+                                                    "description": "lat"
+                                                  },
+                                                  "lon": {
+                                                    "type": "string",
+                                                    "description": "lon"
+                                                  }
+                                                }
+                                              },
+                                              "description": "points"
+                                            }
+                                          }
+                                        },
+                                        "description": "interiors"
+                                      }
+                                    },
+                                    "description": "geo_polygon"
+                                  },
+                                  "values_count": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lt": {
+                                        "type": "string",
+                                        "description": "lt"
+                                      },
+                                      "gt": {
+                                        "type": "string",
+                                        "description": "gt"
+                                      },
+                                      "gte": {
+                                        "type": "string",
+                                        "description": "gte"
+                                      },
+                                      "lte": {
+                                        "type": "string",
+                                        "description": "lte"
+                                      }
+                                    },
+                                    "description": "values_count"
+                                  }
+                                },
+                                "description": "must_not"
+                              }
+                            },
+                            "description": "filter"
+                          },
+                          "params": {
+                            "type": "object",
+                            "properties": {
+                              "hnsw_ef": {
+                                "type": "string",
+                                "description": "hnsw_ef"
+                              },
+                              "exact": {
+                                "type": "boolean",
+                                "description": "exact"
+                              },
+                              "quantization": {
+                                "type": "object",
+                                "properties": {
+                                  "ignore": {
+                                    "type": "boolean",
+                                    "description": "ignore"
+                                  },
+                                  "rescore": {
+                                    "type": "string",
+                                    "description": "rescore"
+                                  },
+                                  "oversampling": {
+                                    "type": "string",
+                                    "description": "oversampling"
+                                  }
+                                },
+                                "description": "quantization"
+                              },
+                              "indexed_only": {
+                                "type": "boolean",
+                                "description": "indexed_only"
+                              }
+                            },
+                            "description": "params"
+                          },
+                          "score_threshold": {
+                            "type": "string",
+                            "description": "score_threshold"
+                          },
+                          "limit": {
+                            "type": "string",
+                            "description": "limit"
+                          },
+                          "lookup_from": {
+                            "type": "object",
+                            "properties": {
+                              "collection": {
+                                "type": "string",
+                                "description": "collection"
+                              },
+                              "vector": {
+                                "type": "string",
+                                "description": "vector"
+                              },
+                              "shard_key": {
+                                "type": "string",
+                                "description": "shard_key"
+                              }
+                            },
+                            "description": "lookup_from"
+                          }
+                        },
+                        "description": "prefetch"
+                      },
+                      "query": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "query"
+                      },
+                      "using": {
+                        "type": "string",
+                        "description": "using"
+                      },
+                      "filter": {
+                        "type": "object",
+                        "properties": {
+                          "should": {
+                            "type": "object",
+                            "properties": {
+                              "key": {
+                                "type": "string",
+                                "description": "key"
+                              },
+                              "match": {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "string",
+                                    "description": "value"
+                                  }
+                                },
+                                "description": "match"
+                              },
+                              "range": {
+                                "type": "object",
+                                "properties": {
+                                  "lt": {
+                                    "type": "string",
+                                    "description": "lt"
+                                  },
+                                  "gt": {
+                                    "type": "string",
+                                    "description": "gt"
+                                  },
+                                  "gte": {
+                                    "type": "string",
+                                    "description": "gte"
+                                  },
+                                  "lte": {
+                                    "type": "string",
+                                    "description": "lte"
+                                  }
+                                },
+                                "description": "range"
+                              },
+                              "geo_bounding_box": {
+                                "type": "object",
+                                "properties": {
+                                  "bottom_right": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    },
+                                    "description": "bottom_right"
+                                  },
+                                  "top_left": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    },
+                                    "description": "top_left"
+                                  }
+                                },
+                                "description": "geo_bounding_box"
+                              },
+                              "geo_radius": {
+                                "type": "object",
+                                "properties": {
+                                  "center": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    },
+                                    "description": "center"
+                                  },
+                                  "radius": {
+                                    "type": "string",
+                                    "description": "radius"
+                                  }
+                                },
+                                "description": "geo_radius"
+                              },
+                              "geo_polygon": {
+                                "type": "object",
+                                "properties": {
+                                  "exterior": {
+                                    "type": "object",
+                                    "properties": {
+                                      "points": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "lat": {
+                                              "type": "string",
+                                              "description": "lat"
+                                            },
+                                            "lon": {
+                                              "type": "string",
+                                              "description": "lon"
+                                            }
+                                          }
+                                        },
+                                        "description": "points"
+                                      }
+                                    },
+                                    "description": "exterior"
+                                  },
+                                  "interiors": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "points": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "lat": {
+                                                "type": "string",
+                                                "description": "lat"
+                                              },
+                                              "lon": {
+                                                "type": "string",
+                                                "description": "lon"
+                                              }
+                                            }
+                                          },
+                                          "description": "points"
+                                        }
+                                      }
+                                    },
+                                    "description": "interiors"
+                                  }
+                                },
+                                "description": "geo_polygon"
+                              },
+                              "values_count": {
+                                "type": "object",
+                                "properties": {
+                                  "lt": {
+                                    "type": "string",
+                                    "description": "lt"
+                                  },
+                                  "gt": {
+                                    "type": "string",
+                                    "description": "gt"
+                                  },
+                                  "gte": {
+                                    "type": "string",
+                                    "description": "gte"
+                                  },
+                                  "lte": {
+                                    "type": "string",
+                                    "description": "lte"
+                                  }
+                                },
+                                "description": "values_count"
+                              }
+                            },
+                            "description": "should"
+                          },
+                          "min_should": {
+                            "type": "object",
+                            "properties": {
+                              "conditions": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "key": {
+                                      "type": "string",
+                                      "description": "key"
+                                    },
+                                    "match": {
+                                      "type": "object",
+                                      "properties": {
+                                        "value": {
+                                          "type": "string",
+                                          "description": "value"
+                                        }
+                                      },
+                                      "description": "match"
+                                    },
+                                    "range": {
+                                      "type": "object",
+                                      "properties": {
+                                        "lt": {
+                                          "type": "string",
+                                          "description": "lt"
+                                        },
+                                        "gt": {
+                                          "type": "string",
+                                          "description": "gt"
+                                        },
+                                        "gte": {
+                                          "type": "string",
+                                          "description": "gte"
+                                        },
+                                        "lte": {
+                                          "type": "string",
+                                          "description": "lte"
+                                        }
+                                      },
+                                      "description": "range"
+                                    },
+                                    "geo_bounding_box": {
+                                      "type": "object",
+                                      "properties": {
+                                        "bottom_right": {
+                                          "type": "object",
+                                          "properties": {
+                                            "lat": {
+                                              "type": "string",
+                                              "description": "lat"
+                                            },
+                                            "lon": {
+                                              "type": "string",
+                                              "description": "lon"
+                                            }
+                                          },
+                                          "description": "bottom_right"
+                                        },
+                                        "top_left": {
+                                          "type": "object",
+                                          "properties": {
+                                            "lat": {
+                                              "type": "string",
+                                              "description": "lat"
+                                            },
+                                            "lon": {
+                                              "type": "string",
+                                              "description": "lon"
+                                            }
+                                          },
+                                          "description": "top_left"
+                                        }
+                                      },
+                                      "description": "geo_bounding_box"
+                                    },
+                                    "geo_radius": {
+                                      "type": "object",
+                                      "properties": {
+                                        "center": {
+                                          "type": "object",
+                                          "properties": {
+                                            "lat": {
+                                              "type": "string",
+                                              "description": "lat"
+                                            },
+                                            "lon": {
+                                              "type": "string",
+                                              "description": "lon"
+                                            }
+                                          },
+                                          "description": "center"
+                                        },
+                                        "radius": {
+                                          "type": "string",
+                                          "description": "radius"
+                                        }
+                                      },
+                                      "description": "geo_radius"
+                                    },
+                                    "geo_polygon": {
+                                      "type": "object",
+                                      "properties": {
+                                        "exterior": {
+                                          "type": "object",
+                                          "properties": {
+                                            "points": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "lat": {
+                                                    "type": "string",
+                                                    "description": "lat"
+                                                  },
+                                                  "lon": {
+                                                    "type": "string",
+                                                    "description": "lon"
+                                                  }
+                                                }
+                                              },
+                                              "description": "points"
+                                            }
+                                          },
+                                          "description": "exterior"
+                                        },
+                                        "interiors": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "points": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "lat": {
+                                                      "type": "string",
+                                                      "description": "lat"
+                                                    },
+                                                    "lon": {
+                                                      "type": "string",
+                                                      "description": "lon"
+                                                    }
+                                                  }
+                                                },
+                                                "description": "points"
+                                              }
+                                            }
+                                          },
+                                          "description": "interiors"
+                                        }
+                                      },
+                                      "description": "geo_polygon"
+                                    },
+                                    "values_count": {
+                                      "type": "object",
+                                      "properties": {
+                                        "lt": {
+                                          "type": "string",
+                                          "description": "lt"
+                                        },
+                                        "gt": {
+                                          "type": "string",
+                                          "description": "gt"
+                                        },
+                                        "gte": {
+                                          "type": "string",
+                                          "description": "gte"
+                                        },
+                                        "lte": {
+                                          "type": "string",
+                                          "description": "lte"
+                                        }
+                                      },
+                                      "description": "values_count"
+                                    }
+                                  }
+                                },
+                                "description": "conditions"
+                              },
+                              "min_count": {
+                                "type": "string",
+                                "description": "min_count"
+                              }
+                            },
+                            "description": "min_should"
+                          },
+                          "must": {
+                            "type": "object",
+                            "properties": {
+                              "key": {
+                                "type": "string",
+                                "description": "key"
+                              },
+                              "match": {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "string",
+                                    "description": "value"
+                                  }
+                                },
+                                "description": "match"
+                              },
+                              "range": {
+                                "type": "object",
+                                "properties": {
+                                  "lt": {
+                                    "type": "string",
+                                    "description": "lt"
+                                  },
+                                  "gt": {
+                                    "type": "string",
+                                    "description": "gt"
+                                  },
+                                  "gte": {
+                                    "type": "string",
+                                    "description": "gte"
+                                  },
+                                  "lte": {
+                                    "type": "string",
+                                    "description": "lte"
+                                  }
+                                },
+                                "description": "range"
+                              },
+                              "geo_bounding_box": {
+                                "type": "object",
+                                "properties": {
+                                  "bottom_right": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    },
+                                    "description": "bottom_right"
+                                  },
+                                  "top_left": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    },
+                                    "description": "top_left"
+                                  }
+                                },
+                                "description": "geo_bounding_box"
+                              },
+                              "geo_radius": {
+                                "type": "object",
+                                "properties": {
+                                  "center": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    },
+                                    "description": "center"
+                                  },
+                                  "radius": {
+                                    "type": "string",
+                                    "description": "radius"
+                                  }
+                                },
+                                "description": "geo_radius"
+                              },
+                              "geo_polygon": {
+                                "type": "object",
+                                "properties": {
+                                  "exterior": {
+                                    "type": "object",
+                                    "properties": {
+                                      "points": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "lat": {
+                                              "type": "string",
+                                              "description": "lat"
+                                            },
+                                            "lon": {
+                                              "type": "string",
+                                              "description": "lon"
+                                            }
+                                          }
+                                        },
+                                        "description": "points"
+                                      }
+                                    },
+                                    "description": "exterior"
+                                  },
+                                  "interiors": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "points": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "lat": {
+                                                "type": "string",
+                                                "description": "lat"
+                                              },
+                                              "lon": {
+                                                "type": "string",
+                                                "description": "lon"
+                                              }
+                                            }
+                                          },
+                                          "description": "points"
+                                        }
+                                      }
+                                    },
+                                    "description": "interiors"
+                                  }
+                                },
+                                "description": "geo_polygon"
+                              },
+                              "values_count": {
+                                "type": "object",
+                                "properties": {
+                                  "lt": {
+                                    "type": "string",
+                                    "description": "lt"
+                                  },
+                                  "gt": {
+                                    "type": "string",
+                                    "description": "gt"
+                                  },
+                                  "gte": {
+                                    "type": "string",
+                                    "description": "gte"
+                                  },
+                                  "lte": {
+                                    "type": "string",
+                                    "description": "lte"
+                                  }
+                                },
+                                "description": "values_count"
+                              }
+                            },
+                            "description": "must"
+                          },
+                          "must_not": {
+                            "type": "object",
+                            "properties": {
+                              "key": {
+                                "type": "string",
+                                "description": "key"
+                              },
+                              "match": {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "string",
+                                    "description": "value"
+                                  }
+                                },
+                                "description": "match"
+                              },
+                              "range": {
+                                "type": "object",
+                                "properties": {
+                                  "lt": {
+                                    "type": "string",
+                                    "description": "lt"
+                                  },
+                                  "gt": {
+                                    "type": "string",
+                                    "description": "gt"
+                                  },
+                                  "gte": {
+                                    "type": "string",
+                                    "description": "gte"
+                                  },
+                                  "lte": {
+                                    "type": "string",
+                                    "description": "lte"
+                                  }
+                                },
+                                "description": "range"
+                              },
+                              "geo_bounding_box": {
+                                "type": "object",
+                                "properties": {
+                                  "bottom_right": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    },
+                                    "description": "bottom_right"
+                                  },
+                                  "top_left": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    },
+                                    "description": "top_left"
+                                  }
+                                },
+                                "description": "geo_bounding_box"
+                              },
+                              "geo_radius": {
+                                "type": "object",
+                                "properties": {
+                                  "center": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    },
+                                    "description": "center"
+                                  },
+                                  "radius": {
+                                    "type": "string",
+                                    "description": "radius"
+                                  }
+                                },
+                                "description": "geo_radius"
+                              },
+                              "geo_polygon": {
+                                "type": "object",
+                                "properties": {
+                                  "exterior": {
+                                    "type": "object",
+                                    "properties": {
+                                      "points": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "lat": {
+                                              "type": "string",
+                                              "description": "lat"
+                                            },
+                                            "lon": {
+                                              "type": "string",
+                                              "description": "lon"
+                                            }
+                                          }
+                                        },
+                                        "description": "points"
+                                      }
+                                    },
+                                    "description": "exterior"
+                                  },
+                                  "interiors": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "points": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "lat": {
+                                                "type": "string",
+                                                "description": "lat"
+                                              },
+                                              "lon": {
+                                                "type": "string",
+                                                "description": "lon"
+                                              }
+                                            }
+                                          },
+                                          "description": "points"
+                                        }
+                                      }
+                                    },
+                                    "description": "interiors"
+                                  }
+                                },
+                                "description": "geo_polygon"
+                              },
+                              "values_count": {
+                                "type": "object",
+                                "properties": {
+                                  "lt": {
+                                    "type": "string",
+                                    "description": "lt"
+                                  },
+                                  "gt": {
+                                    "type": "string",
+                                    "description": "gt"
+                                  },
+                                  "gte": {
+                                    "type": "string",
+                                    "description": "gte"
+                                  },
+                                  "lte": {
+                                    "type": "string",
+                                    "description": "lte"
+                                  }
+                                },
+                                "description": "values_count"
+                              }
+                            },
+                            "description": "must_not"
+                          }
+                        },
+                        "description": "filter"
+                      },
+                      "params": {
+                        "type": "object",
+                        "properties": {
+                          "hnsw_ef": {
+                            "type": "string",
+                            "description": "hnsw_ef"
+                          },
+                          "exact": {
+                            "type": "boolean",
+                            "description": "exact"
+                          },
+                          "quantization": {
+                            "type": "object",
+                            "properties": {
+                              "ignore": {
+                                "type": "boolean",
+                                "description": "ignore"
+                              },
+                              "rescore": {
+                                "type": "string",
+                                "description": "rescore"
+                              },
+                              "oversampling": {
+                                "type": "string",
+                                "description": "oversampling"
+                              }
+                            },
+                            "description": "quantization"
+                          },
+                          "indexed_only": {
+                            "type": "boolean",
+                            "description": "indexed_only"
+                          }
+                        },
+                        "description": "params"
+                      },
+                      "score_threshold": {
+                        "type": "string",
+                        "description": "score_threshold"
+                      },
+                      "limit": {
+                        "type": "string",
+                        "description": "limit"
+                      },
+                      "offset": {
+                        "type": "string",
+                        "description": "offset"
+                      },
+                      "with_vector": {
+                        "type": "string",
+                        "description": "with_vector"
+                      },
+                      "with_payload": {
+                        "type": "string",
+                        "description": "with_payload"
+                      },
+                      "lookup_from": {
+                        "type": "object",
+                        "properties": {
+                          "collection": {
+                            "type": "string",
+                            "description": "collection"
+                          },
+                          "vector": {
+                            "type": "string",
+                            "description": "vector"
+                          },
+                          "shard_key": {
+                            "type": "string",
+                            "description": "shard_key"
+                          }
+                        },
+                        "description": "lookup_from"
+                      }
+                    }
+                  },
+                  "description": "searches"
+                }
+              },
+              "default": {
+                "searches": [
+                  {
+                    "shard_key": "<string>",
+                    "prefetch": {
+                      "prefetch": {
+                        "value": "<Circular reference to #/components/schemas/Prefetch detected>"
+                      },
+                      "query": [
+                        "<float>",
+                        "<float>"
+                      ],
+                      "using": "<string>",
+                      "filter": {
+                        "should": {
+                          "key": "<string>",
+                          "match": {
+                            "value": "<string>"
+                          },
+                          "range": {
+                            "lt": "<double>",
+                            "gt": "<double>",
+                            "gte": "<double>",
+                            "lte": "<double>"
+                          },
+                          "geo_bounding_box": {
+                            "bottom_right": {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            "top_left": {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          },
+                          "geo_radius": {
+                            "center": {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            "radius": "<double>"
+                          },
+                          "geo_polygon": {
+                            "exterior": {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            },
+                            "interiors": [
+                              {
+                                "points": [
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  },
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  }
+                                ]
+                              },
+                              {
+                                "points": [
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  },
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          "values_count": {
+                            "lt": "<integer>",
+                            "gt": "<integer>",
+                            "gte": "<integer>",
+                            "lte": "<integer>"
+                          }
+                        },
+                        "min_should": {
+                          "conditions": [
+                            {
+                              "key": "<string>",
+                              "match": {
+                                "value": "<string>"
+                              },
+                              "range": {
+                                "lt": "<double>",
+                                "gt": "<double>",
+                                "gte": "<double>",
+                                "lte": "<double>"
+                              },
+                              "geo_bounding_box": {
+                                "bottom_right": {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                "top_left": {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              },
+                              "geo_radius": {
+                                "center": {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                "radius": "<double>"
+                              },
+                              "geo_polygon": {
+                                "exterior": {
+                                  "points": [
+                                    {
+                                      "lat": "<double>",
+                                      "lon": "<double>"
+                                    },
+                                    {
+                                      "lat": "<double>",
+                                      "lon": "<double>"
+                                    }
+                                  ]
+                                },
+                                "interiors": [
+                                  {
+                                    "points": [
+                                      {
+                                        "lat": "<double>",
+                                        "lon": "<double>"
+                                      },
+                                      {
+                                        "lat": "<double>",
+                                        "lon": "<double>"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "points": [
+                                      {
+                                        "lat": "<double>",
+                                        "lon": "<double>"
+                                      },
+                                      {
+                                        "lat": "<double>",
+                                        "lon": "<double>"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              "values_count": {
+                                "lt": "<integer>",
+                                "gt": "<integer>",
+                                "gte": "<integer>",
+                                "lte": "<integer>"
+                              }
+                            },
+                            {
+                              "key": "<string>",
+                              "match": {
+                                "value": "<string>"
+                              },
+                              "range": {
+                                "lt": "<double>",
+                                "gt": "<double>",
+                                "gte": "<double>",
+                                "lte": "<double>"
+                              },
+                              "geo_bounding_box": {
+                                "bottom_right": {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                "top_left": {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              },
+                              "geo_radius": {
+                                "center": {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                "radius": "<double>"
+                              },
+                              "geo_polygon": {
+                                "exterior": {
+                                  "points": [
+                                    {
+                                      "lat": "<double>",
+                                      "lon": "<double>"
+                                    },
+                                    {
+                                      "lat": "<double>",
+                                      "lon": "<double>"
+                                    }
+                                  ]
+                                },
+                                "interiors": [
+                                  {
+                                    "points": [
+                                      {
+                                        "lat": "<double>",
+                                        "lon": "<double>"
+                                      },
+                                      {
+                                        "lat": "<double>",
+                                        "lon": "<double>"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "points": [
+                                      {
+                                        "lat": "<double>",
+                                        "lon": "<double>"
+                                      },
+                                      {
+                                        "lat": "<double>",
+                                        "lon": "<double>"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              "values_count": {
+                                "lt": "<integer>",
+                                "gt": "<integer>",
+                                "gte": "<integer>",
+                                "lte": "<integer>"
+                              }
+                            }
+                          ],
+                          "min_count": "<integer>"
+                        },
+                        "must": {
+                          "key": "<string>",
+                          "match": {
+                            "value": "<string>"
+                          },
+                          "range": {
+                            "lt": "<double>",
+                            "gt": "<double>",
+                            "gte": "<double>",
+                            "lte": "<double>"
+                          },
+                          "geo_bounding_box": {
+                            "bottom_right": {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            "top_left": {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          },
+                          "geo_radius": {
+                            "center": {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            "radius": "<double>"
+                          },
+                          "geo_polygon": {
+                            "exterior": {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            },
+                            "interiors": [
+                              {
+                                "points": [
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  },
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  }
+                                ]
+                              },
+                              {
+                                "points": [
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  },
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          "values_count": {
+                            "lt": "<integer>",
+                            "gt": "<integer>",
+                            "gte": "<integer>",
+                            "lte": "<integer>"
+                          }
+                        },
+                        "must_not": {
+                          "key": "<string>",
+                          "match": {
+                            "value": "<string>"
+                          },
+                          "range": {
+                            "lt": "<double>",
+                            "gt": "<double>",
+                            "gte": "<double>",
+                            "lte": "<double>"
+                          },
+                          "geo_bounding_box": {
+                            "bottom_right": {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            "top_left": {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          },
+                          "geo_radius": {
+                            "center": {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            "radius": "<double>"
+                          },
+                          "geo_polygon": {
+                            "exterior": {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            },
+                            "interiors": [
+                              {
+                                "points": [
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  },
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  }
+                                ]
+                              },
+                              {
+                                "points": [
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  },
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          "values_count": {
+                            "lt": "<integer>",
+                            "gt": "<integer>",
+                            "gte": "<integer>",
+                            "lte": "<integer>"
+                          }
+                        }
+                      },
+                      "params": {
+                        "hnsw_ef": "<integer>",
+                        "exact": false,
+                        "quantization": {
+                          "ignore": false,
+                          "rescore": null,
+                          "oversampling": null
+                        },
+                        "indexed_only": false
+                      },
+                      "score_threshold": "<float>",
+                      "limit": "<integer>",
+                      "lookup_from": {
+                        "collection": "<string>",
+                        "vector": null,
+                        "shard_key": "<string>"
+                      }
+                    },
+                    "query": [
+                      "<float>",
+                      "<float>"
+                    ],
+                    "using": "<string>",
+                    "filter": {
+                      "should": {
+                        "key": "<string>",
+                        "match": {
+                          "value": "<string>"
+                        },
+                        "range": {
+                          "lt": "<double>",
+                          "gt": "<double>",
+                          "gte": "<double>",
+                          "lte": "<double>"
+                        },
+                        "geo_bounding_box": {
+                          "bottom_right": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "top_left": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        },
+                        "geo_radius": {
+                          "center": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "radius": "<double>"
+                        },
+                        "geo_polygon": {
+                          "exterior": {
+                            "points": [
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            ]
+                          },
+                          "interiors": [
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            },
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "values_count": {
+                          "lt": "<integer>",
+                          "gt": "<integer>",
+                          "gte": "<integer>",
+                          "lte": "<integer>"
+                        }
+                      },
+                      "min_should": {
+                        "conditions": [
+                          {
+                            "key": "<string>",
+                            "match": {
+                              "value": "<string>"
+                            },
+                            "range": {
+                              "lt": "<double>",
+                              "gt": "<double>",
+                              "gte": "<double>",
+                              "lte": "<double>"
+                            },
+                            "geo_bounding_box": {
+                              "bottom_right": {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              "top_left": {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            },
+                            "geo_radius": {
+                              "center": {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              "radius": "<double>"
+                            },
+                            "geo_polygon": {
+                              "exterior": {
+                                "points": [
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  },
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  }
+                                ]
+                              },
+                              "interiors": [
+                                {
+                                  "points": [
+                                    {
+                                      "lat": "<double>",
+                                      "lon": "<double>"
+                                    },
+                                    {
+                                      "lat": "<double>",
+                                      "lon": "<double>"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "points": [
+                                    {
+                                      "lat": "<double>",
+                                      "lon": "<double>"
+                                    },
+                                    {
+                                      "lat": "<double>",
+                                      "lon": "<double>"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            "values_count": {
+                              "lt": "<integer>",
+                              "gt": "<integer>",
+                              "gte": "<integer>",
+                              "lte": "<integer>"
+                            }
+                          },
+                          {
+                            "key": "<string>",
+                            "match": {
+                              "value": "<string>"
+                            },
+                            "range": {
+                              "lt": "<double>",
+                              "gt": "<double>",
+                              "gte": "<double>",
+                              "lte": "<double>"
+                            },
+                            "geo_bounding_box": {
+                              "bottom_right": {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              "top_left": {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            },
+                            "geo_radius": {
+                              "center": {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              "radius": "<double>"
+                            },
+                            "geo_polygon": {
+                              "exterior": {
+                                "points": [
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  },
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  }
+                                ]
+                              },
+                              "interiors": [
+                                {
+                                  "points": [
+                                    {
+                                      "lat": "<double>",
+                                      "lon": "<double>"
+                                    },
+                                    {
+                                      "lat": "<double>",
+                                      "lon": "<double>"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "points": [
+                                    {
+                                      "lat": "<double>",
+                                      "lon": "<double>"
+                                    },
+                                    {
+                                      "lat": "<double>",
+                                      "lon": "<double>"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            "values_count": {
+                              "lt": "<integer>",
+                              "gt": "<integer>",
+                              "gte": "<integer>",
+                              "lte": "<integer>"
+                            }
+                          }
+                        ],
+                        "min_count": "<integer>"
+                      },
+                      "must": {
+                        "key": "<string>",
+                        "match": {
+                          "value": "<string>"
+                        },
+                        "range": {
+                          "lt": "<double>",
+                          "gt": "<double>",
+                          "gte": "<double>",
+                          "lte": "<double>"
+                        },
+                        "geo_bounding_box": {
+                          "bottom_right": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "top_left": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        },
+                        "geo_radius": {
+                          "center": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "radius": "<double>"
+                        },
+                        "geo_polygon": {
+                          "exterior": {
+                            "points": [
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            ]
+                          },
+                          "interiors": [
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            },
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "values_count": {
+                          "lt": "<integer>",
+                          "gt": "<integer>",
+                          "gte": "<integer>",
+                          "lte": "<integer>"
+                        }
+                      },
+                      "must_not": {
+                        "key": "<string>",
+                        "match": {
+                          "value": "<string>"
+                        },
+                        "range": {
+                          "lt": "<double>",
+                          "gt": "<double>",
+                          "gte": "<double>",
+                          "lte": "<double>"
+                        },
+                        "geo_bounding_box": {
+                          "bottom_right": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "top_left": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        },
+                        "geo_radius": {
+                          "center": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "radius": "<double>"
+                        },
+                        "geo_polygon": {
+                          "exterior": {
+                            "points": [
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            ]
+                          },
+                          "interiors": [
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            },
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "values_count": {
+                          "lt": "<integer>",
+                          "gt": "<integer>",
+                          "gte": "<integer>",
+                          "lte": "<integer>"
+                        }
+                      }
+                    },
+                    "params": {
+                      "hnsw_ef": "<integer>",
+                      "exact": false,
+                      "quantization": {
+                        "ignore": false,
+                        "rescore": null,
+                        "oversampling": null
+                      },
+                      "indexed_only": false
+                    },
+                    "score_threshold": "<float>",
+                    "limit": "<integer>",
+                    "offset": "<integer>",
+                    "with_vector": "<boolean>",
+                    "with_payload": "<boolean>",
+                    "lookup_from": {
+                      "collection": "<string>",
+                      "vector": null,
+                      "shard_key": "<string>"
+                    }
+                  },
+                  {
+                    "shard_key": "<string>",
+                    "prefetch": {
+                      "prefetch": {
+                        "value": "<Circular reference to #/components/schemas/Prefetch detected>"
+                      },
+                      "query": [
+                        "<float>",
+                        "<float>"
+                      ],
+                      "using": "<string>",
+                      "filter": {
+                        "should": {
+                          "key": "<string>",
+                          "match": {
+                            "value": "<string>"
+                          },
+                          "range": {
+                            "lt": "<double>",
+                            "gt": "<double>",
+                            "gte": "<double>",
+                            "lte": "<double>"
+                          },
+                          "geo_bounding_box": {
+                            "bottom_right": {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            "top_left": {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          },
+                          "geo_radius": {
+                            "center": {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            "radius": "<double>"
+                          },
+                          "geo_polygon": {
+                            "exterior": {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            },
+                            "interiors": [
+                              {
+                                "points": [
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  },
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  }
+                                ]
+                              },
+                              {
+                                "points": [
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  },
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          "values_count": {
+                            "lt": "<integer>",
+                            "gt": "<integer>",
+                            "gte": "<integer>",
+                            "lte": "<integer>"
+                          }
+                        },
+                        "min_should": {
+                          "conditions": [
+                            {
+                              "key": "<string>",
+                              "match": {
+                                "value": "<string>"
+                              },
+                              "range": {
+                                "lt": "<double>",
+                                "gt": "<double>",
+                                "gte": "<double>",
+                                "lte": "<double>"
+                              },
+                              "geo_bounding_box": {
+                                "bottom_right": {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                "top_left": {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              },
+                              "geo_radius": {
+                                "center": {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                "radius": "<double>"
+                              },
+                              "geo_polygon": {
+                                "exterior": {
+                                  "points": [
+                                    {
+                                      "lat": "<double>",
+                                      "lon": "<double>"
+                                    },
+                                    {
+                                      "lat": "<double>",
+                                      "lon": "<double>"
+                                    }
+                                  ]
+                                },
+                                "interiors": [
+                                  {
+                                    "points": [
+                                      {
+                                        "lat": "<double>",
+                                        "lon": "<double>"
+                                      },
+                                      {
+                                        "lat": "<double>",
+                                        "lon": "<double>"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "points": [
+                                      {
+                                        "lat": "<double>",
+                                        "lon": "<double>"
+                                      },
+                                      {
+                                        "lat": "<double>",
+                                        "lon": "<double>"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              "values_count": {
+                                "lt": "<integer>",
+                                "gt": "<integer>",
+                                "gte": "<integer>",
+                                "lte": "<integer>"
+                              }
+                            },
+                            {
+                              "key": "<string>",
+                              "match": {
+                                "value": "<string>"
+                              },
+                              "range": {
+                                "lt": "<double>",
+                                "gt": "<double>",
+                                "gte": "<double>",
+                                "lte": "<double>"
+                              },
+                              "geo_bounding_box": {
+                                "bottom_right": {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                "top_left": {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              },
+                              "geo_radius": {
+                                "center": {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                "radius": "<double>"
+                              },
+                              "geo_polygon": {
+                                "exterior": {
+                                  "points": [
+                                    {
+                                      "lat": "<double>",
+                                      "lon": "<double>"
+                                    },
+                                    {
+                                      "lat": "<double>",
+                                      "lon": "<double>"
+                                    }
+                                  ]
+                                },
+                                "interiors": [
+                                  {
+                                    "points": [
+                                      {
+                                        "lat": "<double>",
+                                        "lon": "<double>"
+                                      },
+                                      {
+                                        "lat": "<double>",
+                                        "lon": "<double>"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "points": [
+                                      {
+                                        "lat": "<double>",
+                                        "lon": "<double>"
+                                      },
+                                      {
+                                        "lat": "<double>",
+                                        "lon": "<double>"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              "values_count": {
+                                "lt": "<integer>",
+                                "gt": "<integer>",
+                                "gte": "<integer>",
+                                "lte": "<integer>"
+                              }
+                            }
+                          ],
+                          "min_count": "<integer>"
+                        },
+                        "must": {
+                          "key": "<string>",
+                          "match": {
+                            "value": "<string>"
+                          },
+                          "range": {
+                            "lt": "<double>",
+                            "gt": "<double>",
+                            "gte": "<double>",
+                            "lte": "<double>"
+                          },
+                          "geo_bounding_box": {
+                            "bottom_right": {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            "top_left": {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          },
+                          "geo_radius": {
+                            "center": {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            "radius": "<double>"
+                          },
+                          "geo_polygon": {
+                            "exterior": {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            },
+                            "interiors": [
+                              {
+                                "points": [
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  },
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  }
+                                ]
+                              },
+                              {
+                                "points": [
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  },
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          "values_count": {
+                            "lt": "<integer>",
+                            "gt": "<integer>",
+                            "gte": "<integer>",
+                            "lte": "<integer>"
+                          }
+                        },
+                        "must_not": {
+                          "key": "<string>",
+                          "match": {
+                            "value": "<string>"
+                          },
+                          "range": {
+                            "lt": "<double>",
+                            "gt": "<double>",
+                            "gte": "<double>",
+                            "lte": "<double>"
+                          },
+                          "geo_bounding_box": {
+                            "bottom_right": {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            "top_left": {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          },
+                          "geo_radius": {
+                            "center": {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            "radius": "<double>"
+                          },
+                          "geo_polygon": {
+                            "exterior": {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            },
+                            "interiors": [
+                              {
+                                "points": [
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  },
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  }
+                                ]
+                              },
+                              {
+                                "points": [
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  },
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          "values_count": {
+                            "lt": "<integer>",
+                            "gt": "<integer>",
+                            "gte": "<integer>",
+                            "lte": "<integer>"
+                          }
+                        }
+                      },
+                      "params": {
+                        "hnsw_ef": "<integer>",
+                        "exact": false,
+                        "quantization": {
+                          "ignore": false,
+                          "rescore": null,
+                          "oversampling": null
+                        },
+                        "indexed_only": false
+                      },
+                      "score_threshold": "<float>",
+                      "limit": "<integer>",
+                      "lookup_from": {
+                        "collection": "<string>",
+                        "vector": null,
+                        "shard_key": "<string>"
+                      }
+                    },
+                    "query": [
+                      "<float>",
+                      "<float>"
+                    ],
+                    "using": "<string>",
+                    "filter": {
+                      "should": {
+                        "key": "<string>",
+                        "match": {
+                          "value": "<string>"
+                        },
+                        "range": {
+                          "lt": "<double>",
+                          "gt": "<double>",
+                          "gte": "<double>",
+                          "lte": "<double>"
+                        },
+                        "geo_bounding_box": {
+                          "bottom_right": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "top_left": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        },
+                        "geo_radius": {
+                          "center": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "radius": "<double>"
+                        },
+                        "geo_polygon": {
+                          "exterior": {
+                            "points": [
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            ]
+                          },
+                          "interiors": [
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            },
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "values_count": {
+                          "lt": "<integer>",
+                          "gt": "<integer>",
+                          "gte": "<integer>",
+                          "lte": "<integer>"
+                        }
+                      },
+                      "min_should": {
+                        "conditions": [
+                          {
+                            "key": "<string>",
+                            "match": {
+                              "value": "<string>"
+                            },
+                            "range": {
+                              "lt": "<double>",
+                              "gt": "<double>",
+                              "gte": "<double>",
+                              "lte": "<double>"
+                            },
+                            "geo_bounding_box": {
+                              "bottom_right": {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              "top_left": {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            },
+                            "geo_radius": {
+                              "center": {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              "radius": "<double>"
+                            },
+                            "geo_polygon": {
+                              "exterior": {
+                                "points": [
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  },
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  }
+                                ]
+                              },
+                              "interiors": [
+                                {
+                                  "points": [
+                                    {
+                                      "lat": "<double>",
+                                      "lon": "<double>"
+                                    },
+                                    {
+                                      "lat": "<double>",
+                                      "lon": "<double>"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "points": [
+                                    {
+                                      "lat": "<double>",
+                                      "lon": "<double>"
+                                    },
+                                    {
+                                      "lat": "<double>",
+                                      "lon": "<double>"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            "values_count": {
+                              "lt": "<integer>",
+                              "gt": "<integer>",
+                              "gte": "<integer>",
+                              "lte": "<integer>"
+                            }
+                          },
+                          {
+                            "key": "<string>",
+                            "match": {
+                              "value": "<string>"
+                            },
+                            "range": {
+                              "lt": "<double>",
+                              "gt": "<double>",
+                              "gte": "<double>",
+                              "lte": "<double>"
+                            },
+                            "geo_bounding_box": {
+                              "bottom_right": {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              "top_left": {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            },
+                            "geo_radius": {
+                              "center": {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              "radius": "<double>"
+                            },
+                            "geo_polygon": {
+                              "exterior": {
+                                "points": [
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  },
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  }
+                                ]
+                              },
+                              "interiors": [
+                                {
+                                  "points": [
+                                    {
+                                      "lat": "<double>",
+                                      "lon": "<double>"
+                                    },
+                                    {
+                                      "lat": "<double>",
+                                      "lon": "<double>"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "points": [
+                                    {
+                                      "lat": "<double>",
+                                      "lon": "<double>"
+                                    },
+                                    {
+                                      "lat": "<double>",
+                                      "lon": "<double>"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            "values_count": {
+                              "lt": "<integer>",
+                              "gt": "<integer>",
+                              "gte": "<integer>",
+                              "lte": "<integer>"
+                            }
+                          }
+                        ],
+                        "min_count": "<integer>"
+                      },
+                      "must": {
+                        "key": "<string>",
+                        "match": {
+                          "value": "<string>"
+                        },
+                        "range": {
+                          "lt": "<double>",
+                          "gt": "<double>",
+                          "gte": "<double>",
+                          "lte": "<double>"
+                        },
+                        "geo_bounding_box": {
+                          "bottom_right": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "top_left": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        },
+                        "geo_radius": {
+                          "center": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "radius": "<double>"
+                        },
+                        "geo_polygon": {
+                          "exterior": {
+                            "points": [
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            ]
+                          },
+                          "interiors": [
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            },
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "values_count": {
+                          "lt": "<integer>",
+                          "gt": "<integer>",
+                          "gte": "<integer>",
+                          "lte": "<integer>"
+                        }
+                      },
+                      "must_not": {
+                        "key": "<string>",
+                        "match": {
+                          "value": "<string>"
+                        },
+                        "range": {
+                          "lt": "<double>",
+                          "gt": "<double>",
+                          "gte": "<double>",
+                          "lte": "<double>"
+                        },
+                        "geo_bounding_box": {
+                          "bottom_right": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "top_left": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        },
+                        "geo_radius": {
+                          "center": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "radius": "<double>"
+                        },
+                        "geo_polygon": {
+                          "exterior": {
+                            "points": [
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            ]
+                          },
+                          "interiors": [
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            },
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "values_count": {
+                          "lt": "<integer>",
+                          "gt": "<integer>",
+                          "gte": "<integer>",
+                          "lte": "<integer>"
+                        }
+                      }
+                    },
+                    "params": {
+                      "hnsw_ef": "<integer>",
+                      "exact": false,
+                      "quantization": {
+                        "ignore": false,
+                        "rescore": null,
+                        "oversampling": null
+                      },
+                      "indexed_only": false
+                    },
+                    "score_threshold": "<float>",
+                    "limit": "<integer>",
+                    "offset": "<integer>",
+                    "with_vector": "<boolean>",
+                    "with_payload": "<boolean>",
+                    "lookup_from": {
+                      "collection": "<string>",
+                      "vector": null,
+                      "shard_key": "<string>"
+                    }
+                  }
+                ]
+              }
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "string",
+                  "description": "status"
+                },
+                "result": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "points": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "id"
+                            },
+                            "score": {
+                              "type": "string",
+                              "description": "score"
+                            },
+                            "version": {
+                              "type": "string",
+                              "description": "version"
+                            },
+                            "payload": {
+                              "type": "object",
+                              "properties": {
+                                "aliqua_c8f": {
+                                  "type": "string",
+                                  "description": "aliqua_c8f"
+                                },
+                                "dolor82": {
+                                  "type": "integer",
+                                  "format": "int32",
+                                  "description": "dolor82"
+                                },
+                                "Duis_6": {
+                                  "type": "boolean",
+                                  "description": "Duis_6"
+                                },
+                                "Lorem0c3": {
+                                  "type": "number",
+                                  "format": "float",
+                                  "description": "Lorem0c3"
+                                },
+                                "euc": {
+                                  "type": "integer",
+                                  "format": "int32",
+                                  "description": "euc"
+                                },
+                                "ut89": {
+                                  "type": "number",
+                                  "format": "float",
+                                  "description": "ut89"
+                                },
+                                "ad_": {
+                                  "type": "integer",
+                                  "format": "int32",
+                                  "description": "ad_"
+                                }
+                              },
+                              "description": "payload"
+                            },
+                            "vector": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              },
+                              "description": "vector"
+                            },
+                            "shard_key": {
+                              "type": "string",
+                              "description": "shard_key"
+                            },
+                            "order_value": {
+                              "type": "string",
+                              "description": "order_value"
+                            }
+                          }
+                        },
+                        "description": "points"
+                      }
+                    }
+                  },
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "500",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/collections/{collection_name}/points/query/groups": {
+      "post": {
+        "summary": "Query points, grouped by a given payload field",
+        "description": "Universally query points, grouped by a given payload field",
+        "operationId": "QueryPointsGroupedByAGivenPayloadField",
+        "parameters": [
+          {
+            "name": "consistency",
+            "default": "<integer>",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "Consistency",
+            "x-ms-summary": "Consistency"
+          },
+          {
+            "name": "timeout",
+            "default": "<integer>",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "Timeout",
+            "x-ms-summary": "Timeout"
+          },
+          {
+            "name": "collection_name",
+            "default": "<string>",
+            "in": "path",
+            "x-ms-url-encoding": "single",
+            "type": "string",
+            "required": true,
+            "description": "Collection Name",
+            "x-ms-summary": "Collection Name"
+          },
+          {
+            "name": "Content-Type",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Content-Type",
+            "x-ms-summary": "Content-Type"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Accept",
+            "x-ms-summary": "Accept"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "group_by": {
+                  "type": "string",
+                  "description": "group_by"
+                },
+                "shard_key": {
+                  "type": "string",
+                  "description": "shard_key"
+                },
+                "prefetch": {
+                  "type": "object",
+                  "properties": {
+                    "prefetch": {
+                      "type": "object",
+                      "properties": {
+                        "value": {
+                          "type": "string",
+                          "description": "value"
+                        }
+                      },
+                      "description": "prefetch"
+                    },
+                    "query": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "query"
+                    },
+                    "using": {
+                      "type": "string",
+                      "description": "using"
+                    },
+                    "filter": {
+                      "type": "object",
+                      "properties": {
+                        "should": {
+                          "type": "object",
+                          "properties": {
+                            "key": {
+                              "type": "string",
+                              "description": "key"
+                            },
+                            "match": {
+                              "type": "object",
+                              "properties": {
+                                "value": {
+                                  "type": "string",
+                                  "description": "value"
+                                }
+                              },
+                              "description": "match"
+                            },
+                            "range": {
+                              "type": "object",
+                              "properties": {
+                                "lt": {
+                                  "type": "string",
+                                  "description": "lt"
+                                },
+                                "gt": {
+                                  "type": "string",
+                                  "description": "gt"
+                                },
+                                "gte": {
+                                  "type": "string",
+                                  "description": "gte"
+                                },
+                                "lte": {
+                                  "type": "string",
+                                  "description": "lte"
+                                }
+                              },
+                              "description": "range"
+                            },
+                            "geo_bounding_box": {
+                              "type": "object",
+                              "properties": {
+                                "bottom_right": {
+                                  "type": "object",
+                                  "properties": {
+                                    "lat": {
+                                      "type": "string",
+                                      "description": "lat"
+                                    },
+                                    "lon": {
+                                      "type": "string",
+                                      "description": "lon"
+                                    }
+                                  },
+                                  "description": "bottom_right"
+                                },
+                                "top_left": {
+                                  "type": "object",
+                                  "properties": {
+                                    "lat": {
+                                      "type": "string",
+                                      "description": "lat"
+                                    },
+                                    "lon": {
+                                      "type": "string",
+                                      "description": "lon"
+                                    }
+                                  },
+                                  "description": "top_left"
+                                }
+                              },
+                              "description": "geo_bounding_box"
+                            },
+                            "geo_radius": {
+                              "type": "object",
+                              "properties": {
+                                "center": {
+                                  "type": "object",
+                                  "properties": {
+                                    "lat": {
+                                      "type": "string",
+                                      "description": "lat"
+                                    },
+                                    "lon": {
+                                      "type": "string",
+                                      "description": "lon"
+                                    }
+                                  },
+                                  "description": "center"
+                                },
+                                "radius": {
+                                  "type": "string",
+                                  "description": "radius"
+                                }
+                              },
+                              "description": "geo_radius"
+                            },
+                            "geo_polygon": {
+                              "type": "object",
+                              "properties": {
+                                "exterior": {
+                                  "type": "object",
+                                  "properties": {
+                                    "points": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "lat": {
+                                            "type": "string",
+                                            "description": "lat"
+                                          },
+                                          "lon": {
+                                            "type": "string",
+                                            "description": "lon"
+                                          }
+                                        }
+                                      },
+                                      "description": "points"
+                                    }
+                                  },
+                                  "description": "exterior"
+                                },
+                                "interiors": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "points": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "lat": {
+                                              "type": "string",
+                                              "description": "lat"
+                                            },
+                                            "lon": {
+                                              "type": "string",
+                                              "description": "lon"
+                                            }
+                                          }
+                                        },
+                                        "description": "points"
+                                      }
+                                    }
+                                  },
+                                  "description": "interiors"
+                                }
+                              },
+                              "description": "geo_polygon"
+                            },
+                            "values_count": {
+                              "type": "object",
+                              "properties": {
+                                "lt": {
+                                  "type": "string",
+                                  "description": "lt"
+                                },
+                                "gt": {
+                                  "type": "string",
+                                  "description": "gt"
+                                },
+                                "gte": {
+                                  "type": "string",
+                                  "description": "gte"
+                                },
+                                "lte": {
+                                  "type": "string",
+                                  "description": "lte"
+                                }
+                              },
+                              "description": "values_count"
+                            }
+                          },
+                          "description": "should"
+                        },
+                        "min_should": {
+                          "type": "object",
+                          "properties": {
+                            "conditions": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "key": {
+                                    "type": "string",
+                                    "description": "key"
+                                  },
+                                  "match": {
+                                    "type": "object",
+                                    "properties": {
+                                      "value": {
+                                        "type": "string",
+                                        "description": "value"
+                                      }
+                                    },
+                                    "description": "match"
+                                  },
+                                  "range": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lt": {
+                                        "type": "string",
+                                        "description": "lt"
+                                      },
+                                      "gt": {
+                                        "type": "string",
+                                        "description": "gt"
+                                      },
+                                      "gte": {
+                                        "type": "string",
+                                        "description": "gte"
+                                      },
+                                      "lte": {
+                                        "type": "string",
+                                        "description": "lte"
+                                      }
+                                    },
+                                    "description": "range"
+                                  },
+                                  "geo_bounding_box": {
+                                    "type": "object",
+                                    "properties": {
+                                      "bottom_right": {
+                                        "type": "object",
+                                        "properties": {
+                                          "lat": {
+                                            "type": "string",
+                                            "description": "lat"
+                                          },
+                                          "lon": {
+                                            "type": "string",
+                                            "description": "lon"
+                                          }
+                                        },
+                                        "description": "bottom_right"
+                                      },
+                                      "top_left": {
+                                        "type": "object",
+                                        "properties": {
+                                          "lat": {
+                                            "type": "string",
+                                            "description": "lat"
+                                          },
+                                          "lon": {
+                                            "type": "string",
+                                            "description": "lon"
+                                          }
+                                        },
+                                        "description": "top_left"
+                                      }
+                                    },
+                                    "description": "geo_bounding_box"
+                                  },
+                                  "geo_radius": {
+                                    "type": "object",
+                                    "properties": {
+                                      "center": {
+                                        "type": "object",
+                                        "properties": {
+                                          "lat": {
+                                            "type": "string",
+                                            "description": "lat"
+                                          },
+                                          "lon": {
+                                            "type": "string",
+                                            "description": "lon"
+                                          }
+                                        },
+                                        "description": "center"
+                                      },
+                                      "radius": {
+                                        "type": "string",
+                                        "description": "radius"
+                                      }
+                                    },
+                                    "description": "geo_radius"
+                                  },
+                                  "geo_polygon": {
+                                    "type": "object",
+                                    "properties": {
+                                      "exterior": {
+                                        "type": "object",
+                                        "properties": {
+                                          "points": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "lat": {
+                                                  "type": "string",
+                                                  "description": "lat"
+                                                },
+                                                "lon": {
+                                                  "type": "string",
+                                                  "description": "lon"
+                                                }
+                                              }
+                                            },
+                                            "description": "points"
+                                          }
+                                        },
+                                        "description": "exterior"
+                                      },
+                                      "interiors": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "points": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "lat": {
+                                                    "type": "string",
+                                                    "description": "lat"
+                                                  },
+                                                  "lon": {
+                                                    "type": "string",
+                                                    "description": "lon"
+                                                  }
+                                                }
+                                              },
+                                              "description": "points"
+                                            }
+                                          }
+                                        },
+                                        "description": "interiors"
+                                      }
+                                    },
+                                    "description": "geo_polygon"
+                                  },
+                                  "values_count": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lt": {
+                                        "type": "string",
+                                        "description": "lt"
+                                      },
+                                      "gt": {
+                                        "type": "string",
+                                        "description": "gt"
+                                      },
+                                      "gte": {
+                                        "type": "string",
+                                        "description": "gte"
+                                      },
+                                      "lte": {
+                                        "type": "string",
+                                        "description": "lte"
+                                      }
+                                    },
+                                    "description": "values_count"
+                                  }
+                                }
+                              },
+                              "description": "conditions"
+                            },
+                            "min_count": {
+                              "type": "string",
+                              "description": "min_count"
+                            }
+                          },
+                          "description": "min_should"
+                        },
+                        "must": {
+                          "type": "object",
+                          "properties": {
+                            "key": {
+                              "type": "string",
+                              "description": "key"
+                            },
+                            "match": {
+                              "type": "object",
+                              "properties": {
+                                "value": {
+                                  "type": "string",
+                                  "description": "value"
+                                }
+                              },
+                              "description": "match"
+                            },
+                            "range": {
+                              "type": "object",
+                              "properties": {
+                                "lt": {
+                                  "type": "string",
+                                  "description": "lt"
+                                },
+                                "gt": {
+                                  "type": "string",
+                                  "description": "gt"
+                                },
+                                "gte": {
+                                  "type": "string",
+                                  "description": "gte"
+                                },
+                                "lte": {
+                                  "type": "string",
+                                  "description": "lte"
+                                }
+                              },
+                              "description": "range"
+                            },
+                            "geo_bounding_box": {
+                              "type": "object",
+                              "properties": {
+                                "bottom_right": {
+                                  "type": "object",
+                                  "properties": {
+                                    "lat": {
+                                      "type": "string",
+                                      "description": "lat"
+                                    },
+                                    "lon": {
+                                      "type": "string",
+                                      "description": "lon"
+                                    }
+                                  },
+                                  "description": "bottom_right"
+                                },
+                                "top_left": {
+                                  "type": "object",
+                                  "properties": {
+                                    "lat": {
+                                      "type": "string",
+                                      "description": "lat"
+                                    },
+                                    "lon": {
+                                      "type": "string",
+                                      "description": "lon"
+                                    }
+                                  },
+                                  "description": "top_left"
+                                }
+                              },
+                              "description": "geo_bounding_box"
+                            },
+                            "geo_radius": {
+                              "type": "object",
+                              "properties": {
+                                "center": {
+                                  "type": "object",
+                                  "properties": {
+                                    "lat": {
+                                      "type": "string",
+                                      "description": "lat"
+                                    },
+                                    "lon": {
+                                      "type": "string",
+                                      "description": "lon"
+                                    }
+                                  },
+                                  "description": "center"
+                                },
+                                "radius": {
+                                  "type": "string",
+                                  "description": "radius"
+                                }
+                              },
+                              "description": "geo_radius"
+                            },
+                            "geo_polygon": {
+                              "type": "object",
+                              "properties": {
+                                "exterior": {
+                                  "type": "object",
+                                  "properties": {
+                                    "points": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "lat": {
+                                            "type": "string",
+                                            "description": "lat"
+                                          },
+                                          "lon": {
+                                            "type": "string",
+                                            "description": "lon"
+                                          }
+                                        }
+                                      },
+                                      "description": "points"
+                                    }
+                                  },
+                                  "description": "exterior"
+                                },
+                                "interiors": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "points": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "lat": {
+                                              "type": "string",
+                                              "description": "lat"
+                                            },
+                                            "lon": {
+                                              "type": "string",
+                                              "description": "lon"
+                                            }
+                                          }
+                                        },
+                                        "description": "points"
+                                      }
+                                    }
+                                  },
+                                  "description": "interiors"
+                                }
+                              },
+                              "description": "geo_polygon"
+                            },
+                            "values_count": {
+                              "type": "object",
+                              "properties": {
+                                "lt": {
+                                  "type": "string",
+                                  "description": "lt"
+                                },
+                                "gt": {
+                                  "type": "string",
+                                  "description": "gt"
+                                },
+                                "gte": {
+                                  "type": "string",
+                                  "description": "gte"
+                                },
+                                "lte": {
+                                  "type": "string",
+                                  "description": "lte"
+                                }
+                              },
+                              "description": "values_count"
+                            }
+                          },
+                          "description": "must"
+                        },
+                        "must_not": {
+                          "type": "object",
+                          "properties": {
+                            "key": {
+                              "type": "string",
+                              "description": "key"
+                            },
+                            "match": {
+                              "type": "object",
+                              "properties": {
+                                "value": {
+                                  "type": "string",
+                                  "description": "value"
+                                }
+                              },
+                              "description": "match"
+                            },
+                            "range": {
+                              "type": "object",
+                              "properties": {
+                                "lt": {
+                                  "type": "string",
+                                  "description": "lt"
+                                },
+                                "gt": {
+                                  "type": "string",
+                                  "description": "gt"
+                                },
+                                "gte": {
+                                  "type": "string",
+                                  "description": "gte"
+                                },
+                                "lte": {
+                                  "type": "string",
+                                  "description": "lte"
+                                }
+                              },
+                              "description": "range"
+                            },
+                            "geo_bounding_box": {
+                              "type": "object",
+                              "properties": {
+                                "bottom_right": {
+                                  "type": "object",
+                                  "properties": {
+                                    "lat": {
+                                      "type": "string",
+                                      "description": "lat"
+                                    },
+                                    "lon": {
+                                      "type": "string",
+                                      "description": "lon"
+                                    }
+                                  },
+                                  "description": "bottom_right"
+                                },
+                                "top_left": {
+                                  "type": "object",
+                                  "properties": {
+                                    "lat": {
+                                      "type": "string",
+                                      "description": "lat"
+                                    },
+                                    "lon": {
+                                      "type": "string",
+                                      "description": "lon"
+                                    }
+                                  },
+                                  "description": "top_left"
+                                }
+                              },
+                              "description": "geo_bounding_box"
+                            },
+                            "geo_radius": {
+                              "type": "object",
+                              "properties": {
+                                "center": {
+                                  "type": "object",
+                                  "properties": {
+                                    "lat": {
+                                      "type": "string",
+                                      "description": "lat"
+                                    },
+                                    "lon": {
+                                      "type": "string",
+                                      "description": "lon"
+                                    }
+                                  },
+                                  "description": "center"
+                                },
+                                "radius": {
+                                  "type": "string",
+                                  "description": "radius"
+                                }
+                              },
+                              "description": "geo_radius"
+                            },
+                            "geo_polygon": {
+                              "type": "object",
+                              "properties": {
+                                "exterior": {
+                                  "type": "object",
+                                  "properties": {
+                                    "points": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "lat": {
+                                            "type": "string",
+                                            "description": "lat"
+                                          },
+                                          "lon": {
+                                            "type": "string",
+                                            "description": "lon"
+                                          }
+                                        }
+                                      },
+                                      "description": "points"
+                                    }
+                                  },
+                                  "description": "exterior"
+                                },
+                                "interiors": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "points": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "lat": {
+                                              "type": "string",
+                                              "description": "lat"
+                                            },
+                                            "lon": {
+                                              "type": "string",
+                                              "description": "lon"
+                                            }
+                                          }
+                                        },
+                                        "description": "points"
+                                      }
+                                    }
+                                  },
+                                  "description": "interiors"
+                                }
+                              },
+                              "description": "geo_polygon"
+                            },
+                            "values_count": {
+                              "type": "object",
+                              "properties": {
+                                "lt": {
+                                  "type": "string",
+                                  "description": "lt"
+                                },
+                                "gt": {
+                                  "type": "string",
+                                  "description": "gt"
+                                },
+                                "gte": {
+                                  "type": "string",
+                                  "description": "gte"
+                                },
+                                "lte": {
+                                  "type": "string",
+                                  "description": "lte"
+                                }
+                              },
+                              "description": "values_count"
+                            }
+                          },
+                          "description": "must_not"
+                        }
+                      },
+                      "description": "filter"
+                    },
+                    "params": {
+                      "type": "object",
+                      "properties": {
+                        "hnsw_ef": {
+                          "type": "string",
+                          "description": "hnsw_ef"
+                        },
+                        "exact": {
+                          "type": "boolean",
+                          "description": "exact"
+                        },
+                        "quantization": {
+                          "type": "object",
+                          "properties": {
+                            "ignore": {
+                              "type": "boolean",
+                              "description": "ignore"
+                            },
+                            "rescore": {
+                              "type": "string",
+                              "description": "rescore"
+                            },
+                            "oversampling": {
+                              "type": "string",
+                              "description": "oversampling"
+                            }
+                          },
+                          "description": "quantization"
+                        },
+                        "indexed_only": {
+                          "type": "boolean",
+                          "description": "indexed_only"
+                        }
+                      },
+                      "description": "params"
+                    },
+                    "score_threshold": {
+                      "type": "string",
+                      "description": "score_threshold"
+                    },
+                    "limit": {
+                      "type": "string",
+                      "description": "limit"
+                    },
+                    "lookup_from": {
+                      "type": "object",
+                      "properties": {
+                        "collection": {
+                          "type": "string",
+                          "description": "collection"
+                        },
+                        "vector": {
+                          "type": "string",
+                          "description": "vector"
+                        },
+                        "shard_key": {
+                          "type": "string",
+                          "description": "shard_key"
+                        }
+                      },
+                      "description": "lookup_from"
+                    }
+                  },
+                  "description": "prefetch"
+                },
+                "query": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "query"
+                },
+                "using": {
+                  "type": "string",
+                  "description": "using"
+                },
+                "filter": {
+                  "type": "object",
+                  "properties": {
+                    "should": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string",
+                          "description": "key"
+                        },
+                        "match": {
+                          "type": "object",
+                          "properties": {
+                            "value": {
+                              "type": "string",
+                              "description": "value"
+                            }
+                          },
+                          "description": "match"
+                        },
+                        "range": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "range"
+                        },
+                        "geo_bounding_box": {
+                          "type": "object",
+                          "properties": {
+                            "bottom_right": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "bottom_right"
+                            },
+                            "top_left": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "top_left"
+                            }
+                          },
+                          "description": "geo_bounding_box"
+                        },
+                        "geo_radius": {
+                          "type": "object",
+                          "properties": {
+                            "center": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "center"
+                            },
+                            "radius": {
+                              "type": "string",
+                              "description": "radius"
+                            }
+                          },
+                          "description": "geo_radius"
+                        },
+                        "geo_polygon": {
+                          "type": "object",
+                          "properties": {
+                            "exterior": {
+                              "type": "object",
+                              "properties": {
+                                "points": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    }
+                                  },
+                                  "description": "points"
+                                }
+                              },
+                              "description": "exterior"
+                            },
+                            "interiors": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "points": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "lat": {
+                                          "type": "string",
+                                          "description": "lat"
+                                        },
+                                        "lon": {
+                                          "type": "string",
+                                          "description": "lon"
+                                        }
+                                      }
+                                    },
+                                    "description": "points"
+                                  }
+                                }
+                              },
+                              "description": "interiors"
+                            }
+                          },
+                          "description": "geo_polygon"
+                        },
+                        "values_count": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "values_count"
+                        }
+                      },
+                      "description": "should"
+                    },
+                    "min_should": {
+                      "type": "object",
+                      "properties": {
+                        "conditions": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "key": {
+                                "type": "string",
+                                "description": "key"
+                              },
+                              "match": {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "string",
+                                    "description": "value"
+                                  }
+                                },
+                                "description": "match"
+                              },
+                              "range": {
+                                "type": "object",
+                                "properties": {
+                                  "lt": {
+                                    "type": "string",
+                                    "description": "lt"
+                                  },
+                                  "gt": {
+                                    "type": "string",
+                                    "description": "gt"
+                                  },
+                                  "gte": {
+                                    "type": "string",
+                                    "description": "gte"
+                                  },
+                                  "lte": {
+                                    "type": "string",
+                                    "description": "lte"
+                                  }
+                                },
+                                "description": "range"
+                              },
+                              "geo_bounding_box": {
+                                "type": "object",
+                                "properties": {
+                                  "bottom_right": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    },
+                                    "description": "bottom_right"
+                                  },
+                                  "top_left": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    },
+                                    "description": "top_left"
+                                  }
+                                },
+                                "description": "geo_bounding_box"
+                              },
+                              "geo_radius": {
+                                "type": "object",
+                                "properties": {
+                                  "center": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    },
+                                    "description": "center"
+                                  },
+                                  "radius": {
+                                    "type": "string",
+                                    "description": "radius"
+                                  }
+                                },
+                                "description": "geo_radius"
+                              },
+                              "geo_polygon": {
+                                "type": "object",
+                                "properties": {
+                                  "exterior": {
+                                    "type": "object",
+                                    "properties": {
+                                      "points": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "lat": {
+                                              "type": "string",
+                                              "description": "lat"
+                                            },
+                                            "lon": {
+                                              "type": "string",
+                                              "description": "lon"
+                                            }
+                                          }
+                                        },
+                                        "description": "points"
+                                      }
+                                    },
+                                    "description": "exterior"
+                                  },
+                                  "interiors": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "points": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "lat": {
+                                                "type": "string",
+                                                "description": "lat"
+                                              },
+                                              "lon": {
+                                                "type": "string",
+                                                "description": "lon"
+                                              }
+                                            }
+                                          },
+                                          "description": "points"
+                                        }
+                                      }
+                                    },
+                                    "description": "interiors"
+                                  }
+                                },
+                                "description": "geo_polygon"
+                              },
+                              "values_count": {
+                                "type": "object",
+                                "properties": {
+                                  "lt": {
+                                    "type": "string",
+                                    "description": "lt"
+                                  },
+                                  "gt": {
+                                    "type": "string",
+                                    "description": "gt"
+                                  },
+                                  "gte": {
+                                    "type": "string",
+                                    "description": "gte"
+                                  },
+                                  "lte": {
+                                    "type": "string",
+                                    "description": "lte"
+                                  }
+                                },
+                                "description": "values_count"
+                              }
+                            }
+                          },
+                          "description": "conditions"
+                        },
+                        "min_count": {
+                          "type": "string",
+                          "description": "min_count"
+                        }
+                      },
+                      "description": "min_should"
+                    },
+                    "must": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string",
+                          "description": "key"
+                        },
+                        "match": {
+                          "type": "object",
+                          "properties": {
+                            "value": {
+                              "type": "string",
+                              "description": "value"
+                            }
+                          },
+                          "description": "match"
+                        },
+                        "range": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "range"
+                        },
+                        "geo_bounding_box": {
+                          "type": "object",
+                          "properties": {
+                            "bottom_right": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "bottom_right"
+                            },
+                            "top_left": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "top_left"
+                            }
+                          },
+                          "description": "geo_bounding_box"
+                        },
+                        "geo_radius": {
+                          "type": "object",
+                          "properties": {
+                            "center": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "center"
+                            },
+                            "radius": {
+                              "type": "string",
+                              "description": "radius"
+                            }
+                          },
+                          "description": "geo_radius"
+                        },
+                        "geo_polygon": {
+                          "type": "object",
+                          "properties": {
+                            "exterior": {
+                              "type": "object",
+                              "properties": {
+                                "points": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    }
+                                  },
+                                  "description": "points"
+                                }
+                              },
+                              "description": "exterior"
+                            },
+                            "interiors": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "points": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "lat": {
+                                          "type": "string",
+                                          "description": "lat"
+                                        },
+                                        "lon": {
+                                          "type": "string",
+                                          "description": "lon"
+                                        }
+                                      }
+                                    },
+                                    "description": "points"
+                                  }
+                                }
+                              },
+                              "description": "interiors"
+                            }
+                          },
+                          "description": "geo_polygon"
+                        },
+                        "values_count": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "values_count"
+                        }
+                      },
+                      "description": "must"
+                    },
+                    "must_not": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string",
+                          "description": "key"
+                        },
+                        "match": {
+                          "type": "object",
+                          "properties": {
+                            "value": {
+                              "type": "string",
+                              "description": "value"
+                            }
+                          },
+                          "description": "match"
+                        },
+                        "range": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "range"
+                        },
+                        "geo_bounding_box": {
+                          "type": "object",
+                          "properties": {
+                            "bottom_right": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "bottom_right"
+                            },
+                            "top_left": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "top_left"
+                            }
+                          },
+                          "description": "geo_bounding_box"
+                        },
+                        "geo_radius": {
+                          "type": "object",
+                          "properties": {
+                            "center": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "center"
+                            },
+                            "radius": {
+                              "type": "string",
+                              "description": "radius"
+                            }
+                          },
+                          "description": "geo_radius"
+                        },
+                        "geo_polygon": {
+                          "type": "object",
+                          "properties": {
+                            "exterior": {
+                              "type": "object",
+                              "properties": {
+                                "points": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    }
+                                  },
+                                  "description": "points"
+                                }
+                              },
+                              "description": "exterior"
+                            },
+                            "interiors": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "points": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "lat": {
+                                          "type": "string",
+                                          "description": "lat"
+                                        },
+                                        "lon": {
+                                          "type": "string",
+                                          "description": "lon"
+                                        }
+                                      }
+                                    },
+                                    "description": "points"
+                                  }
+                                }
+                              },
+                              "description": "interiors"
+                            }
+                          },
+                          "description": "geo_polygon"
+                        },
+                        "values_count": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "values_count"
+                        }
+                      },
+                      "description": "must_not"
+                    }
+                  },
+                  "description": "filter"
+                },
+                "params": {
+                  "type": "object",
+                  "properties": {
+                    "hnsw_ef": {
+                      "type": "string",
+                      "description": "hnsw_ef"
+                    },
+                    "exact": {
+                      "type": "boolean",
+                      "description": "exact"
+                    },
+                    "quantization": {
+                      "type": "object",
+                      "properties": {
+                        "ignore": {
+                          "type": "boolean",
+                          "description": "ignore"
+                        },
+                        "rescore": {
+                          "type": "string",
+                          "description": "rescore"
+                        },
+                        "oversampling": {
+                          "type": "string",
+                          "description": "oversampling"
+                        }
+                      },
+                      "description": "quantization"
+                    },
+                    "indexed_only": {
+                      "type": "boolean",
+                      "description": "indexed_only"
+                    }
+                  },
+                  "description": "params"
+                },
+                "score_threshold": {
+                  "type": "string",
+                  "description": "score_threshold"
+                },
+                "with_vector": {
+                  "type": "string",
+                  "description": "with_vector"
+                },
+                "with_payload": {
+                  "type": "string",
+                  "description": "with_payload"
+                },
+                "lookup_from": {
+                  "type": "object",
+                  "properties": {
+                    "collection": {
+                      "type": "string",
+                      "description": "collection"
+                    },
+                    "vector": {
+                      "type": "string",
+                      "description": "vector"
+                    },
+                    "shard_key": {
+                      "type": "string",
+                      "description": "shard_key"
+                    }
+                  },
+                  "description": "lookup_from"
+                },
+                "group_size": {
+                  "type": "string",
+                  "description": "group_size"
+                },
+                "limit": {
+                  "type": "string",
+                  "description": "limit"
+                },
+                "with_lookup": {
+                  "type": "string",
+                  "description": "with_lookup"
+                }
+              },
+              "default": {
+                "group_by": "<string>",
+                "shard_key": "<string>",
+                "prefetch": {
+                  "prefetch": {
+                    "value": "<Circular reference to #/components/schemas/Prefetch detected>"
+                  },
+                  "query": [
+                    "<float>",
+                    "<float>"
+                  ],
+                  "using": "<string>",
+                  "filter": {
+                    "should": {
+                      "key": "<string>",
+                      "match": {
+                        "value": "<string>"
+                      },
+                      "range": {
+                        "lt": "<double>",
+                        "gt": "<double>",
+                        "gte": "<double>",
+                        "lte": "<double>"
+                      },
+                      "geo_bounding_box": {
+                        "bottom_right": {
+                          "lat": "<double>",
+                          "lon": "<double>"
+                        },
+                        "top_left": {
+                          "lat": "<double>",
+                          "lon": "<double>"
+                        }
+                      },
+                      "geo_radius": {
+                        "center": {
+                          "lat": "<double>",
+                          "lon": "<double>"
+                        },
+                        "radius": "<double>"
+                      },
+                      "geo_polygon": {
+                        "exterior": {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        },
+                        "interiors": [
+                          {
+                            "points": [
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            ]
+                          },
+                          {
+                            "points": [
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      "values_count": {
+                        "lt": "<integer>",
+                        "gt": "<integer>",
+                        "gte": "<integer>",
+                        "lte": "<integer>"
+                      }
+                    },
+                    "min_should": {
+                      "conditions": [
+                        {
+                          "key": "<string>",
+                          "match": {
+                            "value": "<string>"
+                          },
+                          "range": {
+                            "lt": "<double>",
+                            "gt": "<double>",
+                            "gte": "<double>",
+                            "lte": "<double>"
+                          },
+                          "geo_bounding_box": {
+                            "bottom_right": {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            "top_left": {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          },
+                          "geo_radius": {
+                            "center": {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            "radius": "<double>"
+                          },
+                          "geo_polygon": {
+                            "exterior": {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            },
+                            "interiors": [
+                              {
+                                "points": [
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  },
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  }
+                                ]
+                              },
+                              {
+                                "points": [
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  },
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          "values_count": {
+                            "lt": "<integer>",
+                            "gt": "<integer>",
+                            "gte": "<integer>",
+                            "lte": "<integer>"
+                          }
+                        },
+                        {
+                          "key": "<string>",
+                          "match": {
+                            "value": "<string>"
+                          },
+                          "range": {
+                            "lt": "<double>",
+                            "gt": "<double>",
+                            "gte": "<double>",
+                            "lte": "<double>"
+                          },
+                          "geo_bounding_box": {
+                            "bottom_right": {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            "top_left": {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          },
+                          "geo_radius": {
+                            "center": {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            "radius": "<double>"
+                          },
+                          "geo_polygon": {
+                            "exterior": {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            },
+                            "interiors": [
+                              {
+                                "points": [
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  },
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  }
+                                ]
+                              },
+                              {
+                                "points": [
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  },
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          "values_count": {
+                            "lt": "<integer>",
+                            "gt": "<integer>",
+                            "gte": "<integer>",
+                            "lte": "<integer>"
+                          }
+                        }
+                      ],
+                      "min_count": "<integer>"
+                    },
+                    "must": {
+                      "key": "<string>",
+                      "match": {
+                        "value": "<string>"
+                      },
+                      "range": {
+                        "lt": "<double>",
+                        "gt": "<double>",
+                        "gte": "<double>",
+                        "lte": "<double>"
+                      },
+                      "geo_bounding_box": {
+                        "bottom_right": {
+                          "lat": "<double>",
+                          "lon": "<double>"
+                        },
+                        "top_left": {
+                          "lat": "<double>",
+                          "lon": "<double>"
+                        }
+                      },
+                      "geo_radius": {
+                        "center": {
+                          "lat": "<double>",
+                          "lon": "<double>"
+                        },
+                        "radius": "<double>"
+                      },
+                      "geo_polygon": {
+                        "exterior": {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        },
+                        "interiors": [
+                          {
+                            "points": [
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            ]
+                          },
+                          {
+                            "points": [
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      "values_count": {
+                        "lt": "<integer>",
+                        "gt": "<integer>",
+                        "gte": "<integer>",
+                        "lte": "<integer>"
+                      }
+                    },
+                    "must_not": {
+                      "key": "<string>",
+                      "match": {
+                        "value": "<string>"
+                      },
+                      "range": {
+                        "lt": "<double>",
+                        "gt": "<double>",
+                        "gte": "<double>",
+                        "lte": "<double>"
+                      },
+                      "geo_bounding_box": {
+                        "bottom_right": {
+                          "lat": "<double>",
+                          "lon": "<double>"
+                        },
+                        "top_left": {
+                          "lat": "<double>",
+                          "lon": "<double>"
+                        }
+                      },
+                      "geo_radius": {
+                        "center": {
+                          "lat": "<double>",
+                          "lon": "<double>"
+                        },
+                        "radius": "<double>"
+                      },
+                      "geo_polygon": {
+                        "exterior": {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        },
+                        "interiors": [
+                          {
+                            "points": [
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            ]
+                          },
+                          {
+                            "points": [
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      "values_count": {
+                        "lt": "<integer>",
+                        "gt": "<integer>",
+                        "gte": "<integer>",
+                        "lte": "<integer>"
+                      }
+                    }
+                  },
+                  "params": {
+                    "hnsw_ef": "<integer>",
+                    "exact": false,
+                    "quantization": {
+                      "ignore": false,
+                      "rescore": null,
+                      "oversampling": null
+                    },
+                    "indexed_only": false
+                  },
+                  "score_threshold": "<float>",
+                  "limit": "<integer>",
+                  "lookup_from": {
+                    "collection": "<string>",
+                    "vector": null,
+                    "shard_key": "<string>"
+                  }
+                },
+                "query": [
+                  "<float>",
+                  "<float>"
+                ],
+                "using": "<string>",
+                "filter": {
+                  "should": {
+                    "key": "<string>",
+                    "match": {
+                      "value": "<string>"
+                    },
+                    "range": {
+                      "lt": "<double>",
+                      "gt": "<double>",
+                      "gte": "<double>",
+                      "lte": "<double>"
+                    },
+                    "geo_bounding_box": {
+                      "bottom_right": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "top_left": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      }
+                    },
+                    "geo_radius": {
+                      "center": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "radius": "<double>"
+                    },
+                    "geo_polygon": {
+                      "exterior": {
+                        "points": [
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        ]
+                      },
+                      "interiors": [
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        },
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "values_count": {
+                      "lt": "<integer>",
+                      "gt": "<integer>",
+                      "gte": "<integer>",
+                      "lte": "<integer>"
+                    }
+                  },
+                  "min_should": {
+                    "conditions": [
+                      {
+                        "key": "<string>",
+                        "match": {
+                          "value": "<string>"
+                        },
+                        "range": {
+                          "lt": "<double>",
+                          "gt": "<double>",
+                          "gte": "<double>",
+                          "lte": "<double>"
+                        },
+                        "geo_bounding_box": {
+                          "bottom_right": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "top_left": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        },
+                        "geo_radius": {
+                          "center": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "radius": "<double>"
+                        },
+                        "geo_polygon": {
+                          "exterior": {
+                            "points": [
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            ]
+                          },
+                          "interiors": [
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            },
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "values_count": {
+                          "lt": "<integer>",
+                          "gt": "<integer>",
+                          "gte": "<integer>",
+                          "lte": "<integer>"
+                        }
+                      },
+                      {
+                        "key": "<string>",
+                        "match": {
+                          "value": "<string>"
+                        },
+                        "range": {
+                          "lt": "<double>",
+                          "gt": "<double>",
+                          "gte": "<double>",
+                          "lte": "<double>"
+                        },
+                        "geo_bounding_box": {
+                          "bottom_right": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "top_left": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        },
+                        "geo_radius": {
+                          "center": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "radius": "<double>"
+                        },
+                        "geo_polygon": {
+                          "exterior": {
+                            "points": [
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            ]
+                          },
+                          "interiors": [
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            },
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "values_count": {
+                          "lt": "<integer>",
+                          "gt": "<integer>",
+                          "gte": "<integer>",
+                          "lte": "<integer>"
+                        }
+                      }
+                    ],
+                    "min_count": "<integer>"
+                  },
+                  "must": {
+                    "key": "<string>",
+                    "match": {
+                      "value": "<string>"
+                    },
+                    "range": {
+                      "lt": "<double>",
+                      "gt": "<double>",
+                      "gte": "<double>",
+                      "lte": "<double>"
+                    },
+                    "geo_bounding_box": {
+                      "bottom_right": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "top_left": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      }
+                    },
+                    "geo_radius": {
+                      "center": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "radius": "<double>"
+                    },
+                    "geo_polygon": {
+                      "exterior": {
+                        "points": [
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        ]
+                      },
+                      "interiors": [
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        },
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "values_count": {
+                      "lt": "<integer>",
+                      "gt": "<integer>",
+                      "gte": "<integer>",
+                      "lte": "<integer>"
+                    }
+                  },
+                  "must_not": {
+                    "key": "<string>",
+                    "match": {
+                      "value": "<string>"
+                    },
+                    "range": {
+                      "lt": "<double>",
+                      "gt": "<double>",
+                      "gte": "<double>",
+                      "lte": "<double>"
+                    },
+                    "geo_bounding_box": {
+                      "bottom_right": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "top_left": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      }
+                    },
+                    "geo_radius": {
+                      "center": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "radius": "<double>"
+                    },
+                    "geo_polygon": {
+                      "exterior": {
+                        "points": [
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        ]
+                      },
+                      "interiors": [
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        },
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "values_count": {
+                      "lt": "<integer>",
+                      "gt": "<integer>",
+                      "gte": "<integer>",
+                      "lte": "<integer>"
+                    }
+                  }
+                },
+                "params": {
+                  "hnsw_ef": "<integer>",
+                  "exact": false,
+                  "quantization": {
+                    "ignore": false,
+                    "rescore": null,
+                    "oversampling": null
+                  },
+                  "indexed_only": false
+                },
+                "score_threshold": "<float>",
+                "with_vector": "<boolean>",
+                "with_payload": "<boolean>",
+                "lookup_from": {
+                  "collection": "<string>",
+                  "vector": null,
+                  "shard_key": "<string>"
+                },
+                "group_size": "<integer>",
+                "limit": "<integer>",
+                "with_lookup": "<string>"
+              }
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "string",
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {
+                    "groups": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "hits": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "description": "id"
+                                },
+                                "score": {
+                                  "type": "string",
+                                  "description": "score"
+                                },
+                                "version": {
+                                  "type": "string",
+                                  "description": "version"
+                                },
+                                "payload": {
+                                  "type": "object",
+                                  "properties": {
+                                    "enim_d8": {
+                                      "type": "number",
+                                      "format": "float",
+                                      "description": "enim_d8"
+                                    },
+                                    "labore___": {
+                                      "type": "string",
+                                      "description": "labore___"
+                                    },
+                                    "irurec": {
+                                      "type": "integer",
+                                      "format": "int32",
+                                      "description": "irurec"
+                                    },
+                                    "sit_975": {
+                                      "type": "integer",
+                                      "format": "int32",
+                                      "description": "sit_975"
+                                    },
+                                    "ut_17": {
+                                      "type": "boolean",
+                                      "description": "ut_17"
+                                    },
+                                    "dolore44b": {
+                                      "type": "string",
+                                      "description": "dolore44b"
+                                    },
+                                    "laboris_7d": {
+                                      "type": "string",
+                                      "description": "laboris_7d"
+                                    }
+                                  },
+                                  "description": "payload"
+                                },
+                                "vector": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "description": "vector"
+                                },
+                                "shard_key": {
+                                  "type": "string",
+                                  "description": "shard_key"
+                                },
+                                "order_value": {
+                                  "type": "string",
+                                  "description": "order_value"
+                                }
+                              }
+                            },
+                            "description": "hits"
+                          },
+                          "id": {
+                            "type": "string",
+                            "description": "id"
+                          },
+                          "lookup": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "description": "id"
+                              },
+                              "payload": {
+                                "type": "object",
+                                "properties": {
+                                  "consectetur86": {
+                                    "type": "integer",
+                                    "format": "int32",
+                                    "description": "consectetur86"
+                                  },
+                                  "dolore_03": {
+                                    "type": "number",
+                                    "format": "float",
+                                    "description": "dolore_03"
+                                  },
+                                  "consequat2e": {
+                                    "type": "integer",
+                                    "format": "int32",
+                                    "description": "consequat2e"
+                                  }
+                                },
+                                "description": "payload"
+                              },
+                              "vector": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "description": "vector"
+                              },
+                              "shard_key": {
+                                "type": "string",
+                                "description": "shard_key"
+                              },
+                              "order_value": {
+                                "type": "string",
+                                "description": "order_value"
+                              }
+                            },
+                            "description": "lookup"
+                          }
+                        }
+                      },
+                      "description": "groups"
+                    }
+                  },
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "500",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/collections/{collection_name}/points/query": {
+      "post": {
+        "summary": "Query points",
+        "description": "Universally query points. This endpoint covers all capabilities of search, recommend, discover, filters. But also enables hybrid and multi-stage queries.",
+        "operationId": "QueryPoints",
+        "parameters": [
+          {
+            "name": "consistency",
+            "default": "<integer>",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "Consistency",
+            "x-ms-summary": "Consistency"
+          },
+          {
+            "name": "timeout",
+            "default": "<integer>",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "Timeout",
+            "x-ms-summary": "Timeout"
+          },
+          {
+            "name": "collection_name",
+            "default": "<string>",
+            "in": "path",
+            "x-ms-url-encoding": "single",
+            "type": "string",
+            "required": true,
+            "description": "Collection Name",
+            "x-ms-summary": "Collection Name"
+          },
+          {
+            "name": "Content-Type",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Content-Type",
+            "x-ms-summary": "Content-Type"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Accept",
+            "x-ms-summary": "Accept"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "shard_key": {
+                  "type": "string",
+                  "description": "shard_key"
+                },
+                "prefetch": {
+                  "type": "object",
+                  "properties": {
+                    "prefetch": {
+                      "type": "object",
+                      "properties": {
+                        "value": {
+                          "type": "string",
+                          "description": "value"
+                        }
+                      },
+                      "description": "prefetch"
+                    },
+                    "query": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "query"
+                    },
+                    "using": {
+                      "type": "string",
+                      "description": "using"
+                    },
+                    "filter": {
+                      "type": "object",
+                      "properties": {
+                        "should": {
+                          "type": "object",
+                          "properties": {
+                            "key": {
+                              "type": "string",
+                              "description": "key"
+                            },
+                            "match": {
+                              "type": "object",
+                              "properties": {
+                                "value": {
+                                  "type": "string",
+                                  "description": "value"
+                                }
+                              },
+                              "description": "match"
+                            },
+                            "range": {
+                              "type": "object",
+                              "properties": {
+                                "lt": {
+                                  "type": "string",
+                                  "description": "lt"
+                                },
+                                "gt": {
+                                  "type": "string",
+                                  "description": "gt"
+                                },
+                                "gte": {
+                                  "type": "string",
+                                  "description": "gte"
+                                },
+                                "lte": {
+                                  "type": "string",
+                                  "description": "lte"
+                                }
+                              },
+                              "description": "range"
+                            },
+                            "geo_bounding_box": {
+                              "type": "object",
+                              "properties": {
+                                "bottom_right": {
+                                  "type": "object",
+                                  "properties": {
+                                    "lat": {
+                                      "type": "string",
+                                      "description": "lat"
+                                    },
+                                    "lon": {
+                                      "type": "string",
+                                      "description": "lon"
+                                    }
+                                  },
+                                  "description": "bottom_right"
+                                },
+                                "top_left": {
+                                  "type": "object",
+                                  "properties": {
+                                    "lat": {
+                                      "type": "string",
+                                      "description": "lat"
+                                    },
+                                    "lon": {
+                                      "type": "string",
+                                      "description": "lon"
+                                    }
+                                  },
+                                  "description": "top_left"
+                                }
+                              },
+                              "description": "geo_bounding_box"
+                            },
+                            "geo_radius": {
+                              "type": "object",
+                              "properties": {
+                                "center": {
+                                  "type": "object",
+                                  "properties": {
+                                    "lat": {
+                                      "type": "string",
+                                      "description": "lat"
+                                    },
+                                    "lon": {
+                                      "type": "string",
+                                      "description": "lon"
+                                    }
+                                  },
+                                  "description": "center"
+                                },
+                                "radius": {
+                                  "type": "string",
+                                  "description": "radius"
+                                }
+                              },
+                              "description": "geo_radius"
+                            },
+                            "geo_polygon": {
+                              "type": "object",
+                              "properties": {
+                                "exterior": {
+                                  "type": "object",
+                                  "properties": {
+                                    "points": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "lat": {
+                                            "type": "string",
+                                            "description": "lat"
+                                          },
+                                          "lon": {
+                                            "type": "string",
+                                            "description": "lon"
+                                          }
+                                        }
+                                      },
+                                      "description": "points"
+                                    }
+                                  },
+                                  "description": "exterior"
+                                },
+                                "interiors": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "points": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "lat": {
+                                              "type": "string",
+                                              "description": "lat"
+                                            },
+                                            "lon": {
+                                              "type": "string",
+                                              "description": "lon"
+                                            }
+                                          }
+                                        },
+                                        "description": "points"
+                                      }
+                                    }
+                                  },
+                                  "description": "interiors"
+                                }
+                              },
+                              "description": "geo_polygon"
+                            },
+                            "values_count": {
+                              "type": "object",
+                              "properties": {
+                                "lt": {
+                                  "type": "string",
+                                  "description": "lt"
+                                },
+                                "gt": {
+                                  "type": "string",
+                                  "description": "gt"
+                                },
+                                "gte": {
+                                  "type": "string",
+                                  "description": "gte"
+                                },
+                                "lte": {
+                                  "type": "string",
+                                  "description": "lte"
+                                }
+                              },
+                              "description": "values_count"
+                            }
+                          },
+                          "description": "should"
+                        },
+                        "min_should": {
+                          "type": "object",
+                          "properties": {
+                            "conditions": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "key": {
+                                    "type": "string",
+                                    "description": "key"
+                                  },
+                                  "match": {
+                                    "type": "object",
+                                    "properties": {
+                                      "value": {
+                                        "type": "string",
+                                        "description": "value"
+                                      }
+                                    },
+                                    "description": "match"
+                                  },
+                                  "range": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lt": {
+                                        "type": "string",
+                                        "description": "lt"
+                                      },
+                                      "gt": {
+                                        "type": "string",
+                                        "description": "gt"
+                                      },
+                                      "gte": {
+                                        "type": "string",
+                                        "description": "gte"
+                                      },
+                                      "lte": {
+                                        "type": "string",
+                                        "description": "lte"
+                                      }
+                                    },
+                                    "description": "range"
+                                  },
+                                  "geo_bounding_box": {
+                                    "type": "object",
+                                    "properties": {
+                                      "bottom_right": {
+                                        "type": "object",
+                                        "properties": {
+                                          "lat": {
+                                            "type": "string",
+                                            "description": "lat"
+                                          },
+                                          "lon": {
+                                            "type": "string",
+                                            "description": "lon"
+                                          }
+                                        },
+                                        "description": "bottom_right"
+                                      },
+                                      "top_left": {
+                                        "type": "object",
+                                        "properties": {
+                                          "lat": {
+                                            "type": "string",
+                                            "description": "lat"
+                                          },
+                                          "lon": {
+                                            "type": "string",
+                                            "description": "lon"
+                                          }
+                                        },
+                                        "description": "top_left"
+                                      }
+                                    },
+                                    "description": "geo_bounding_box"
+                                  },
+                                  "geo_radius": {
+                                    "type": "object",
+                                    "properties": {
+                                      "center": {
+                                        "type": "object",
+                                        "properties": {
+                                          "lat": {
+                                            "type": "string",
+                                            "description": "lat"
+                                          },
+                                          "lon": {
+                                            "type": "string",
+                                            "description": "lon"
+                                          }
+                                        },
+                                        "description": "center"
+                                      },
+                                      "radius": {
+                                        "type": "string",
+                                        "description": "radius"
+                                      }
+                                    },
+                                    "description": "geo_radius"
+                                  },
+                                  "geo_polygon": {
+                                    "type": "object",
+                                    "properties": {
+                                      "exterior": {
+                                        "type": "object",
+                                        "properties": {
+                                          "points": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "lat": {
+                                                  "type": "string",
+                                                  "description": "lat"
+                                                },
+                                                "lon": {
+                                                  "type": "string",
+                                                  "description": "lon"
+                                                }
+                                              }
+                                            },
+                                            "description": "points"
+                                          }
+                                        },
+                                        "description": "exterior"
+                                      },
+                                      "interiors": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "points": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "lat": {
+                                                    "type": "string",
+                                                    "description": "lat"
+                                                  },
+                                                  "lon": {
+                                                    "type": "string",
+                                                    "description": "lon"
+                                                  }
+                                                }
+                                              },
+                                              "description": "points"
+                                            }
+                                          }
+                                        },
+                                        "description": "interiors"
+                                      }
+                                    },
+                                    "description": "geo_polygon"
+                                  },
+                                  "values_count": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lt": {
+                                        "type": "string",
+                                        "description": "lt"
+                                      },
+                                      "gt": {
+                                        "type": "string",
+                                        "description": "gt"
+                                      },
+                                      "gte": {
+                                        "type": "string",
+                                        "description": "gte"
+                                      },
+                                      "lte": {
+                                        "type": "string",
+                                        "description": "lte"
+                                      }
+                                    },
+                                    "description": "values_count"
+                                  }
+                                }
+                              },
+                              "description": "conditions"
+                            },
+                            "min_count": {
+                              "type": "string",
+                              "description": "min_count"
+                            }
+                          },
+                          "description": "min_should"
+                        },
+                        "must": {
+                          "type": "object",
+                          "properties": {
+                            "key": {
+                              "type": "string",
+                              "description": "key"
+                            },
+                            "match": {
+                              "type": "object",
+                              "properties": {
+                                "value": {
+                                  "type": "string",
+                                  "description": "value"
+                                }
+                              },
+                              "description": "match"
+                            },
+                            "range": {
+                              "type": "object",
+                              "properties": {
+                                "lt": {
+                                  "type": "string",
+                                  "description": "lt"
+                                },
+                                "gt": {
+                                  "type": "string",
+                                  "description": "gt"
+                                },
+                                "gte": {
+                                  "type": "string",
+                                  "description": "gte"
+                                },
+                                "lte": {
+                                  "type": "string",
+                                  "description": "lte"
+                                }
+                              },
+                              "description": "range"
+                            },
+                            "geo_bounding_box": {
+                              "type": "object",
+                              "properties": {
+                                "bottom_right": {
+                                  "type": "object",
+                                  "properties": {
+                                    "lat": {
+                                      "type": "string",
+                                      "description": "lat"
+                                    },
+                                    "lon": {
+                                      "type": "string",
+                                      "description": "lon"
+                                    }
+                                  },
+                                  "description": "bottom_right"
+                                },
+                                "top_left": {
+                                  "type": "object",
+                                  "properties": {
+                                    "lat": {
+                                      "type": "string",
+                                      "description": "lat"
+                                    },
+                                    "lon": {
+                                      "type": "string",
+                                      "description": "lon"
+                                    }
+                                  },
+                                  "description": "top_left"
+                                }
+                              },
+                              "description": "geo_bounding_box"
+                            },
+                            "geo_radius": {
+                              "type": "object",
+                              "properties": {
+                                "center": {
+                                  "type": "object",
+                                  "properties": {
+                                    "lat": {
+                                      "type": "string",
+                                      "description": "lat"
+                                    },
+                                    "lon": {
+                                      "type": "string",
+                                      "description": "lon"
+                                    }
+                                  },
+                                  "description": "center"
+                                },
+                                "radius": {
+                                  "type": "string",
+                                  "description": "radius"
+                                }
+                              },
+                              "description": "geo_radius"
+                            },
+                            "geo_polygon": {
+                              "type": "object",
+                              "properties": {
+                                "exterior": {
+                                  "type": "object",
+                                  "properties": {
+                                    "points": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "lat": {
+                                            "type": "string",
+                                            "description": "lat"
+                                          },
+                                          "lon": {
+                                            "type": "string",
+                                            "description": "lon"
+                                          }
+                                        }
+                                      },
+                                      "description": "points"
+                                    }
+                                  },
+                                  "description": "exterior"
+                                },
+                                "interiors": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "points": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "lat": {
+                                              "type": "string",
+                                              "description": "lat"
+                                            },
+                                            "lon": {
+                                              "type": "string",
+                                              "description": "lon"
+                                            }
+                                          }
+                                        },
+                                        "description": "points"
+                                      }
+                                    }
+                                  },
+                                  "description": "interiors"
+                                }
+                              },
+                              "description": "geo_polygon"
+                            },
+                            "values_count": {
+                              "type": "object",
+                              "properties": {
+                                "lt": {
+                                  "type": "string",
+                                  "description": "lt"
+                                },
+                                "gt": {
+                                  "type": "string",
+                                  "description": "gt"
+                                },
+                                "gte": {
+                                  "type": "string",
+                                  "description": "gte"
+                                },
+                                "lte": {
+                                  "type": "string",
+                                  "description": "lte"
+                                }
+                              },
+                              "description": "values_count"
+                            }
+                          },
+                          "description": "must"
+                        },
+                        "must_not": {
+                          "type": "object",
+                          "properties": {
+                            "key": {
+                              "type": "string",
+                              "description": "key"
+                            },
+                            "match": {
+                              "type": "object",
+                              "properties": {
+                                "value": {
+                                  "type": "string",
+                                  "description": "value"
+                                }
+                              },
+                              "description": "match"
+                            },
+                            "range": {
+                              "type": "object",
+                              "properties": {
+                                "lt": {
+                                  "type": "string",
+                                  "description": "lt"
+                                },
+                                "gt": {
+                                  "type": "string",
+                                  "description": "gt"
+                                },
+                                "gte": {
+                                  "type": "string",
+                                  "description": "gte"
+                                },
+                                "lte": {
+                                  "type": "string",
+                                  "description": "lte"
+                                }
+                              },
+                              "description": "range"
+                            },
+                            "geo_bounding_box": {
+                              "type": "object",
+                              "properties": {
+                                "bottom_right": {
+                                  "type": "object",
+                                  "properties": {
+                                    "lat": {
+                                      "type": "string",
+                                      "description": "lat"
+                                    },
+                                    "lon": {
+                                      "type": "string",
+                                      "description": "lon"
+                                    }
+                                  },
+                                  "description": "bottom_right"
+                                },
+                                "top_left": {
+                                  "type": "object",
+                                  "properties": {
+                                    "lat": {
+                                      "type": "string",
+                                      "description": "lat"
+                                    },
+                                    "lon": {
+                                      "type": "string",
+                                      "description": "lon"
+                                    }
+                                  },
+                                  "description": "top_left"
+                                }
+                              },
+                              "description": "geo_bounding_box"
+                            },
+                            "geo_radius": {
+                              "type": "object",
+                              "properties": {
+                                "center": {
+                                  "type": "object",
+                                  "properties": {
+                                    "lat": {
+                                      "type": "string",
+                                      "description": "lat"
+                                    },
+                                    "lon": {
+                                      "type": "string",
+                                      "description": "lon"
+                                    }
+                                  },
+                                  "description": "center"
+                                },
+                                "radius": {
+                                  "type": "string",
+                                  "description": "radius"
+                                }
+                              },
+                              "description": "geo_radius"
+                            },
+                            "geo_polygon": {
+                              "type": "object",
+                              "properties": {
+                                "exterior": {
+                                  "type": "object",
+                                  "properties": {
+                                    "points": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "lat": {
+                                            "type": "string",
+                                            "description": "lat"
+                                          },
+                                          "lon": {
+                                            "type": "string",
+                                            "description": "lon"
+                                          }
+                                        }
+                                      },
+                                      "description": "points"
+                                    }
+                                  },
+                                  "description": "exterior"
+                                },
+                                "interiors": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "points": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "lat": {
+                                              "type": "string",
+                                              "description": "lat"
+                                            },
+                                            "lon": {
+                                              "type": "string",
+                                              "description": "lon"
+                                            }
+                                          }
+                                        },
+                                        "description": "points"
+                                      }
+                                    }
+                                  },
+                                  "description": "interiors"
+                                }
+                              },
+                              "description": "geo_polygon"
+                            },
+                            "values_count": {
+                              "type": "object",
+                              "properties": {
+                                "lt": {
+                                  "type": "string",
+                                  "description": "lt"
+                                },
+                                "gt": {
+                                  "type": "string",
+                                  "description": "gt"
+                                },
+                                "gte": {
+                                  "type": "string",
+                                  "description": "gte"
+                                },
+                                "lte": {
+                                  "type": "string",
+                                  "description": "lte"
+                                }
+                              },
+                              "description": "values_count"
+                            }
+                          },
+                          "description": "must_not"
+                        }
+                      },
+                      "description": "filter"
+                    },
+                    "params": {
+                      "type": "object",
+                      "properties": {
+                        "hnsw_ef": {
+                          "type": "string",
+                          "description": "hnsw_ef"
+                        },
+                        "exact": {
+                          "type": "boolean",
+                          "description": "exact"
+                        },
+                        "quantization": {
+                          "type": "object",
+                          "properties": {
+                            "ignore": {
+                              "type": "boolean",
+                              "description": "ignore"
+                            },
+                            "rescore": {
+                              "type": "string",
+                              "description": "rescore"
+                            },
+                            "oversampling": {
+                              "type": "string",
+                              "description": "oversampling"
+                            }
+                          },
+                          "description": "quantization"
+                        },
+                        "indexed_only": {
+                          "type": "boolean",
+                          "description": "indexed_only"
+                        }
+                      },
+                      "description": "params"
+                    },
+                    "score_threshold": {
+                      "type": "string",
+                      "description": "score_threshold"
+                    },
+                    "limit": {
+                      "type": "string",
+                      "description": "limit"
+                    },
+                    "lookup_from": {
+                      "type": "object",
+                      "properties": {
+                        "collection": {
+                          "type": "string",
+                          "description": "collection"
+                        },
+                        "vector": {
+                          "type": "string",
+                          "description": "vector"
+                        },
+                        "shard_key": {
+                          "type": "string",
+                          "description": "shard_key"
+                        }
+                      },
+                      "description": "lookup_from"
+                    }
+                  },
+                  "description": "prefetch"
+                },
+                "query": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "query"
+                },
+                "using": {
+                  "type": "string",
+                  "description": "using"
+                },
+                "filter": {
+                  "type": "object",
+                  "properties": {
+                    "should": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string",
+                          "description": "key"
+                        },
+                        "match": {
+                          "type": "object",
+                          "properties": {
+                            "value": {
+                              "type": "string",
+                              "description": "value"
+                            }
+                          },
+                          "description": "match"
+                        },
+                        "range": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "range"
+                        },
+                        "geo_bounding_box": {
+                          "type": "object",
+                          "properties": {
+                            "bottom_right": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "bottom_right"
+                            },
+                            "top_left": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "top_left"
+                            }
+                          },
+                          "description": "geo_bounding_box"
+                        },
+                        "geo_radius": {
+                          "type": "object",
+                          "properties": {
+                            "center": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "center"
+                            },
+                            "radius": {
+                              "type": "string",
+                              "description": "radius"
+                            }
+                          },
+                          "description": "geo_radius"
+                        },
+                        "geo_polygon": {
+                          "type": "object",
+                          "properties": {
+                            "exterior": {
+                              "type": "object",
+                              "properties": {
+                                "points": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    }
+                                  },
+                                  "description": "points"
+                                }
+                              },
+                              "description": "exterior"
+                            },
+                            "interiors": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "points": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "lat": {
+                                          "type": "string",
+                                          "description": "lat"
+                                        },
+                                        "lon": {
+                                          "type": "string",
+                                          "description": "lon"
+                                        }
+                                      }
+                                    },
+                                    "description": "points"
+                                  }
+                                }
+                              },
+                              "description": "interiors"
+                            }
+                          },
+                          "description": "geo_polygon"
+                        },
+                        "values_count": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "values_count"
+                        }
+                      },
+                      "description": "should"
+                    },
+                    "min_should": {
+                      "type": "object",
+                      "properties": {
+                        "conditions": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "key": {
+                                "type": "string",
+                                "description": "key"
+                              },
+                              "match": {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "string",
+                                    "description": "value"
+                                  }
+                                },
+                                "description": "match"
+                              },
+                              "range": {
+                                "type": "object",
+                                "properties": {
+                                  "lt": {
+                                    "type": "string",
+                                    "description": "lt"
+                                  },
+                                  "gt": {
+                                    "type": "string",
+                                    "description": "gt"
+                                  },
+                                  "gte": {
+                                    "type": "string",
+                                    "description": "gte"
+                                  },
+                                  "lte": {
+                                    "type": "string",
+                                    "description": "lte"
+                                  }
+                                },
+                                "description": "range"
+                              },
+                              "geo_bounding_box": {
+                                "type": "object",
+                                "properties": {
+                                  "bottom_right": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    },
+                                    "description": "bottom_right"
+                                  },
+                                  "top_left": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    },
+                                    "description": "top_left"
+                                  }
+                                },
+                                "description": "geo_bounding_box"
+                              },
+                              "geo_radius": {
+                                "type": "object",
+                                "properties": {
+                                  "center": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    },
+                                    "description": "center"
+                                  },
+                                  "radius": {
+                                    "type": "string",
+                                    "description": "radius"
+                                  }
+                                },
+                                "description": "geo_radius"
+                              },
+                              "geo_polygon": {
+                                "type": "object",
+                                "properties": {
+                                  "exterior": {
+                                    "type": "object",
+                                    "properties": {
+                                      "points": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "lat": {
+                                              "type": "string",
+                                              "description": "lat"
+                                            },
+                                            "lon": {
+                                              "type": "string",
+                                              "description": "lon"
+                                            }
+                                          }
+                                        },
+                                        "description": "points"
+                                      }
+                                    },
+                                    "description": "exterior"
+                                  },
+                                  "interiors": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "points": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "lat": {
+                                                "type": "string",
+                                                "description": "lat"
+                                              },
+                                              "lon": {
+                                                "type": "string",
+                                                "description": "lon"
+                                              }
+                                            }
+                                          },
+                                          "description": "points"
+                                        }
+                                      }
+                                    },
+                                    "description": "interiors"
+                                  }
+                                },
+                                "description": "geo_polygon"
+                              },
+                              "values_count": {
+                                "type": "object",
+                                "properties": {
+                                  "lt": {
+                                    "type": "string",
+                                    "description": "lt"
+                                  },
+                                  "gt": {
+                                    "type": "string",
+                                    "description": "gt"
+                                  },
+                                  "gte": {
+                                    "type": "string",
+                                    "description": "gte"
+                                  },
+                                  "lte": {
+                                    "type": "string",
+                                    "description": "lte"
+                                  }
+                                },
+                                "description": "values_count"
+                              }
+                            }
+                          },
+                          "description": "conditions"
+                        },
+                        "min_count": {
+                          "type": "string",
+                          "description": "min_count"
+                        }
+                      },
+                      "description": "min_should"
+                    },
+                    "must": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string",
+                          "description": "key"
+                        },
+                        "match": {
+                          "type": "object",
+                          "properties": {
+                            "value": {
+                              "type": "string",
+                              "description": "value"
+                            }
+                          },
+                          "description": "match"
+                        },
+                        "range": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "range"
+                        },
+                        "geo_bounding_box": {
+                          "type": "object",
+                          "properties": {
+                            "bottom_right": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "bottom_right"
+                            },
+                            "top_left": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "top_left"
+                            }
+                          },
+                          "description": "geo_bounding_box"
+                        },
+                        "geo_radius": {
+                          "type": "object",
+                          "properties": {
+                            "center": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "center"
+                            },
+                            "radius": {
+                              "type": "string",
+                              "description": "radius"
+                            }
+                          },
+                          "description": "geo_radius"
+                        },
+                        "geo_polygon": {
+                          "type": "object",
+                          "properties": {
+                            "exterior": {
+                              "type": "object",
+                              "properties": {
+                                "points": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    }
+                                  },
+                                  "description": "points"
+                                }
+                              },
+                              "description": "exterior"
+                            },
+                            "interiors": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "points": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "lat": {
+                                          "type": "string",
+                                          "description": "lat"
+                                        },
+                                        "lon": {
+                                          "type": "string",
+                                          "description": "lon"
+                                        }
+                                      }
+                                    },
+                                    "description": "points"
+                                  }
+                                }
+                              },
+                              "description": "interiors"
+                            }
+                          },
+                          "description": "geo_polygon"
+                        },
+                        "values_count": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "values_count"
+                        }
+                      },
+                      "description": "must"
+                    },
+                    "must_not": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string",
+                          "description": "key"
+                        },
+                        "match": {
+                          "type": "object",
+                          "properties": {
+                            "value": {
+                              "type": "string",
+                              "description": "value"
+                            }
+                          },
+                          "description": "match"
+                        },
+                        "range": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "range"
+                        },
+                        "geo_bounding_box": {
+                          "type": "object",
+                          "properties": {
+                            "bottom_right": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "bottom_right"
+                            },
+                            "top_left": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "top_left"
+                            }
+                          },
+                          "description": "geo_bounding_box"
+                        },
+                        "geo_radius": {
+                          "type": "object",
+                          "properties": {
+                            "center": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "string",
+                                  "description": "lat"
+                                },
+                                "lon": {
+                                  "type": "string",
+                                  "description": "lon"
+                                }
+                              },
+                              "description": "center"
+                            },
+                            "radius": {
+                              "type": "string",
+                              "description": "radius"
+                            }
+                          },
+                          "description": "geo_radius"
+                        },
+                        "geo_polygon": {
+                          "type": "object",
+                          "properties": {
+                            "exterior": {
+                              "type": "object",
+                              "properties": {
+                                "points": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "string",
+                                        "description": "lat"
+                                      },
+                                      "lon": {
+                                        "type": "string",
+                                        "description": "lon"
+                                      }
+                                    }
+                                  },
+                                  "description": "points"
+                                }
+                              },
+                              "description": "exterior"
+                            },
+                            "interiors": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "points": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "lat": {
+                                          "type": "string",
+                                          "description": "lat"
+                                        },
+                                        "lon": {
+                                          "type": "string",
+                                          "description": "lon"
+                                        }
+                                      }
+                                    },
+                                    "description": "points"
+                                  }
+                                }
+                              },
+                              "description": "interiors"
+                            }
+                          },
+                          "description": "geo_polygon"
+                        },
+                        "values_count": {
+                          "type": "object",
+                          "properties": {
+                            "lt": {
+                              "type": "string",
+                              "description": "lt"
+                            },
+                            "gt": {
+                              "type": "string",
+                              "description": "gt"
+                            },
+                            "gte": {
+                              "type": "string",
+                              "description": "gte"
+                            },
+                            "lte": {
+                              "type": "string",
+                              "description": "lte"
+                            }
+                          },
+                          "description": "values_count"
+                        }
+                      },
+                      "description": "must_not"
+                    }
+                  },
+                  "description": "filter"
+                },
+                "params": {
+                  "type": "object",
+                  "properties": {
+                    "hnsw_ef": {
+                      "type": "string",
+                      "description": "hnsw_ef"
+                    },
+                    "exact": {
+                      "type": "boolean",
+                      "description": "exact"
+                    },
+                    "quantization": {
+                      "type": "object",
+                      "properties": {
+                        "ignore": {
+                          "type": "boolean",
+                          "description": "ignore"
+                        },
+                        "rescore": {
+                          "type": "string",
+                          "description": "rescore"
+                        },
+                        "oversampling": {
+                          "type": "string",
+                          "description": "oversampling"
+                        }
+                      },
+                      "description": "quantization"
+                    },
+                    "indexed_only": {
+                      "type": "boolean",
+                      "description": "indexed_only"
+                    }
+                  },
+                  "description": "params"
+                },
+                "score_threshold": {
+                  "type": "string",
+                  "description": "score_threshold"
+                },
+                "limit": {
+                  "type": "string",
+                  "description": "limit"
+                },
+                "offset": {
+                  "type": "string",
+                  "description": "offset"
+                },
+                "with_vector": {
+                  "type": "string",
+                  "description": "with_vector"
+                },
+                "with_payload": {
+                  "type": "string",
+                  "description": "with_payload"
+                },
+                "lookup_from": {
+                  "type": "object",
+                  "properties": {
+                    "collection": {
+                      "type": "string",
+                      "description": "collection"
+                    },
+                    "vector": {
+                      "type": "string",
+                      "description": "vector"
+                    },
+                    "shard_key": {
+                      "type": "string",
+                      "description": "shard_key"
+                    }
+                  },
+                  "description": "lookup_from"
+                }
+              },
+              "default": {
+                "shard_key": "<string>",
+                "prefetch": {
+                  "prefetch": {
+                    "value": "<Circular reference to #/components/schemas/Prefetch detected>"
+                  },
+                  "query": [
+                    "<float>",
+                    "<float>"
+                  ],
+                  "using": "<string>",
+                  "filter": {
+                    "should": {
+                      "key": "<string>",
+                      "match": {
+                        "value": "<string>"
+                      },
+                      "range": {
+                        "lt": "<double>",
+                        "gt": "<double>",
+                        "gte": "<double>",
+                        "lte": "<double>"
+                      },
+                      "geo_bounding_box": {
+                        "bottom_right": {
+                          "lat": "<double>",
+                          "lon": "<double>"
+                        },
+                        "top_left": {
+                          "lat": "<double>",
+                          "lon": "<double>"
+                        }
+                      },
+                      "geo_radius": {
+                        "center": {
+                          "lat": "<double>",
+                          "lon": "<double>"
+                        },
+                        "radius": "<double>"
+                      },
+                      "geo_polygon": {
+                        "exterior": {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        },
+                        "interiors": [
+                          {
+                            "points": [
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            ]
+                          },
+                          {
+                            "points": [
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      "values_count": {
+                        "lt": "<integer>",
+                        "gt": "<integer>",
+                        "gte": "<integer>",
+                        "lte": "<integer>"
+                      }
+                    },
+                    "min_should": {
+                      "conditions": [
+                        {
+                          "key": "<string>",
+                          "match": {
+                            "value": "<string>"
+                          },
+                          "range": {
+                            "lt": "<double>",
+                            "gt": "<double>",
+                            "gte": "<double>",
+                            "lte": "<double>"
+                          },
+                          "geo_bounding_box": {
+                            "bottom_right": {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            "top_left": {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          },
+                          "geo_radius": {
+                            "center": {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            "radius": "<double>"
+                          },
+                          "geo_polygon": {
+                            "exterior": {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            },
+                            "interiors": [
+                              {
+                                "points": [
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  },
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  }
+                                ]
+                              },
+                              {
+                                "points": [
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  },
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          "values_count": {
+                            "lt": "<integer>",
+                            "gt": "<integer>",
+                            "gte": "<integer>",
+                            "lte": "<integer>"
+                          }
+                        },
+                        {
+                          "key": "<string>",
+                          "match": {
+                            "value": "<string>"
+                          },
+                          "range": {
+                            "lt": "<double>",
+                            "gt": "<double>",
+                            "gte": "<double>",
+                            "lte": "<double>"
+                          },
+                          "geo_bounding_box": {
+                            "bottom_right": {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            "top_left": {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          },
+                          "geo_radius": {
+                            "center": {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            "radius": "<double>"
+                          },
+                          "geo_polygon": {
+                            "exterior": {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            },
+                            "interiors": [
+                              {
+                                "points": [
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  },
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  }
+                                ]
+                              },
+                              {
+                                "points": [
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  },
+                                  {
+                                    "lat": "<double>",
+                                    "lon": "<double>"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          "values_count": {
+                            "lt": "<integer>",
+                            "gt": "<integer>",
+                            "gte": "<integer>",
+                            "lte": "<integer>"
+                          }
+                        }
+                      ],
+                      "min_count": "<integer>"
+                    },
+                    "must": {
+                      "key": "<string>",
+                      "match": {
+                        "value": "<string>"
+                      },
+                      "range": {
+                        "lt": "<double>",
+                        "gt": "<double>",
+                        "gte": "<double>",
+                        "lte": "<double>"
+                      },
+                      "geo_bounding_box": {
+                        "bottom_right": {
+                          "lat": "<double>",
+                          "lon": "<double>"
+                        },
+                        "top_left": {
+                          "lat": "<double>",
+                          "lon": "<double>"
+                        }
+                      },
+                      "geo_radius": {
+                        "center": {
+                          "lat": "<double>",
+                          "lon": "<double>"
+                        },
+                        "radius": "<double>"
+                      },
+                      "geo_polygon": {
+                        "exterior": {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        },
+                        "interiors": [
+                          {
+                            "points": [
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            ]
+                          },
+                          {
+                            "points": [
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      "values_count": {
+                        "lt": "<integer>",
+                        "gt": "<integer>",
+                        "gte": "<integer>",
+                        "lte": "<integer>"
+                      }
+                    },
+                    "must_not": {
+                      "key": "<string>",
+                      "match": {
+                        "value": "<string>"
+                      },
+                      "range": {
+                        "lt": "<double>",
+                        "gt": "<double>",
+                        "gte": "<double>",
+                        "lte": "<double>"
+                      },
+                      "geo_bounding_box": {
+                        "bottom_right": {
+                          "lat": "<double>",
+                          "lon": "<double>"
+                        },
+                        "top_left": {
+                          "lat": "<double>",
+                          "lon": "<double>"
+                        }
+                      },
+                      "geo_radius": {
+                        "center": {
+                          "lat": "<double>",
+                          "lon": "<double>"
+                        },
+                        "radius": "<double>"
+                      },
+                      "geo_polygon": {
+                        "exterior": {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        },
+                        "interiors": [
+                          {
+                            "points": [
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            ]
+                          },
+                          {
+                            "points": [
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      "values_count": {
+                        "lt": "<integer>",
+                        "gt": "<integer>",
+                        "gte": "<integer>",
+                        "lte": "<integer>"
+                      }
+                    }
+                  },
+                  "params": {
+                    "hnsw_ef": "<integer>",
+                    "exact": false,
+                    "quantization": {
+                      "ignore": false,
+                      "rescore": null,
+                      "oversampling": null
+                    },
+                    "indexed_only": false
+                  },
+                  "score_threshold": "<float>",
+                  "limit": "<integer>",
+                  "lookup_from": {
+                    "collection": "<string>",
+                    "vector": null,
+                    "shard_key": "<string>"
+                  }
+                },
+                "query": [
+                  "<float>",
+                  "<float>"
+                ],
+                "using": "<string>",
+                "filter": {
+                  "should": {
+                    "key": "<string>",
+                    "match": {
+                      "value": "<string>"
+                    },
+                    "range": {
+                      "lt": "<double>",
+                      "gt": "<double>",
+                      "gte": "<double>",
+                      "lte": "<double>"
+                    },
+                    "geo_bounding_box": {
+                      "bottom_right": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "top_left": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      }
+                    },
+                    "geo_radius": {
+                      "center": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "radius": "<double>"
+                    },
+                    "geo_polygon": {
+                      "exterior": {
+                        "points": [
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        ]
+                      },
+                      "interiors": [
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        },
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "values_count": {
+                      "lt": "<integer>",
+                      "gt": "<integer>",
+                      "gte": "<integer>",
+                      "lte": "<integer>"
+                    }
+                  },
+                  "min_should": {
+                    "conditions": [
+                      {
+                        "key": "<string>",
+                        "match": {
+                          "value": "<string>"
+                        },
+                        "range": {
+                          "lt": "<double>",
+                          "gt": "<double>",
+                          "gte": "<double>",
+                          "lte": "<double>"
+                        },
+                        "geo_bounding_box": {
+                          "bottom_right": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "top_left": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        },
+                        "geo_radius": {
+                          "center": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "radius": "<double>"
+                        },
+                        "geo_polygon": {
+                          "exterior": {
+                            "points": [
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            ]
+                          },
+                          "interiors": [
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            },
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "values_count": {
+                          "lt": "<integer>",
+                          "gt": "<integer>",
+                          "gte": "<integer>",
+                          "lte": "<integer>"
+                        }
+                      },
+                      {
+                        "key": "<string>",
+                        "match": {
+                          "value": "<string>"
+                        },
+                        "range": {
+                          "lt": "<double>",
+                          "gt": "<double>",
+                          "gte": "<double>",
+                          "lte": "<double>"
+                        },
+                        "geo_bounding_box": {
+                          "bottom_right": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "top_left": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        },
+                        "geo_radius": {
+                          "center": {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          "radius": "<double>"
+                        },
+                        "geo_polygon": {
+                          "exterior": {
+                            "points": [
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              },
+                              {
+                                "lat": "<double>",
+                                "lon": "<double>"
+                              }
+                            ]
+                          },
+                          "interiors": [
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            },
+                            {
+                              "points": [
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                },
+                                {
+                                  "lat": "<double>",
+                                  "lon": "<double>"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "values_count": {
+                          "lt": "<integer>",
+                          "gt": "<integer>",
+                          "gte": "<integer>",
+                          "lte": "<integer>"
+                        }
+                      }
+                    ],
+                    "min_count": "<integer>"
+                  },
+                  "must": {
+                    "key": "<string>",
+                    "match": {
+                      "value": "<string>"
+                    },
+                    "range": {
+                      "lt": "<double>",
+                      "gt": "<double>",
+                      "gte": "<double>",
+                      "lte": "<double>"
+                    },
+                    "geo_bounding_box": {
+                      "bottom_right": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "top_left": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      }
+                    },
+                    "geo_radius": {
+                      "center": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "radius": "<double>"
+                    },
+                    "geo_polygon": {
+                      "exterior": {
+                        "points": [
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        ]
+                      },
+                      "interiors": [
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        },
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "values_count": {
+                      "lt": "<integer>",
+                      "gt": "<integer>",
+                      "gte": "<integer>",
+                      "lte": "<integer>"
+                    }
+                  },
+                  "must_not": {
+                    "key": "<string>",
+                    "match": {
+                      "value": "<string>"
+                    },
+                    "range": {
+                      "lt": "<double>",
+                      "gt": "<double>",
+                      "gte": "<double>",
+                      "lte": "<double>"
+                    },
+                    "geo_bounding_box": {
+                      "bottom_right": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "top_left": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      }
+                    },
+                    "geo_radius": {
+                      "center": {
+                        "lat": "<double>",
+                        "lon": "<double>"
+                      },
+                      "radius": "<double>"
+                    },
+                    "geo_polygon": {
+                      "exterior": {
+                        "points": [
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          },
+                          {
+                            "lat": "<double>",
+                            "lon": "<double>"
+                          }
+                        ]
+                      },
+                      "interiors": [
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        },
+                        {
+                          "points": [
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            },
+                            {
+                              "lat": "<double>",
+                              "lon": "<double>"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "values_count": {
+                      "lt": "<integer>",
+                      "gt": "<integer>",
+                      "gte": "<integer>",
+                      "lte": "<integer>"
+                    }
+                  }
+                },
+                "params": {
+                  "hnsw_ef": "<integer>",
+                  "exact": false,
+                  "quantization": {
+                    "ignore": false,
+                    "rescore": null,
+                    "oversampling": null
+                  },
+                  "indexed_only": false
+                },
+                "score_threshold": "<float>",
+                "limit": "<integer>",
+                "offset": "<integer>",
+                "with_vector": "<boolean>",
+                "with_payload": "<boolean>",
+                "lookup_from": {
+                  "collection": "<string>",
+                  "vector": null,
+                  "shard_key": "<string>"
+                }
+              }
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "string",
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {
+                    "points": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "id"
+                          },
+                          "score": {
+                            "type": "string",
+                            "description": "score"
+                          },
+                          "version": {
+                            "type": "string",
+                            "description": "version"
+                          },
+                          "payload": {
+                            "type": "object",
+                            "properties": {
+                              "sit63c": {
+                                "type": "boolean",
+                                "description": "sit63c"
+                              },
+                              "nisi_1a": {
+                                "type": "string",
+                                "description": "nisi_1a"
+                              },
+                              "officia_096": {
+                                "type": "integer",
+                                "format": "int32",
+                                "description": "officia_096"
+                              },
+                              "officia6a": {
+                                "type": "number",
+                                "format": "float",
+                                "description": "officia6a"
+                              }
+                            },
+                            "description": "payload"
+                          },
+                          "vector": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "description": "vector"
+                          },
+                          "shard_key": {
+                            "type": "string",
+                            "description": "shard_key"
+                          },
+                          "order_value": {
+                            "type": "string",
+                            "description": "order_value"
+                          }
+                        }
+                      },
+                      "description": "points"
+                    }
+                  },
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "500",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/collections/{collection_name}/points": {
+      "post": {
+        "summary": "Get points",
+        "description": "Retrieve multiple points by specified IDs",
+        "operationId": "GetPoints",
+        "parameters": [
+          {
+            "name": "consistency",
+            "default": "<integer>",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "Consistency",
+            "x-ms-summary": "Consistency"
+          },
+          {
+            "name": "timeout",
+            "default": "<integer>",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "Timeout",
+            "x-ms-summary": "Timeout"
+          },
+          {
+            "name": "collection_name",
+            "default": "<string>",
+            "in": "path",
+            "x-ms-url-encoding": "single",
+            "type": "string",
+            "required": true,
+            "description": "Collection Name",
+            "x-ms-summary": "Collection Name"
+          },
+          {
+            "name": "Content-Type",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Content-Type",
+            "x-ms-summary": "Content-Type"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Accept",
+            "x-ms-summary": "Accept"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "ids": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "ids"
+                },
+                "shard_key": {
+                  "type": "string",
+                  "description": "shard_key"
+                },
+                "with_payload": {
+                  "type": "string",
+                  "description": "with_payload"
+                },
+                "with_vector": {
+                  "type": "string",
+                  "description": "with_vector"
+                }
+              },
+              "default": {
+                "ids": [
+                  "<integer>",
+                  "<integer>"
+                ],
+                "shard_key": "<string>",
+                "with_payload": "<boolean>",
+                "with_vector": "<boolean>"
+              }
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "string",
+                  "description": "status"
+                },
+                "result": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "description": "id"
+                      },
+                      "payload": {
+                        "type": "object",
+                        "properties": {
+                          "quis_c": {
+                            "type": "boolean",
+                            "description": "quis_c"
+                          },
+                          "nisi98": {
+                            "type": "string",
+                            "description": "nisi98"
+                          }
+                        },
+                        "description": "payload"
+                      },
+                      "vector": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "vector"
+                      },
+                      "shard_key": {
+                        "type": "string",
+                        "description": "shard_key"
+                      },
+                      "order_value": {
+                        "type": "string",
+                        "description": "order_value"
+                      }
+                    }
+                  },
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "500",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "Upsert points",
+        "description": "Perform insert + updates on points. If point with given ID already exists - it will be overwritten.",
+        "operationId": "UpsertPoints",
+        "parameters": [
+          {
+            "name": "wait",
+            "default": "<boolean>",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "Wait",
+            "x-ms-summary": "Wait"
+          },
+          {
+            "name": "ordering",
+            "default": "strong",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "Ordering",
+            "x-ms-summary": "Ordering"
+          },
+          {
+            "name": "collection_name",
+            "default": "<string>",
+            "in": "path",
+            "x-ms-url-encoding": "single",
+            "type": "string",
+            "required": true,
+            "description": "Collection Name",
+            "x-ms-summary": "Collection Name"
+          },
+          {
+            "name": "Content-Type",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Content-Type",
+            "x-ms-summary": "Content-Type"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Accept",
+            "x-ms-summary": "Accept"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "batch": {
+                  "type": "object",
+                  "properties": {
+                    "ids": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "ids"
+                    },
+                    "vectors": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "description": "vectors"
+                    },
+                    "payloads": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "proident36": {
+                            "type": "boolean",
+                            "description": "proident36"
+                          },
+                          "in17": {
+                            "type": "number",
+                            "format": "float",
+                            "description": "in17"
+                          },
+                          "ut_c7": {
+                            "type": "number",
+                            "format": "float",
+                            "description": "ut_c7"
+                          },
+                          "Excepteur_2": {
+                            "type": "string",
+                            "description": "Excepteur_2"
+                          }
+                        }
+                      },
+                      "description": "payloads"
+                    }
+                  },
+                  "description": "batch"
+                },
+                "shard_key": {
+                  "type": "string",
+                  "description": "shard_key"
+                }
+              },
+              "default": {
+                "batch": {
+                  "ids": [
+                    "<integer>",
+                    "<integer>"
+                  ],
+                  "vectors": [
+                    [
+                      "<float>",
+                      "<float>"
+                    ],
+                    [
+                      "<float>",
+                      "<float>"
+                    ]
+                  ],
+                  "payloads": [
+                    {
+                      "proident36": false,
+                      "in17": -17395309.717965394,
+                      "ut_c7": -89025423.55392824,
+                      "Excepteur_2": "Lorem"
+                    },
+                    {
+                      "in17": -17395309.717965394,
+                      "ut_c7": -89025423.55392824,
+                      "Excepteur_2": "Lorem"
+                    }
+                  ]
+                },
+                "shard_key": "<string>"
+              }
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "string",
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "description": "status"
+                    },
+                    "operation_id": {
+                      "type": "string",
+                      "description": "operation_id"
+                    }
+                  },
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "500",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/collections/{collection_name}": {
+      "get": {
+        "summary": "Collection info",
+        "description": "Get detailed information about specified existing collection",
+        "operationId": "CollectionInfo",
+        "parameters": [
+          {
+            "name": "collection_name",
+            "default": "<string>",
+            "in": "path",
+            "x-ms-url-encoding": "single",
+            "type": "string",
+            "required": true,
+            "description": "Collection Name",
+            "x-ms-summary": "Collection Name"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Accept",
+            "x-ms-summary": "Accept"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "string",
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {
+                    "config": {
+                      "type": "object",
+                      "properties": {
+                        "hnsw_config": {
+                          "type": "object",
+                          "properties": {
+                            "ef_construct": {
+                              "type": "string",
+                              "description": "ef_construct"
+                            },
+                            "full_scan_threshold": {
+                              "type": "string",
+                              "description": "full_scan_threshold"
+                            },
+                            "m": {
+                              "type": "string",
+                              "description": "m"
+                            },
+                            "max_indexing_threads": {
+                              "type": "integer",
+                              "format": "int32",
+                              "description": "max_indexing_threads"
+                            },
+                            "on_disk": {
+                              "type": "string",
+                              "description": "on_disk"
+                            },
+                            "payload_m": {
+                              "type": "string",
+                              "description": "payload_m"
+                            }
+                          },
+                          "description": "hnsw_config"
+                        },
+                        "optimizer_config": {
+                          "type": "object",
+                          "properties": {
+                            "default_segment_number": {
+                              "type": "string",
+                              "description": "default_segment_number"
+                            },
+                            "deleted_threshold": {
+                              "type": "string",
+                              "description": "deleted_threshold"
+                            },
+                            "flush_interval_sec": {
+                              "type": "string",
+                              "description": "flush_interval_sec"
+                            },
+                            "vacuum_min_vector_number": {
+                              "type": "string",
+                              "description": "vacuum_min_vector_number"
+                            },
+                            "max_segment_size": {
+                              "type": "string",
+                              "description": "max_segment_size"
+                            },
+                            "memmap_threshold": {
+                              "type": "string",
+                              "description": "memmap_threshold"
+                            },
+                            "indexing_threshold": {
+                              "type": "string",
+                              "description": "indexing_threshold"
+                            },
+                            "max_optimization_threads": {
+                              "type": "string",
+                              "description": "max_optimization_threads"
+                            }
+                          },
+                          "description": "optimizer_config"
+                        },
+                        "params": {
+                          "type": "object",
+                          "properties": {
+                            "vectors": {
+                              "type": "object",
+                              "properties": {
+                                "distance": {
+                                  "type": "string",
+                                  "description": "distance"
+                                },
+                                "size": {
+                                  "type": "string",
+                                  "description": "size"
+                                },
+                                "hnsw_config": {
+                                  "type": "object",
+                                  "properties": {
+                                    "m": {
+                                      "type": "string",
+                                      "description": "m"
+                                    },
+                                    "ef_construct": {
+                                      "type": "string",
+                                      "description": "ef_construct"
+                                    },
+                                    "full_scan_threshold": {
+                                      "type": "string",
+                                      "description": "full_scan_threshold"
+                                    },
+                                    "max_indexing_threads": {
+                                      "type": "string",
+                                      "description": "max_indexing_threads"
+                                    },
+                                    "on_disk": {
+                                      "type": "string",
+                                      "description": "on_disk"
+                                    },
+                                    "payload_m": {
+                                      "type": "string",
+                                      "description": "payload_m"
+                                    }
+                                  },
+                                  "description": "hnsw_config"
+                                },
+                                "quantization_config": {
+                                  "type": "object",
+                                  "properties": {
+                                    "scalar": {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "description": "type"
+                                        },
+                                        "quantile": {
+                                          "type": "string",
+                                          "description": "quantile"
+                                        },
+                                        "always_ram": {
+                                          "type": "string",
+                                          "description": "always_ram"
+                                        }
+                                      },
+                                      "description": "scalar"
+                                    }
+                                  },
+                                  "description": "quantization_config"
+                                },
+                                "on_disk": {
+                                  "type": "string",
+                                  "description": "on_disk"
+                                },
+                                "datatype": {
+                                  "type": "string",
+                                  "description": "datatype"
+                                },
+                                "multivector_config": {
+                                  "type": "object",
+                                  "properties": {
+                                    "comparator": {
+                                      "type": "string",
+                                      "description": "comparator"
+                                    }
+                                  },
+                                  "description": "multivector_config"
+                                }
+                              },
+                              "description": "vectors"
+                            },
+                            "shard_number": {
+                              "type": "integer",
+                              "format": "int32",
+                              "description": "shard_number"
+                            },
+                            "sharding_method": {
+                              "type": "string",
+                              "description": "sharding_method"
+                            },
+                            "replication_factor": {
+                              "type": "integer",
+                              "format": "int32",
+                              "description": "replication_factor"
+                            },
+                            "write_consistency_factor": {
+                              "type": "integer",
+                              "format": "int32",
+                              "description": "write_consistency_factor"
+                            },
+                            "read_fan_out_factor": {
+                              "type": "string",
+                              "description": "read_fan_out_factor"
+                            },
+                            "on_disk_payload": {
+                              "type": "boolean",
+                              "description": "on_disk_payload"
+                            },
+                            "sparse_vectors": {
+                              "type": "object",
+                              "properties": {
+                                "id3": {
+                                  "type": "object",
+                                  "properties": {
+                                    "index": {
+                                      "type": "object",
+                                      "properties": {
+                                        "full_scan_threshold": {
+                                          "type": "string",
+                                          "description": "full_scan_threshold"
+                                        },
+                                        "on_disk": {
+                                          "type": "string",
+                                          "description": "on_disk"
+                                        },
+                                        "datatype": {
+                                          "type": "string",
+                                          "description": "datatype"
+                                        }
+                                      },
+                                      "description": "index"
+                                    },
+                                    "modifier": {
+                                      "type": "string",
+                                      "description": "modifier"
+                                    }
+                                  },
+                                  "description": "id3"
+                                }
+                              },
+                              "description": "sparse_vectors"
+                            }
+                          },
+                          "description": "params"
+                        },
+                        "wal_config": {
+                          "type": "object",
+                          "properties": {
+                            "wal_capacity_mb": {
+                              "type": "string",
+                              "description": "wal_capacity_mb"
+                            },
+                            "wal_segments_ahead": {
+                              "type": "string",
+                              "description": "wal_segments_ahead"
+                            }
+                          },
+                          "description": "wal_config"
+                        },
+                        "quantization_config": {
+                          "type": "object",
+                          "properties": {
+                            "scalar": {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "description": "type"
+                                },
+                                "quantile": {
+                                  "type": "string",
+                                  "description": "quantile"
+                                },
+                                "always_ram": {
+                                  "type": "string",
+                                  "description": "always_ram"
+                                }
+                              },
+                              "description": "scalar"
+                            }
+                          },
+                          "description": "quantization_config"
+                        }
+                      },
+                      "description": "config"
+                    },
+                    "optimizer_status": {
+                      "type": "string",
+                      "description": "optimizer_status"
+                    },
+                    "payload_schema": {
+                      "type": "object",
+                      "properties": {
+                        "dolore_580": {
+                          "type": "object",
+                          "properties": {
+                            "data_type": {
+                              "type": "string",
+                              "description": "data_type"
+                            },
+                            "points": {
+                              "type": "string",
+                              "description": "points"
+                            },
+                            "params": {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "description": "type"
+                                },
+                                "is_tenant": {
+                                  "type": "string",
+                                  "description": "is_tenant"
+                                },
+                                "on_disk": {
+                                  "type": "string",
+                                  "description": "on_disk"
+                                }
+                              },
+                              "description": "params"
+                            }
+                          },
+                          "description": "dolore_580"
+                        }
+                      },
+                      "description": "payload_schema"
+                    },
+                    "segments_count": {
+                      "type": "string",
+                      "description": "segments_count"
+                    },
+                    "status": {
+                      "type": "string",
+                      "description": "status"
+                    },
+                    "vectors_count": {
+                      "type": "string",
+                      "description": "vectors_count"
+                    },
+                    "indexed_vectors_count": {
+                      "type": "string",
+                      "description": "indexed_vectors_count"
+                    },
+                    "points_count": {
+                      "type": "string",
+                      "description": "points_count"
+                    }
+                  },
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "500",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete collection",
+        "description": "Drop collection and all associated data",
+        "operationId": "DeleteCollection",
+        "parameters": [
+          {
+            "name": "timeout",
+            "default": "<integer>",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "Timeout",
+            "x-ms-summary": "Timeout"
+          },
+          {
+            "name": "collection_name",
+            "default": "<string>",
+            "in": "path",
+            "x-ms-url-encoding": "single",
+            "type": "string",
+            "required": true,
+            "description": "Collection Name",
+            "x-ms-summary": "Collection Name"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Accept",
+            "x-ms-summary": "Accept"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "string",
+                  "description": "status"
+                },
+                "result": {
+                  "type": "string",
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "500",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "Create collection",
+        "description": "Create new collection with given parameters",
+        "operationId": "CreateCollection",
+        "parameters": [
+          {
+            "name": "timeout",
+            "default": "<integer>",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "Timeout",
+            "x-ms-summary": "Timeout"
+          },
+          {
+            "name": "collection_name",
+            "default": "<string>",
+            "in": "path",
+            "x-ms-url-encoding": "single",
+            "type": "string",
+            "required": true,
+            "description": "Collection Name",
+            "x-ms-summary": "Collection Name"
+          },
+          {
+            "name": "Content-Type",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Content-Type",
+            "x-ms-summary": "Content-Type"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Accept",
+            "x-ms-summary": "Accept"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "vectors": {
+                  "type": "object",
+                  "properties": {
+                    "distance": {
+                      "type": "string",
+                      "description": "distance"
+                    },
+                    "size": {
+                      "type": "string",
+                      "description": "size"
+                    },
+                    "hnsw_config": {
+                      "type": "object",
+                      "properties": {
+                        "m": {
+                          "type": "string",
+                          "description": "m"
+                        },
+                        "ef_construct": {
+                          "type": "string",
+                          "description": "ef_construct"
+                        },
+                        "full_scan_threshold": {
+                          "type": "string",
+                          "description": "full_scan_threshold"
+                        },
+                        "max_indexing_threads": {
+                          "type": "string",
+                          "description": "max_indexing_threads"
+                        },
+                        "on_disk": {
+                          "type": "string",
+                          "description": "on_disk"
+                        },
+                        "payload_m": {
+                          "type": "string",
+                          "description": "payload_m"
+                        }
+                      },
+                      "description": "hnsw_config"
+                    },
+                    "quantization_config": {
+                      "type": "object",
+                      "properties": {
+                        "scalar": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "description": "type"
+                            },
+                            "quantile": {
+                              "type": "string",
+                              "description": "quantile"
+                            },
+                            "always_ram": {
+                              "type": "string",
+                              "description": "always_ram"
+                            }
+                          },
+                          "description": "scalar"
+                        }
+                      },
+                      "description": "quantization_config"
+                    },
+                    "on_disk": {
+                      "type": "string",
+                      "description": "on_disk"
+                    },
+                    "datatype": {
+                      "type": "string",
+                      "description": "datatype"
+                    },
+                    "multivector_config": {
+                      "type": "object",
+                      "properties": {
+                        "comparator": {
+                          "type": "string",
+                          "description": "comparator"
+                        }
+                      },
+                      "description": "multivector_config"
+                    }
+                  },
+                  "description": "vectors"
+                },
+                "shard_number": {
+                  "type": "string",
+                  "description": "shard_number"
+                },
+                "sharding_method": {
+                  "type": "string",
+                  "description": "sharding_method"
+                },
+                "replication_factor": {
+                  "type": "string",
+                  "description": "replication_factor"
+                },
+                "write_consistency_factor": {
+                  "type": "string",
+                  "description": "write_consistency_factor"
+                },
+                "on_disk_payload": {
+                  "type": "string",
+                  "description": "on_disk_payload"
+                },
+                "hnsw_config": {
+                  "type": "object",
+                  "properties": {
+                    "m": {
+                      "type": "string",
+                      "description": "m"
+                    },
+                    "ef_construct": {
+                      "type": "string",
+                      "description": "ef_construct"
+                    },
+                    "full_scan_threshold": {
+                      "type": "string",
+                      "description": "full_scan_threshold"
+                    },
+                    "max_indexing_threads": {
+                      "type": "string",
+                      "description": "max_indexing_threads"
+                    },
+                    "on_disk": {
+                      "type": "string",
+                      "description": "on_disk"
+                    },
+                    "payload_m": {
+                      "type": "string",
+                      "description": "payload_m"
+                    }
+                  },
+                  "description": "hnsw_config"
+                },
+                "wal_config": {
+                  "type": "object",
+                  "properties": {
+                    "wal_capacity_mb": {
+                      "type": "string",
+                      "description": "wal_capacity_mb"
+                    },
+                    "wal_segments_ahead": {
+                      "type": "string",
+                      "description": "wal_segments_ahead"
+                    }
+                  },
+                  "description": "wal_config"
+                },
+                "optimizers_config": {
+                  "type": "object",
+                  "properties": {
+                    "deleted_threshold": {
+                      "type": "string",
+                      "description": "deleted_threshold"
+                    },
+                    "vacuum_min_vector_number": {
+                      "type": "string",
+                      "description": "vacuum_min_vector_number"
+                    },
+                    "default_segment_number": {
+                      "type": "string",
+                      "description": "default_segment_number"
+                    },
+                    "max_segment_size": {
+                      "type": "string",
+                      "description": "max_segment_size"
+                    },
+                    "memmap_threshold": {
+                      "type": "string",
+                      "description": "memmap_threshold"
+                    },
+                    "indexing_threshold": {
+                      "type": "string",
+                      "description": "indexing_threshold"
+                    },
+                    "flush_interval_sec": {
+                      "type": "string",
+                      "description": "flush_interval_sec"
+                    },
+                    "max_optimization_threads": {
+                      "type": "string",
+                      "description": "max_optimization_threads"
+                    }
+                  },
+                  "description": "optimizers_config"
+                },
+                "init_from": {
+                  "type": "object",
+                  "properties": {
+                    "collection": {
+                      "type": "string",
+                      "description": "collection"
+                    }
+                  },
+                  "description": "init_from"
+                },
+                "quantization_config": {
+                  "type": "object",
+                  "properties": {
+                    "scalar": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "description": "type"
+                        },
+                        "quantile": {
+                          "type": "string",
+                          "description": "quantile"
+                        },
+                        "always_ram": {
+                          "type": "string",
+                          "description": "always_ram"
+                        }
+                      },
+                      "description": "scalar"
+                    }
+                  },
+                  "description": "quantization_config"
+                },
+                "sparse_vectors": {
+                  "type": "object",
+                  "properties": {
+                    "irureb": {
+                      "type": "object",
+                      "properties": {
+                        "index": {
+                          "type": "object",
+                          "properties": {
+                            "full_scan_threshold": {
+                              "type": "string",
+                              "description": "full_scan_threshold"
+                            },
+                            "on_disk": {
+                              "type": "string",
+                              "description": "on_disk"
+                            },
+                            "datatype": {
+                              "type": "string",
+                              "description": "datatype"
+                            }
+                          },
+                          "description": "index"
+                        },
+                        "modifier": {
+                          "type": "string",
+                          "description": "modifier"
+                        }
+                      },
+                      "description": "irureb"
+                    },
+                    "adipisicing4fb": {
+                      "type": "object",
+                      "properties": {
+                        "index": {
+                          "type": "object",
+                          "properties": {
+                            "full_scan_threshold": {
+                              "type": "string",
+                              "description": "full_scan_threshold"
+                            },
+                            "on_disk": {
+                              "type": "string",
+                              "description": "on_disk"
+                            },
+                            "datatype": {
+                              "type": "string",
+                              "description": "datatype"
+                            }
+                          },
+                          "description": "index"
+                        },
+                        "modifier": {
+                          "type": "string",
+                          "description": "modifier"
+                        }
+                      },
+                      "description": "adipisicing4fb"
+                    },
+                    "sed294": {
+                      "type": "object",
+                      "properties": {
+                        "index": {
+                          "type": "object",
+                          "properties": {
+                            "full_scan_threshold": {
+                              "type": "string",
+                              "description": "full_scan_threshold"
+                            },
+                            "on_disk": {
+                              "type": "string",
+                              "description": "on_disk"
+                            },
+                            "datatype": {
+                              "type": "string",
+                              "description": "datatype"
+                            }
+                          },
+                          "description": "index"
+                        },
+                        "modifier": {
+                          "type": "string",
+                          "description": "modifier"
+                        }
+                      },
+                      "description": "sed294"
+                    }
+                  },
+                  "description": "sparse_vectors"
+                }
+              },
+              "default": {
+                "vectors": {
+                  "distance": "Manhattan",
+                  "size": "<integer>",
+                  "hnsw_config": {
+                    "m": "<integer>",
+                    "ef_construct": "<integer>",
+                    "full_scan_threshold": "<integer>",
+                    "max_indexing_threads": "<integer>",
+                    "on_disk": "<boolean>",
+                    "payload_m": "<integer>"
+                  },
+                  "quantization_config": {
+                    "scalar": {
+                      "type": "int8",
+                      "quantile": "<float>",
+                      "always_ram": "<boolean>"
+                    }
+                  },
+                  "on_disk": "<boolean>",
+                  "datatype": "uint8",
+                  "multivector_config": {
+                    "comparator": "max_sim"
+                  }
+                },
+                "shard_number": null,
+                "sharding_method": "auto",
+                "replication_factor": null,
+                "write_consistency_factor": null,
+                "on_disk_payload": null,
+                "hnsw_config": {
+                  "m": "<integer>",
+                  "ef_construct": "<integer>",
+                  "full_scan_threshold": "<integer>",
+                  "max_indexing_threads": "<integer>",
+                  "on_disk": "<boolean>",
+                  "payload_m": "<integer>"
+                },
+                "wal_config": {
+                  "wal_capacity_mb": "<integer>",
+                  "wal_segments_ahead": "<integer>"
+                },
+                "optimizers_config": {
+                  "deleted_threshold": "<double>",
+                  "vacuum_min_vector_number": "<integer>",
+                  "default_segment_number": "<integer>",
+                  "max_segment_size": "<integer>",
+                  "memmap_threshold": "<integer>",
+                  "indexing_threshold": "<integer>",
+                  "flush_interval_sec": "<integer>",
+                  "max_optimization_threads": "<integer>"
+                },
+                "init_from": {
+                  "collection": "<string>"
+                },
+                "quantization_config": {
+                  "scalar": {
+                    "type": "int8",
+                    "quantile": "<float>",
+                    "always_ram": "<boolean>"
+                  }
+                },
+                "sparse_vectors": {
+                  "irureb": {
+                    "index": {
+                      "full_scan_threshold": "<integer>",
+                      "on_disk": "<boolean>",
+                      "datatype": "uint8"
+                    },
+                    "modifier": "idf"
+                  },
+                  "adipisicing4fb": {
+                    "index": {
+                      "full_scan_threshold": "<integer>",
+                      "on_disk": "<boolean>",
+                      "datatype": "float16"
+                    },
+                    "modifier": "none"
+                  },
+                  "sed294": {
+                    "index": {
+                      "full_scan_threshold": "<integer>",
+                      "on_disk": "<boolean>",
+                      "datatype": "uint8"
+                    },
+                    "modifier": "idf"
+                  }
+                }
+              }
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "string",
+                  "description": "status"
+                },
+                "result": {
+                  "type": "string",
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "500",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update collection parameters",
+        "description": "Update parameters of the existing collection",
+        "operationId": "UpdateCollectionParameters",
+        "parameters": [
+          {
+            "name": "timeout",
+            "default": "<integer>",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "Timeout",
+            "x-ms-summary": "Timeout"
+          },
+          {
+            "name": "collection_name",
+            "default": "<string>",
+            "in": "path",
+            "x-ms-url-encoding": "single",
+            "type": "string",
+            "required": true,
+            "description": "Collection Name",
+            "x-ms-summary": "Collection Name"
+          },
+          {
+            "name": "Content-Type",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Content-Type",
+            "x-ms-summary": "Content-Type"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Accept",
+            "x-ms-summary": "Accept"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "vectors": {
+                  "type": "object",
+                  "properties": {
+                    "ullamco_1_": {
+                      "type": "object",
+                      "properties": {
+                        "hnsw_config": {
+                          "type": "object",
+                          "properties": {
+                            "m": {
+                              "type": "string",
+                              "description": "m"
+                            },
+                            "ef_construct": {
+                              "type": "string",
+                              "description": "ef_construct"
+                            },
+                            "full_scan_threshold": {
+                              "type": "string",
+                              "description": "full_scan_threshold"
+                            },
+                            "max_indexing_threads": {
+                              "type": "string",
+                              "description": "max_indexing_threads"
+                            },
+                            "on_disk": {
+                              "type": "string",
+                              "description": "on_disk"
+                            },
+                            "payload_m": {
+                              "type": "string",
+                              "description": "payload_m"
+                            }
+                          },
+                          "description": "hnsw_config"
+                        },
+                        "quantization_config": {
+                          "type": "object",
+                          "properties": {
+                            "scalar": {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "description": "type"
+                                },
+                                "quantile": {
+                                  "type": "string",
+                                  "description": "quantile"
+                                },
+                                "always_ram": {
+                                  "type": "string",
+                                  "description": "always_ram"
+                                }
+                              },
+                              "description": "scalar"
+                            }
+                          },
+                          "description": "quantization_config"
+                        },
+                        "on_disk": {
+                          "type": "string",
+                          "description": "on_disk"
+                        }
+                      },
+                      "description": "ullamco_1_"
+                    },
+                    "cillum_1": {
+                      "type": "object",
+                      "properties": {
+                        "hnsw_config": {
+                          "type": "object",
+                          "properties": {
+                            "m": {
+                              "type": "string",
+                              "description": "m"
+                            },
+                            "ef_construct": {
+                              "type": "string",
+                              "description": "ef_construct"
+                            },
+                            "full_scan_threshold": {
+                              "type": "string",
+                              "description": "full_scan_threshold"
+                            },
+                            "max_indexing_threads": {
+                              "type": "string",
+                              "description": "max_indexing_threads"
+                            },
+                            "on_disk": {
+                              "type": "string",
+                              "description": "on_disk"
+                            },
+                            "payload_m": {
+                              "type": "string",
+                              "description": "payload_m"
+                            }
+                          },
+                          "description": "hnsw_config"
+                        },
+                        "quantization_config": {
+                          "type": "object",
+                          "properties": {
+                            "scalar": {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "description": "type"
+                                },
+                                "quantile": {
+                                  "type": "string",
+                                  "description": "quantile"
+                                },
+                                "always_ram": {
+                                  "type": "string",
+                                  "description": "always_ram"
+                                }
+                              },
+                              "description": "scalar"
+                            }
+                          },
+                          "description": "quantization_config"
+                        },
+                        "on_disk": {
+                          "type": "string",
+                          "description": "on_disk"
+                        }
+                      },
+                      "description": "cillum_1"
+                    },
+                    "tempor_1e9": {
+                      "type": "object",
+                      "properties": {
+                        "hnsw_config": {
+                          "type": "object",
+                          "properties": {
+                            "m": {
+                              "type": "string",
+                              "description": "m"
+                            },
+                            "ef_construct": {
+                              "type": "string",
+                              "description": "ef_construct"
+                            },
+                            "full_scan_threshold": {
+                              "type": "string",
+                              "description": "full_scan_threshold"
+                            },
+                            "max_indexing_threads": {
+                              "type": "string",
+                              "description": "max_indexing_threads"
+                            },
+                            "on_disk": {
+                              "type": "string",
+                              "description": "on_disk"
+                            },
+                            "payload_m": {
+                              "type": "string",
+                              "description": "payload_m"
+                            }
+                          },
+                          "description": "hnsw_config"
+                        },
+                        "quantization_config": {
+                          "type": "object",
+                          "properties": {
+                            "scalar": {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "description": "type"
+                                },
+                                "quantile": {
+                                  "type": "string",
+                                  "description": "quantile"
+                                },
+                                "always_ram": {
+                                  "type": "string",
+                                  "description": "always_ram"
+                                }
+                              },
+                              "description": "scalar"
+                            }
+                          },
+                          "description": "quantization_config"
+                        },
+                        "on_disk": {
+                          "type": "string",
+                          "description": "on_disk"
+                        }
+                      },
+                      "description": "tempor_1e9"
+                    },
+                    "exercitation5": {
+                      "type": "object",
+                      "properties": {
+                        "hnsw_config": {
+                          "type": "object",
+                          "properties": {
+                            "m": {
+                              "type": "string",
+                              "description": "m"
+                            },
+                            "ef_construct": {
+                              "type": "string",
+                              "description": "ef_construct"
+                            },
+                            "full_scan_threshold": {
+                              "type": "string",
+                              "description": "full_scan_threshold"
+                            },
+                            "max_indexing_threads": {
+                              "type": "string",
+                              "description": "max_indexing_threads"
+                            },
+                            "on_disk": {
+                              "type": "string",
+                              "description": "on_disk"
+                            },
+                            "payload_m": {
+                              "type": "string",
+                              "description": "payload_m"
+                            }
+                          },
+                          "description": "hnsw_config"
+                        },
+                        "quantization_config": {
+                          "type": "object",
+                          "properties": {
+                            "scalar": {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "description": "type"
+                                },
+                                "quantile": {
+                                  "type": "string",
+                                  "description": "quantile"
+                                },
+                                "always_ram": {
+                                  "type": "string",
+                                  "description": "always_ram"
+                                }
+                              },
+                              "description": "scalar"
+                            }
+                          },
+                          "description": "quantization_config"
+                        },
+                        "on_disk": {
+                          "type": "string",
+                          "description": "on_disk"
+                        }
+                      },
+                      "description": "exercitation5"
+                    }
+                  },
+                  "description": "vectors"
+                },
+                "optimizers_config": {
+                  "type": "object",
+                  "properties": {
+                    "deleted_threshold": {
+                      "type": "string",
+                      "description": "deleted_threshold"
+                    },
+                    "vacuum_min_vector_number": {
+                      "type": "string",
+                      "description": "vacuum_min_vector_number"
+                    },
+                    "default_segment_number": {
+                      "type": "string",
+                      "description": "default_segment_number"
+                    },
+                    "max_segment_size": {
+                      "type": "string",
+                      "description": "max_segment_size"
+                    },
+                    "memmap_threshold": {
+                      "type": "string",
+                      "description": "memmap_threshold"
+                    },
+                    "indexing_threshold": {
+                      "type": "string",
+                      "description": "indexing_threshold"
+                    },
+                    "flush_interval_sec": {
+                      "type": "string",
+                      "description": "flush_interval_sec"
+                    },
+                    "max_optimization_threads": {
+                      "type": "string",
+                      "description": "max_optimization_threads"
+                    }
+                  },
+                  "description": "optimizers_config"
+                },
+                "params": {
+                  "type": "object",
+                  "properties": {
+                    "replication_factor": {
+                      "type": "string",
+                      "description": "replication_factor"
+                    },
+                    "write_consistency_factor": {
+                      "type": "string",
+                      "description": "write_consistency_factor"
+                    },
+                    "read_fan_out_factor": {
+                      "type": "string",
+                      "description": "read_fan_out_factor"
+                    },
+                    "on_disk_payload": {
+                      "type": "string",
+                      "description": "on_disk_payload"
+                    }
+                  },
+                  "description": "params"
+                },
+                "hnsw_config": {
+                  "type": "object",
+                  "properties": {
+                    "m": {
+                      "type": "string",
+                      "description": "m"
+                    },
+                    "ef_construct": {
+                      "type": "string",
+                      "description": "ef_construct"
+                    },
+                    "full_scan_threshold": {
+                      "type": "string",
+                      "description": "full_scan_threshold"
+                    },
+                    "max_indexing_threads": {
+                      "type": "string",
+                      "description": "max_indexing_threads"
+                    },
+                    "on_disk": {
+                      "type": "string",
+                      "description": "on_disk"
+                    },
+                    "payload_m": {
+                      "type": "string",
+                      "description": "payload_m"
+                    }
+                  },
+                  "description": "hnsw_config"
+                },
+                "quantization_config": {
+                  "type": "object",
+                  "properties": {
+                    "scalar": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "description": "type"
+                        },
+                        "quantile": {
+                          "type": "string",
+                          "description": "quantile"
+                        },
+                        "always_ram": {
+                          "type": "string",
+                          "description": "always_ram"
+                        }
+                      },
+                      "description": "scalar"
+                    }
+                  },
+                  "description": "quantization_config"
+                },
+                "sparse_vectors": {
+                  "type": "object",
+                  "properties": {
+                    "ut__f4": {
+                      "type": "object",
+                      "properties": {
+                        "index": {
+                          "type": "object",
+                          "properties": {
+                            "full_scan_threshold": {
+                              "type": "string",
+                              "description": "full_scan_threshold"
+                            },
+                            "on_disk": {
+                              "type": "string",
+                              "description": "on_disk"
+                            },
+                            "datatype": {
+                              "type": "string",
+                              "description": "datatype"
+                            }
+                          },
+                          "description": "index"
+                        },
+                        "modifier": {
+                          "type": "string",
+                          "description": "modifier"
+                        }
+                      },
+                      "description": "ut__f4"
+                    }
+                  },
+                  "description": "sparse_vectors"
+                }
+              },
+              "default": {
+                "vectors": {
+                  "ullamco_1_": {
+                    "hnsw_config": {
+                      "m": "<integer>",
+                      "ef_construct": "<integer>",
+                      "full_scan_threshold": "<integer>",
+                      "max_indexing_threads": "<integer>",
+                      "on_disk": "<boolean>",
+                      "payload_m": "<integer>"
+                    },
+                    "quantization_config": {
+                      "scalar": {
+                        "type": "int8",
+                        "quantile": "<float>",
+                        "always_ram": "<boolean>"
+                      }
+                    },
+                    "on_disk": "<boolean>"
+                  },
+                  "cillum_1": {
+                    "hnsw_config": {
+                      "m": "<integer>",
+                      "ef_construct": "<integer>",
+                      "full_scan_threshold": "<integer>",
+                      "max_indexing_threads": "<integer>",
+                      "on_disk": "<boolean>",
+                      "payload_m": "<integer>"
+                    },
+                    "quantization_config": {
+                      "scalar": {
+                        "type": "int8",
+                        "quantile": "<float>",
+                        "always_ram": "<boolean>"
+                      }
+                    },
+                    "on_disk": "<boolean>"
+                  },
+                  "tempor_1e9": {
+                    "hnsw_config": {
+                      "m": "<integer>",
+                      "ef_construct": "<integer>",
+                      "full_scan_threshold": "<integer>",
+                      "max_indexing_threads": "<integer>",
+                      "on_disk": "<boolean>",
+                      "payload_m": "<integer>"
+                    },
+                    "quantization_config": {
+                      "scalar": {
+                        "type": "int8",
+                        "quantile": "<float>",
+                        "always_ram": "<boolean>"
+                      }
+                    },
+                    "on_disk": "<boolean>"
+                  },
+                  "exercitation5": {
+                    "hnsw_config": {
+                      "m": "<integer>",
+                      "ef_construct": "<integer>",
+                      "full_scan_threshold": "<integer>",
+                      "max_indexing_threads": "<integer>",
+                      "on_disk": "<boolean>",
+                      "payload_m": "<integer>"
+                    },
+                    "quantization_config": {
+                      "scalar": {
+                        "type": "int8",
+                        "quantile": "<float>",
+                        "always_ram": "<boolean>"
+                      }
+                    },
+                    "on_disk": "<boolean>"
+                  }
+                },
+                "optimizers_config": {
+                  "deleted_threshold": "<double>",
+                  "vacuum_min_vector_number": "<integer>",
+                  "default_segment_number": "<integer>",
+                  "max_segment_size": "<integer>",
+                  "memmap_threshold": "<integer>",
+                  "indexing_threshold": "<integer>",
+                  "flush_interval_sec": "<integer>",
+                  "max_optimization_threads": "<integer>"
+                },
+                "params": {
+                  "replication_factor": "<integer>",
+                  "write_consistency_factor": "<integer>",
+                  "read_fan_out_factor": "<integer>",
+                  "on_disk_payload": null
+                },
+                "hnsw_config": {
+                  "m": "<integer>",
+                  "ef_construct": "<integer>",
+                  "full_scan_threshold": "<integer>",
+                  "max_indexing_threads": "<integer>",
+                  "on_disk": "<boolean>",
+                  "payload_m": "<integer>"
+                },
+                "quantization_config": {
+                  "scalar": {
+                    "type": "int8",
+                    "quantile": "<float>",
+                    "always_ram": "<boolean>"
+                  }
+                },
+                "sparse_vectors": {
+                  "ut__f4": {
+                    "index": {
+                      "full_scan_threshold": "<integer>",
+                      "on_disk": "<boolean>",
+                      "datatype": "float16"
+                    },
+                    "modifier": "none"
+                  }
+                }
+              }
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "string",
+                  "description": "status"
+                },
+                "result": {
+                  "type": "string",
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "500",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/collections": {
+      "get": {
+        "summary": "List collections",
+        "description": "Get list name of all existing collections",
+        "operationId": "ListCollections",
+        "parameters": [
+          {
+            "name": "Accept",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Accept",
+            "x-ms-summary": "Accept"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "result": {
+                  "type": "object",
+                  "properties": {
+                    "collections": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "description": "name"
+                          }
+                        }
+                      },
+                      "description": "collections"
+                    }
+                  },
+                  "description": "result"
+                },
+                "status": {
+                  "type": "string",
+                  "description": "status"
+                },
+                "time": {
+                  "type": "number",
+                  "format": "float",
+                  "description": "time"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "500",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "description": "time"
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "error"
+                    }
+                  },
+                  "description": "status"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {},
+                  "description": "result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/": {
+      "get": {
+        "summary": "Returns information about the running Qdrant instance",
+        "description": "Returns information about the running Qdrant instance like version and commit id",
+        "operationId": "ReturnsInformationAboutTheRunningQdrantInstance",
+        "parameters": [
+          {
+            "name": "Accept",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "description": "Accept",
+            "x-ms-summary": "Accept"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "type": "string",
+                  "description": "title"
+                },
+                "version": {
+                  "type": "string",
+                  "description": "version"
+                },
+                "commit": {
+                  "type": "string",
+                  "description": "commit"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {},
+  "parameters": {},
+  "responses": {},
+  "securityDefinitions": {
+    "API Key": {
+      "type": "apiKey",
+      "in": "header",
+      "name": "api-key"
+    },
+    "Host": {
+      "type": "apiKey",
+      "in": "header",
+      "name": "host"
+    }
+  },
+  "security": [
+    {
+      "API Key": []
+    }
+  ],
+  "tags": [],
+  "x-ms-connector-metadata": [
+    {
+      "propertyName": "Website",
+      "propertyValue": "https://www.qdrant.tech/"
+    },
+    {
+      "propertyName": "Terms and Conditions",
+      "propertyValue": "https://qdrant.tech/legal/terms_and_conditions/"
+    },
+    {
+      "propertyName": "Privacy policy",
+      "propertyValue": "https://qdrant.tech/legal/privacy-policy/"
+    },
+    {
+      "propertyName": "Categories",
+      "propertyValue": "AI"
+    }
+  ]
+}

--- a/independent-publisher-connectors/Qdrant/apiProperties.json
+++ b/independent-publisher-connectors/Qdrant/apiProperties.json
@@ -1,0 +1,45 @@
+{
+  "properties": {
+    "connectionParameters": {
+      "api_key": {
+        "type": "securestring",
+        "uiDefinition": {
+          "displayName": "API Key",
+          "description": "The API Key for this api",
+          "tooltip": "Provide your API Key",
+          "constraints": {
+            "tabIndex": 2,
+            "clearText": false,
+            "required": "true"
+          }
+        }
+      },
+      "host": {
+        "type": "string",
+        "uiDefinition": {
+          "displayName": "Host",
+          "description": "The Hostname of the Qdrant instance.",
+          "tooltip": "Provider your hostname",
+          "constraints": {
+            "tabIndex": 2,
+            "clearText": false,
+            "required": "true"
+          }
+        }
+      }
+    },
+    "iconBrandColor": "#090E1A",
+    "capabilities": [],
+    "policyTemplateInstances": [
+      {
+        "templateId": "dynamichosturl",
+        "title": "Set host",
+        "parameters": {
+          "x-ms-apimTemplateParameter.urlTemplate": "https://@connectionParameters('host')"
+        }
+      }
+    ],
+    "publisher": "Anush",
+    "stackOwner": "Qdrant Solutions GmbH"
+  }
+}

--- a/independent-publisher-connectors/Qdrant/apiProperties.json
+++ b/independent-publisher-connectors/Qdrant/apiProperties.json
@@ -28,7 +28,7 @@
         }
       }
     },
-    "iconBrandColor": "#090E1A",
+    "iconBrandColor": "#da3b01",
     "capabilities": [],
     "policyTemplateInstances": [
       {

--- a/independent-publisher-connectors/Qdrant/readme.md
+++ b/independent-publisher-connectors/Qdrant/readme.md
@@ -1,0 +1,111 @@
+# Qdrant
+
+[Qdrant](https://qdrant.tech/) is a vector similarity search engine. It provides a production-ready service with a convenient API to store, search, and manage vectors with additional payload and extended filtering support. It makes it useful for all sorts of neural network or semantic-based matching, faceted search, and other applications.
+
+## Publisher: Anush, Qdrant
+
+## Obtaining Credentials
+
+If using Qdrant cloud, you can refer to the [Authentication Documentation](https://qdrant.tech/documentation/cloud/authentication/) to learn how to create an API key.
+
+## Supported Operations
+
+### Delete Index
+
+Delete index for a field in a collection.
+
+### Create Index
+
+Create index for a field in a collection.
+
+### Check Collection Existence
+
+Check the existence of a collection.
+
+### Delete Points
+
+Delete points.
+
+### Delete vectors
+
+Delete named vectors from the given points.
+
+### Update vectors
+
+Update specified named vectors on points, keep unspecified vectors intact.
+
+### Delete payload
+
+Delete specified key payload for points.
+
+### Clear payload
+
+Remove all payload for specified points.
+
+### Set payload
+
+Set payload values for points.
+
+### Overwrite payload
+
+Replace full payload of points with new one.
+
+### Batch update points
+
+Apply a series of update operations for points, vectors and payloads.
+
+### Scroll points
+
+Scroll request - paginate over all points which matches given filtering condition.
+
+### Count points
+
+Count points which matches given filtering condition.
+
+### Query points in batch
+
+Universally query points in batch. This endpoint covers all capabilities of search, recommend, discover, filters. But also enables hybrid and multi-stage queries.
+
+### Query points with grouping
+
+Universally query points, grouped by a given payload field.
+
+### Query points
+
+Universally query points. This endpoint covers all capabilities of search, recommend, discover, filters. But also enables hybrid and multi-stage queries.
+
+### Get points
+
+Retrieve multiple points by specified IDs.
+
+### Upsert points
+
+Perform insert + updates on points. If point with given ID already exists - it will be overwritten.
+
+### Collection info
+
+Get detailed information about specified existing collection.
+
+### Delete collection
+
+Drop collection and all associated data.
+
+### Create collection
+
+Create new collection with given parameters.
+
+### Update collection parameters
+
+Update parameters of the existing collection
+
+### List collections
+
+Get list name of all existing collections
+
+### Returns information about the running Qdrant instance
+
+Returns information about the running Qdrant instance like version and commit id
+
+## Known Issues and Limitations
+
+There are no known issues at this time.


### PR DESCRIPTION
---

Adds a connector to include support for Qdrant - https://qdrant.tech/

I've tested with the test suites and templates.

- [x] I attest that the connector doesn't exist on the Power Platform today. I've verified by checking the pull requests in GitHub and by searching for the connector on the platform or in the documentation. 
- [x] I attest that the connector works and I verified by deploying and testing all the operations. 
- [x] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [x] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [x] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [x] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.

If you are an Independent Publisher, you must also attest to the following to ensure a smooth publishing process:
- [x] I have named this PR after the pattern of "Connector Name (Independent Publisher)" ex: HubSpot Marketing (Independent Publisher)
- [x] Within this PR markdown file, I have pasted screenshots that show: 3 unique operations (actions/triggers) working within a Flow. This can be in one flow or part of multiple flows. For each one of those flows, I have pasted in screenshots of the Flow succeeding. 
- [x] Within this PR markdown file, I have pasted in a screenshot from the Test operations section within the Custom Connector UI.
- [x] If the connector uses OAuth, I have provided detailed steps on how to create an app in the readme.md. 

<img width="978" alt="Screenshot 2024-09-26 at 11 05 21 AM" src="https://github.com/user-attachments/assets/f89c5eed-b970-4573-adbc-11b15dd36a7b">
<img width="974" alt="Screenshot 2024-09-26 at 11 18 28 AM" src="https://github.com/user-attachments/assets/01e0842c-5828-406c-82ad-b38c7933f8da">

