### PR TITLE
OneBlink & CivicPlus v1.9

### DIFF
--- a/certified-connectors/CivicPlus/apiDefinition.swagger.json
+++ b/certified-connectors/CivicPlus/apiDefinition.swagger.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "version": "1.8",
+    "version": "1.9",
     "title": "CivicPlus Transform",
     "description": "Empowers business users to create and deploy digital forms for enterprise and government organizations as web and native apps, while allowing developers to customize, extend, or harness the forms through their own custom apps. Connect your forms with this connector to allow easy submission of your form data into your backend systems or databases without the need to write complex integration code.",
     "contact": {
@@ -284,6 +284,16 @@
             "required": true,
             "type": "string",
             "x-ms-summary": "Attachment Id"
+          },
+          {
+            "name": "range",
+            "in": "header",
+            "description": "The range of bytes to gather for a chunked file.",
+            "required": true,
+            "type": "string",
+            "default": "bytes=0-10000000",
+            "x-ms-visibility": "internal",
+            "x-ms-summary": "range"
           }
         ],
         "responses": {
@@ -348,6 +358,195 @@
                       "name": {
                         "type": "string"
                       }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated",
+            "schema": {
+              "$ref": "#/definitions/APIErrorPayload"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/APIErrorPayload"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "$ref": "#/definitions/APIErrorPayload"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/APIErrorPayload"
+            }
+          }
+        }
+      }
+    },
+    "/forms/{formId}/approval-steps": {
+      "get": {
+        "description": "Allows for Form approval steps to be retrieved",
+        "summary": "Retrieve Form Approval Steps",
+        "operationId": "GetFormApprovalSteps",
+        "x-ms-visibility": "internal",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "formId",
+            "type": "integer",
+            "required": true,
+            "x-ms-visibility": "important",
+            "x-ms-dynamic-values": {
+              "operationId": "GetForms",
+              "value-path": "id",
+              "value-collection": "forms",
+              "value-title": "name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "approvalSteps": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "properties": {
+                      "label": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated",
+            "schema": {
+              "$ref": "#/definitions/APIErrorPayload"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/APIErrorPayload"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "$ref": "#/definitions/APIErrorPayload"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/APIErrorPayload"
+            }
+          }
+        }
+      }
+    },
+    "/form-submission-meta/{submissionId}/approval-steps/{approvalLabel}": {
+      "get": {
+        "description": "Allows for Form Approval data for a single step to be retrieved",
+        "summary": "Retrieve Approval Record",
+        "operationId": "GetFormSubmissionApprovalByStepLabel",
+        "x-ms-visibility": "important",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "submissionId",
+            "description": "ID of the form submission",
+            "required": true,
+            "type": "string",
+            "x-ms-summary": "Submission Id",
+            "x-ms-visibility": "important"
+          },
+          {
+            "in": "query",
+            "name": "formId",
+            "type": "integer",
+            "required": true,
+            "x-ms-summary": "Form",
+            "x-ms-visibility": "important",
+            "description": "Form to select an approval step",
+            "x-ms-dynamic-values": {
+              "operationId": "GetForms",
+              "value-path": "id",
+              "value-collection": "forms",
+              "value-title": "name"
+            }
+          },
+          {
+            "in": "path",
+            "name": "approvalLabel",
+            "type": "string",
+            "required": true,
+            "x-ms-summary": "Approval Step",
+            "x-ms-visibility": "important",
+            "description": "Approval step to retrieve approval record",
+            "x-ms-dynamic-values": {
+              "operationId": "GetFormApprovalSteps",
+              "value-path": "label",
+              "value-collection": "approvalSteps",
+              "value-title": "label",
+              "parameters": {
+                "formId": {
+                  "parameter": "formId"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "formSubmissionApproval": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "updatedBy": {
+                      "type": "string",
+                      "format": "date-time",
+                      "x-ms-summary": "Approved By: Email Address"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "x-ms-summary": "Approved Timestamp"
+                    },
+                    "approvalFormId": {
+                      "type": "number",
+                      "x-ms-summary": "Approval Form Id"
+                    },
+                    "approvalFormSubmissionId": {
+                      "type": "string",
+                      "x-ms-summary": "Approval Form Submission Id"
                     }
                   }
                 }

--- a/certified-connectors/OneBlink/apiDefinition.swagger.json
+++ b/certified-connectors/OneBlink/apiDefinition.swagger.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "version": "1.8",
+    "version": "1.9",
     "title": "OneBlink",
     "description": "Empowers business users to create and deploy digital forms for enterprise and government organisations as web and native apps, while allowing developers to customise, extend, or harness the forms through their own custom apps. Connect your forms with this connector to allow easy submission of your form data into your backend systems or databases without the need to write complex integration code.",
     "contact": {
@@ -284,6 +284,16 @@
             "required": true,
             "type": "string",
             "x-ms-summary": "Attachment Id"
+          },
+          {
+            "name": "range",
+            "in": "header",
+            "description": "The range of bytes to gather for a chunked file.",
+            "required": true,
+            "type": "string",
+            "default": "bytes=0-10000000",
+            "x-ms-visibility": "internal",
+            "x-ms-summary": "range"
           }
         ],
         "responses": {
@@ -348,6 +358,195 @@
                       "name": {
                         "type": "string"
                       }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated",
+            "schema": {
+              "$ref": "#/definitions/APIErrorPayload"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/APIErrorPayload"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "$ref": "#/definitions/APIErrorPayload"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/APIErrorPayload"
+            }
+          }
+        }
+      }
+    },
+    "/forms/{formId}/approval-steps": {
+      "get": {
+        "description": "Allows for Form approval steps to be retrieved",
+        "summary": "Retrieve Form Approval Steps",
+        "operationId": "GetFormApprovalSteps",
+        "x-ms-visibility": "internal",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "formId",
+            "type": "integer",
+            "required": true,
+            "x-ms-visibility": "important",
+            "x-ms-dynamic-values": {
+              "operationId": "GetForms",
+              "value-path": "id",
+              "value-collection": "forms",
+              "value-title": "name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "approvalSteps": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "properties": {
+                      "label": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated",
+            "schema": {
+              "$ref": "#/definitions/APIErrorPayload"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/APIErrorPayload"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "$ref": "#/definitions/APIErrorPayload"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/APIErrorPayload"
+            }
+          }
+        }
+      }
+    },
+    "/form-submission-meta/{submissionId}/approval-steps/{approvalLabel}": {
+      "get": {
+        "description": "Allows for Form Approval data for a single step to be retrieved",
+        "summary": "Retrieve Approval Record",
+        "operationId": "GetFormSubmissionApprovalByStepLabel",
+        "x-ms-visibility": "important",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "submissionId",
+            "description": "ID of the form submission",
+            "required": true,
+            "type": "string",
+            "x-ms-summary": "Submission Id",
+            "x-ms-visibility": "important"
+          },
+          {
+            "in": "query",
+            "name": "formId",
+            "type": "integer",
+            "required": true,
+            "x-ms-summary": "Form",
+            "x-ms-visibility": "important",
+            "description": "Form to select an approval step",
+            "x-ms-dynamic-values": {
+              "operationId": "GetForms",
+              "value-path": "id",
+              "value-collection": "forms",
+              "value-title": "name"
+            }
+          },
+          {
+            "in": "path",
+            "name": "approvalLabel",
+            "type": "string",
+            "required": true,
+            "x-ms-summary": "Approval Step",
+            "x-ms-visibility": "important",
+            "description": "Approval step to retrieve approval record",
+            "x-ms-dynamic-values": {
+              "operationId": "GetFormApprovalSteps",
+              "value-path": "label",
+              "value-collection": "approvalSteps",
+              "value-title": "label",
+              "parameters": {
+                "formId": {
+                  "parameter": "formId"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "formSubmissionApproval": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "updatedBy": {
+                      "type": "string",
+                      "format": "date-time",
+                      "x-ms-summary": "Approved By: Email Address"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "x-ms-summary": "Approved Timestamp"
+                    },
+                    "approvalFormId": {
+                      "type": "number",
+                      "x-ms-summary": "Approval Form Id"
+                    },
+                    "approvalFormSubmissionId": {
+                      "type": "string",
+                      "x-ms-summary": "Approval Form Submission Id"
                     }
                   }
                 }


### PR DESCRIPTION
ON-45986 # Added operation to retrieve approval record


---
### When submitting a connector, please make sure that you follow the requirements below, otherwise your PR might be rejected. We want to make you have a well-built connector, a smooth certification experience, and your users are happy :) 

If this is your first time submitting to GitHub and you need some help, please sign up for this [session](https://forms.office.com/pages/responsepage.aspx?id=KtIy2vgLW0SOgZbwvQuRaXDXyCl9DkBHq4A2OG7uLpdUMTFJWFFGVUxBNUFZQjZWRUdaOE5BMFkwNS4u). 

- [x] I attest that the connector doesn't exist on the Power Platform today. I've verified by checking the pull requests in GitHub and by searching for the connector on the platform or in the documentation. 
- [x] I attest that the connector works and I verified by deploying and testing all the operations. 
- [x] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [x] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [x] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [x] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.

If you are an Independent Publisher, you must also attest to the following to ensure a smooth publishing process:
- [x] I have named this PR after the pattern of "Connector Name (Independent Publisher)" ex: HubSpot Marketing (Independent Publisher)
- [x] Within this PR markdown file, I have pasted screenshots that show: 3 unique operations (actions/triggers) working within a Flow. This can be in one flow or part of multiple flows. For each one of those flows, I have pasted in screenshots of the Flow succeeding. 
- [x] Within this PR markdown file, I have pasted in a screenshot from the Test operations section within the Custom Connector UI.
- [x] If the connector uses OAuth, I have provided detailed steps on how to create an app in the readme.md. 


