### PR TITLE
Fixed: Issue in AWS Signature v4 query parameters encoding at operation `List-S3-Object`

### DIFF
--- a/independent-publisher-connectors/AmazonS3Bucket/readme.md
+++ b/independent-publisher-connectors/AmazonS3Bucket/readme.md
@@ -46,6 +46,8 @@ This connector supports the following operations:
   * The connector now supports filenames with characters such as spaces (`folder 1/my file.csv`).
   * The connector now supports binary content such as PDF files.
     *Note: Large files might run into timeout issues.([Microsoft FAQ: Script must be finished within 5 seconds](https://learn.microsoft.com/en-us/connectors/custom-connectors/write-code#custom-code-faq))
+* List Object
+  * The connector now encodes the query parameters correctly for AWS Signature Version 4. This caused an authentication issue when parameter `prefix` was used together with special characters such as `/`.
 
 ## AWS Signature Version 4
 

--- a/independent-publisher-connectors/AmazonS3Bucket/script.csx
+++ b/independent-publisher-connectors/AmazonS3Bucket/script.csx
@@ -31,7 +31,7 @@
             var path = pathAfterAws.Split('/');
             string service    = path.Skip(0).FirstOrDefault(); // Service;
             string region     = path.Skip(1).FirstOrDefault(); // Region;
-            string objectName = path.Skip(2).FirstOrDefault(); // Object Name;
+            string bucketName = path.Skip(2).FirstOrDefault(); // Bucket Name;
             string objectKey  = path.Skip(3).FirstOrDefault(); // Object Key;
             
             // Object key can include / in the name, so we need to decode it
@@ -42,7 +42,7 @@
 
             logger.LogInformation($"Service:     {(service ?? "---")}");
             logger.LogInformation($"Region:      {(region ?? "---")}");
-            logger.LogInformation($"Object Name: {(objectName ?? "---")}");
+            logger.LogInformation($"Bucket Name: {(bucketName ?? "---")}");
             logger.LogInformation($"Object Key:  {(objectKey  ?? "---")}");
             
             var regionUrlPart = string.Empty;
@@ -55,17 +55,23 @@
             var endpointUri = string.Format("https://{2}.{0}{1}.amazonaws.com",
                                                 service,
                                                 regionUrlPart,
-                                                objectName);
+                                                bucketName);
             if (! string.IsNullOrEmpty(objectKey)) {
                 endpointUri = string.Format("{0}/{1}", endpointUri, objectKey);
-            }  
+            }
+            foreach (var character in new[]{"(", ")", "[", "]", "{", "}", "#"}) {
+                if (endpointUri.Contains(character))
+                    endpointUri = endpointUri.Replace(character, Uri.EscapeDataString(character));
+            }
             var uri = new Uri($"{endpointUri}{requestUri.Query}");
-            
+            logger.LogInformation($"Uri AbsolutePath: {uri.AbsolutePath}");
+
             var request = new System.Net.Http.HttpRequestMessage(this.Context.Request.Method, uri)
             {
-                Content = this.Context.Request.Content
+                Content = GetConvertedRequestContent()
             };
-            SignRequest(request, service, region, accessKeyId, accessKeySecret);
+
+            SignRequest(request, service, region, accessKeyId, accessKeySecret, logger);
             logger.LogInformation($"Call: {request.Method} {request.RequestUri!}");
             
             // Use the context to forward/send an HTTP request
@@ -83,6 +89,20 @@
         }
         else 
             throw new Exception("Unexpected Authentication");
+    }
+
+    private System.Net.Http.HttpContent GetConvertedRequestContent()
+    {
+        var logger = this.Context.Logger;
+        try {
+            var binary = Convert.FromBase64String(this.Context.Request.Content.ReadAsStringAsync().Result);
+            logger.LogInformation($"Base64 content converted into binary (Binary content length: {binary.Length})");
+            return new System.Net.Http.ByteArrayContent(binary);
+            
+        } catch {
+            logger.LogInformation("Content can't be converted from Base64 to binary, keep the content as it is.");
+            return this.Context.Request.Content;
+        }
     }
 
     private async Task<HttpResponseMessage> HandleTransformXML2Json(HttpResponseMessage response)
@@ -125,7 +145,8 @@
                                 string service,
                                 string region,
                                 string awsAccessKey,
-                                string awsSecretKey)            
+                                string awsSecretKey,
+                                ILogger logger = null)            
     {
         var signer = new AWS4SignerForAuthorizationHeader
             {
@@ -156,7 +177,7 @@
             headers.Add(AWS4SignerBase.X_Amz_Content_SHA256, bodyHash);                
         }
 
-        string signature = signer.ComputeSignature(headers, queryParameters, bodyHash, awsAccessKey, awsSecretKey);
+        string signature = signer.ComputeSignature(headers, queryParameters, bodyHash, awsAccessKey, awsSecretKey, logger);
         
         foreach (var header in headers.Keys)
         {
@@ -465,7 +486,8 @@
                                        string queryParameters,
                                        string bodyHash,
                                        string awsAccessKey,
-                                       string awsSecretKey)
+                                       string awsSecretKey,
+                                       ILogger logger = null)
         {
             // first get the date and time for the subsequent request, and convert to ISO 8601 format
             // for use in signature generation
@@ -502,7 +524,7 @@
                 {
                     if (sb.Length > 0)
                         sb.Append("&");
-                    sb.AppendFormat("{0}={1}", p, paramDictionary[p]);
+                    sb.AppendFormat("{0}={1}", p, Uri.EscapeDataString(HttpUtility.UrlDecode(paramDictionary[p])));
                 }
 
                 canonicalizedQueryParameters = sb.ToString();
@@ -515,6 +537,7 @@
                                                        canonicalizedHeaderNames,
                                                        canonicalizedHeaders,
                                                        bodyHash);
+            logger?.LogInformation($"Canonical Request:\n{canonicalRequest}");
             Console.WriteLine("\nCanonicalRequest:\n{0}", canonicalRequest);
 
             // generate a hash of the canonical request, to go into signature computation
@@ -534,6 +557,7 @@
             stringToSign.AppendFormat("{0}-{1}\n{2}\n{3}\n", SCHEME, ALGORITHM, dateTimeStamp, scope);
             stringToSign.Append(ToHexString(canonicalRequestHashBytes, true));
 
+            logger?.LogInformation($"String to Sign:\n{stringToSign}");
             Console.WriteLine("\nStringToSign:\n{0}", stringToSign);
 
             // compute the signing key


### PR DESCRIPTION
Fixed and issue in AWS Signature v4 query parameters encoding at operation `List-S3-Object`.

## Issue Details

Parameter `prefix` with special characters such as `/` caused an `SignatureDoesNotMatch` issue in AWS Signature v4.
The Error Message was:

```
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>SignatureDoesNotMatch</Code><Message>The request signature we calculated does not match the signature you provided. Check your key and signing method.</Message><AWSAccessKeyId>AKIAXUTJO2VJ2B6CSFXA</AWSAccessKeyId><StringToSign>AWS4-HMAC-SHA256
20250303T081339Z
20250303/eu-central-1/s3/aws4_request
56f5af14e64431afcdcd5ec7481ac047cd5ea3bce5733aee8e54ecdfbe2e5ffd</StringToSign><SignatureProvided>917d9c3ea4f350c29299f37df7ac0208420216c3bc07882cb4f53075922dbff2</SignatureProvided><StringToSignBytes>....</StringToSignBytes>
<CanonicalRequest>GET
/
bucketlist-type=2&amp;prefix=folder-with-space%2FShared-Documents
host:my-powerapps-demo-bucket.s3-eu-central-1.amazonaws.com
x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
x-amz-date:20250303T081339Z

host;x-amz-content-sha256;x-amz-date
e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855</CanonicalRequest>
...
```

## Tests:

![image](https://github.com/user-attachments/assets/dce45a23-923e-4121-be3b-ae5fbc4f05eb)

### Put S3 Object

With Text Files:
![image](https://github.com/user-attachments/assets/da4af817-69f1-4c18-88f1-9e887a8f295c)

With Binary Content:
![image](https://github.com/user-attachments/assets/2030b9e2-6188-4230-b7fc-1d1aca87c095)

### List S3 Object

![image](https://github.com/user-attachments/assets/428832f0-5bbe-491d-9423-814324d68e4c)

### Get S3 Object

![image](https://github.com/user-attachments/assets/b91e2b8f-11ba-4453-84ba-7ce4aa60211d)

---
### When submitting a connector, please make sure that you follow the requirements below, otherwise your PR might be rejected. We want to make you have a well-built connector, a smooth certification experience, and your users are happy :) 

If this is your first time submitting to GitHub and you need some help, please sign up for this [session](https://forms.office.com/pages/responsepage.aspx?id=KtIy2vgLW0SOgZbwvQuRaXDXyCl9DkBHq4A2OG7uLpdUMTFJWFFGVUxBNUFZQjZWRUdaOE5BMFkwNS4u). 

- [ ] I attest that the connector doesn't exist on the Power Platform today. I've verified by checking the pull requests in GitHub and by searching for the connector on the platform or in the documentation. 
- [x] I attest that the connector works and I verified by deploying and testing all the operations. 
- [x] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [x] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [x] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [x] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.

If you are an Independent Publisher, you must also attest to the following to ensure a smooth publishing process:
- [x] I have named this PR after the pattern of "Connector Name (Independent Publisher)" ex: HubSpot Marketing (Independent Publisher)
- [x] Within this PR markdown file, I have pasted screenshots that show: 3 unique operations (actions/triggers) working within a Flow. This can be in one flow or part of multiple flows. For each one of those flows, I have pasted in screenshots of the Flow succeeding. 
- [x] Within this PR markdown file, I have pasted in a screenshot from the Test operations section within the Custom Connector UI.
- [x] If the connector uses OAuth, I have provided detailed steps on how to create an app in the readme.md. 


