### PR TITLE
fix(Qdrant): Collection Exists  API return type

### DIFF
--- a/independent-publisher-connectors/Qdrant/apiDefinition.swagger.json
+++ b/independent-publisher-connectors/Qdrant/apiDefinition.swagger.json
@@ -371,7 +371,7 @@
                   "type": "object",
                   "properties": {
                     "exists": {
-                      "type": "string",
+                      "type": "boolean",
                       "description": "exists"
                     }
                   },


### PR DESCRIPTION
## Description

This API endpoint returns a boolean not a string.
Ref: https://api.qdrant.tech/v-1-12-x/api-reference/collections/collection-exists#response.body.result.exists