### PR TITLE
ActivityInfo Connector

### DIFF
--- a/certified-connectors/ActivityInfo/README.md
+++ b/certified-connectors/ActivityInfo/README.md
@@ -1,0 +1,56 @@
+# Title
+ActivityInfo provides a no code relational database builder for data collection and management in the social sector. 
+This connector will allow users to create automations in their ActivityInfo databases from Power Automate. 
+This will allow Power Automate users to create workflows that perform an action in Power Automate (e.g. send an email) 
+in response to an event triggered in their ActivityInfo database (e.g. when a caseworker adds a new record).
+
+## Publisher: Publisher's Name
+BeDataDriven B.V.
+
+## Prerequisites
+* A valid Microsoft Power Automate subscription.
+* A valid ActivityInfo account with access to an active database.
+* An ActivityIfo database you own or have "Manage Automations" permission granted.
+* An API token from ActivityInfo with Read and Write scope.
+
+## Supported Operations
+
+### GetForms
+Get a list of forms in an ActivityInfo database (internal action).
+
+### GetAddRecordSchema
+Get schema of event data when a record is added (internal action).
+
+### GetEditRecordSchema
+Get schema of event data when a record is edited (internal action).
+
+### GetDeleteRecordSchema
+Get schema of event data when a record is deleted (internal action).
+
+### DeleteAutomaton
+Deletes an automation (internal action).
+
+### AddRecordTrigger
+Notifications of add records events.
+
+### EditRecordTrigger
+Notifications of edit records events.
+
+### DeleteRecordTrigger
+Notifications of delete records events.
+
+## Obtaining Credentials
+This connector requires an API token from ActivityInfo. Log into [ActivityInfo](https://www.activityinfo.org) and visit your account settings to
+create a token with Read and Write scope.
+
+## Getting Started
+Log into your Power Automate account. Create a new flow and search for ActivityInfo when prompted for a trigger.
+
+## Known Issues and Limitations
+* Filters can only be specified in ActivityInfo and not in Power Automate.
+* To use a filter, you will have to [update the automation definition in ActivityInfo](https://www.activityinfo.org/support/webinars/2024-05-15-introduction-to-automations.html).
+* Any changes made to an automation created in Power Automate will not reflect in Power Automate.
+* Any edits made in Power Automate will result in loss of any edits previously made in ActivityInfo for the automation.
+
+## Deployment Instructions
+Please use [these instructions](https://docs.microsoft.com/en-us/connectors/custom-connectors/paconn-cli) to deploy this connector as a custom connector in Microsoft Power Automate.

--- a/certified-connectors/ActivityInfo/apiDefinition.swagger.json
+++ b/certified-connectors/ActivityInfo/apiDefinition.swagger.json
@@ -1,0 +1,512 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0",
+    "title": "ActivityInfo",
+    "description": "This is a connector for working with automation features in ActivityInfo, and triggering Power Automate workflows from events in your ActivityInfo database.",
+    "contact": {
+      "name": "ActivityInfo",
+      "url": "https://www.activityinfo.org",
+      "email": "info@activityinfo.org"
+    }
+  },
+  "host": "www.activityinfo.org",
+  "basePath": "/",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [],
+  "produces": [],
+  "parameters": {},
+  "responses": {},
+  "securityDefinitions": {
+    "API Key": {
+      "type": "apiKey",
+      "in": "header",
+      "name": "Authorization"
+    }
+  },
+  "security": [
+    {
+      "API Key": []
+    }
+  ],
+  "tags": [],
+  "paths": {
+    "/resources/powerautomate/v1/forms": {
+      "get": {
+        "summary": "List ActivityInfo forms",
+        "description": "Get a list of forms in an ActivityInfo database",
+        "operationId": "GetForms",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "x-ms-summary": "Form ID"
+                  },
+                  "label": {
+                    "type": "string",
+                    "x-ms-summary": "Form label"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-ms-visibility": "internal"
+      }
+    },
+    "/resources/powerautomate/v1/forms/{formId}/schemas/add": {
+      "get": {
+        "summary": "Get schema of event data when a record is added",
+        "description": "Get schema of event data when a record is added",
+        "operationId": "GetAddRecordSchema",
+        "parameters": [
+          {
+            "name": "formId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object"
+            }
+          }
+        },
+        "x-ms-visibility": "internal"
+      }
+    },
+    "/resources/powerautomate/v1/forms/{formId}/schemas/edit": {
+      "get": {
+        "summary": "Get schema of event data when a record is edited",
+        "description": "Get schema of event data when a record is edited",
+        "operationId": "GetEditRecordSchema",
+        "parameters": [
+          {
+            "name": "formId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object"
+            }
+          }
+        },
+        "x-ms-visibility": "internal"
+      }
+    },
+    "/resources/powerautomate/v1/forms/{formId}/schemas/delete": {
+      "get": {
+        "summary": "Get schema of event data when a record is deleted",
+        "description": "Get schema of event data when a record is deleted",
+        "operationId": "GetDeleteRecordSchema",
+        "parameters": [
+          {
+            "name": "formId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object"
+            }
+          }
+        },
+        "x-ms-visibility": "internal"
+      }
+    },
+    "/resources/powerautomate/v1/forms/{formId}/automation/{autoId}": {
+      "delete": {
+        "summary": "Deletes an automation",
+        "description": "Deletes an automation",
+        "operationId": "DeleteAutomaton",
+        "parameters": [
+          {
+            "name": "formId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "autoId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object"
+            }
+          }
+        },
+        "x-ms-visibility": "internal"
+      }
+    },
+    "/resources/powerautomate/v1/forms/{formId}/automation/add": {
+      "x-ms-notification-content": {
+        "summary": "Triggered when a record is added",
+        "schema": {
+          "type": "object",
+          "x-ms-dynamic-schema": {
+            "operationId": "GetAddRecordSchema",
+            "value-path": "schema",
+            "parameters": {
+              "formId": {
+                "parameter": "formId"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          }
+        },
+        "summary": "When a record is added",
+        "operationId": "AddRecordTrigger",
+        "x-ms-trigger-hint": "To see it work, add a record in ActivityInfo",
+        "x-ms-trigger": "single",
+        "parameters": [
+          {
+            "name": "formId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Form Id",
+            "x-ms-visibility": "important",
+            "x-ms-dynamic-values": {
+              "operationId": "GetForms",
+              "parameters": {},
+              "value-title": "label",
+              "value-path": "id"
+            }
+          },
+          {
+            "name": "Content-type",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "x-ms-visibility": "internal"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "x-ms-visibility": "internal"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": false,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "label": {
+                  "type": "string",
+                  "description": "label",
+                  "title": "Automation Name",
+                  "default": "Power Automate Webhook",
+                  "x-ms-visibility": "important"
+                },
+                "action": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "description": "type",
+                      "title": "Type of action",
+                      "default": "WEBHOOK",
+                      "x-ms-visibility": "internal"
+                    },
+                    "url": {
+                      "type": "string",
+                      "description": "url",
+                      "title": "URL of the webhook",
+                      "x-ms-visibility": "internal",
+                      "x-ms-notification-url": true
+                    }
+                  },
+                  "description": "action",
+                  "required": [
+                    "type",
+                    "url"
+                  ]
+                }
+              },
+              "required": [
+                "action",
+                "label"
+              ]
+            }
+          }
+        ],
+        "description": "Notifications of add records events"
+      }
+    },
+    "/resources/powerautomate/v1/forms/{formId}/automation/edit": {
+      "x-ms-notification-content": {
+        "summary": "Triggered when a record is edited",
+        "schema": {
+          "type": "object",
+          "x-ms-dynamic-schema": {
+            "operationId": "GetEditRecordSchema",
+            "value-path": "schema",
+            "parameters": {
+              "formId": {
+                "parameter": "formId"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          }
+        },
+        "summary": "When a record is edited",
+        "operationId": "EditRecordTrigger",
+        "x-ms-trigger-hint": "To see it work, edit a record in ActivityInfo",
+        "x-ms-trigger": "single",
+        "parameters": [
+          {
+            "name": "formId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Form Id",
+            "x-ms-visibility": "important",
+            "x-ms-dynamic-values": {
+              "operationId": "GetForms",
+              "parameters": {},
+              "value-title": "label",
+              "value-path": "id"
+            }
+          },
+          {
+            "name": "Content-type",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "x-ms-visibility": "internal"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "x-ms-visibility": "internal"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": false,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "label": {
+                  "type": "string",
+                  "description": "label",
+                  "title": "Automation Name",
+                  "default": "Power Automate Webhook",
+                  "x-ms-visibility": "important"
+                },
+                "action": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "description": "type",
+                      "title": "Type of action",
+                      "default": "WEBHOOK",
+                      "x-ms-visibility": "internal"
+                    },
+                    "url": {
+                      "type": "string",
+                      "description": "url",
+                      "title": "URL of the webhook",
+                      "x-ms-visibility": "internal",
+                      "x-ms-notification-url": true
+                    }
+                  },
+                  "description": "action",
+                  "required": [
+                    "type",
+                    "url"
+                  ]
+                }
+              },
+              "required": [
+                "action",
+                "label"
+              ]
+            }
+          }
+        ],
+        "description": "Notifications of edit records events"
+      }
+    },
+    "/resources/powerautomate/v1/forms/{formId}/automation/delete": {
+      "x-ms-notification-content": {
+        "summary": "Triggered when a record is deleted",
+        "schema": {
+          "type": "object",
+          "x-ms-dynamic-schema": {
+            "operationId": "GetDeleteRecordSchema",
+            "value-path": "schema",
+            "parameters": {
+              "formId": {
+                "parameter": "formId"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          }
+        },
+        "summary": "When a record is deleted",
+        "operationId": "DeleteRecordTrigger",
+        "x-ms-trigger-hint": "To see it work, delete a record in ActivityInfo",
+        "x-ms-trigger": "single",
+        "parameters": [
+          {
+            "name": "formId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Form Id",
+            "x-ms-visibility": "important",
+            "x-ms-dynamic-values": {
+              "operationId": "GetForms",
+              "parameters": {},
+              "value-title": "label",
+              "value-path": "id"
+            }
+          },
+          {
+            "name": "Content-type",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "x-ms-visibility": "internal"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "application/json",
+            "x-ms-visibility": "internal"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": false,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "label": {
+                  "type": "string",
+                  "description": "label",
+                  "title": "Automation Name",
+                  "default": "Power Automate Webhook",
+                  "x-ms-visibility": "important"
+                },
+                "action": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "description": "type",
+                      "title": "Type of action",
+                      "default": "WEBHOOK",
+                      "x-ms-visibility": "internal"
+                    },
+                    "url": {
+                      "type": "string",
+                      "description": "url",
+                      "title": "URL of the webhook",
+                      "x-ms-visibility": "internal",
+                      "x-ms-notification-url": true
+                    }
+                  },
+                  "description": "action",
+                  "required": [
+                    "type",
+                    "url"
+                  ]
+                }
+              },
+              "required": [
+                "action",
+                "label"
+              ]
+            }
+          }
+        ],
+        "description": "Notifications of delete records events"
+      }
+    }
+  },
+  "x-ms-connector-metadata": [
+    {
+      "propertyName": "Website",
+      "propertyValue": "https://www.activityinfo.org"
+    },
+    {
+      "propertyName": "Privacy policy",
+      "propertyValue": "https://www.activityinfo.org/about/privacy-policy.html"
+    },
+    {
+      "propertyName": "Categories",
+      "propertyValue": "Data;Collaboration;Productivity"
+    }
+  ]
+}

--- a/certified-connectors/ActivityInfo/apiDefinition.swagger.json
+++ b/certified-connectors/ActivityInfo/apiDefinition.swagger.json
@@ -3,7 +3,7 @@
   "info": {
     "version": "1.0",
     "title": "ActivityInfo",
-    "description": "This is a connector for working with automation features in ActivityInfo, and triggering Power Automate workflows from events in your ActivityInfo database.",
+    "description": "This is a connector for working with automation features in ActivityInfo, and triggering workflows from events in your ActivityInfo database.",
     "contact": {
       "name": "ActivityInfo",
       "url": "https://www.activityinfo.org",
@@ -72,7 +72,8 @@
             "name": "formId",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "x-ms-url-encoding": "single"
           }
         ],
         "responses": {
@@ -96,7 +97,8 @@
             "name": "formId",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "x-ms-url-encoding": "single"
           }
         ],
         "responses": {
@@ -120,7 +122,8 @@
             "name": "formId",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "x-ms-url-encoding": "single"
           }
         ],
         "responses": {
@@ -134,7 +137,7 @@
         "x-ms-visibility": "internal"
       }
     },
-    "/resources/powerautomate/v1/forms/{formId}/automation/{autoId}": {
+    "/resources/powerautomate/v1/forms/{formId}/automation/{automationId}": {
       "delete": {
         "summary": "Deletes an automation",
         "description": "Deletes an automation",
@@ -144,13 +147,15 @@
             "name": "formId",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "x-ms-url-encoding": "single"
           },
           {
-            "name": "autoId",
+            "name": "automationId",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "x-ms-url-encoding": "single"
           }
         ],
         "responses": {
@@ -191,6 +196,7 @@
           }
         },
         "summary": "When a record is added",
+        "consumes": [ "application/json" ],
         "operationId": "AddRecordTrigger",
         "x-ms-trigger-hint": "To see it work, add a record in ActivityInfo",
         "x-ms-trigger": "single",
@@ -201,7 +207,9 @@
             "required": true,
             "type": "string",
             "description": "Form Id",
+            "x-ms-summary": "Form Id",
             "x-ms-visibility": "important",
+            "x-ms-url-encoding": "single",
             "x-ms-dynamic-values": {
               "operationId": "GetForms",
               "parameters": {},
@@ -228,7 +236,7 @@
           {
             "name": "body",
             "in": "body",
-            "required": false,
+            "required": true,
             "schema": {
               "type": "object",
               "properties": {
@@ -302,6 +310,7 @@
         },
         "summary": "When a record is edited",
         "operationId": "EditRecordTrigger",
+        "consumes": [ "application/json" ],
         "x-ms-trigger-hint": "To see it work, edit a record in ActivityInfo",
         "x-ms-trigger": "single",
         "parameters": [
@@ -311,7 +320,9 @@
             "required": true,
             "type": "string",
             "description": "Form Id",
+            "x-ms-url-encoding": "single",
             "x-ms-visibility": "important",
+            "x-ms-summary": "Form Id",
             "x-ms-dynamic-values": {
               "operationId": "GetForms",
               "parameters": {},
@@ -338,7 +349,7 @@
           {
             "name": "body",
             "in": "body",
-            "required": false,
+            "required": true,
             "schema": {
               "type": "object",
               "properties": {
@@ -414,6 +425,7 @@
         "operationId": "DeleteRecordTrigger",
         "x-ms-trigger-hint": "To see it work, delete a record in ActivityInfo",
         "x-ms-trigger": "single",
+        "consumes": [ "application/json" ],
         "parameters": [
           {
             "name": "formId",
@@ -421,6 +433,8 @@
             "required": true,
             "type": "string",
             "description": "Form Id",
+            "x-ms-summary": "Form Id",
+            "x-ms-url-encoding": "single",
             "x-ms-visibility": "important",
             "x-ms-dynamic-values": {
               "operationId": "GetForms",
@@ -448,7 +462,7 @@
           {
             "name": "body",
             "in": "body",
-            "required": false,
+            "required": true,
             "schema": {
               "type": "object",
               "properties": {
@@ -506,7 +520,7 @@
     },
     {
       "propertyName": "Categories",
-      "propertyValue": "Data;Collaboration;Productivity"
+      "propertyValue": "Data;Collaboration"
     }
   ]
 }

--- a/certified-connectors/ActivityInfo/apiProperties.json
+++ b/certified-connectors/ActivityInfo/apiProperties.json
@@ -1,0 +1,23 @@
+{
+  "properties": {
+    "connectionParameters": {
+      "api_key": {
+        "type": "securestring",
+        "uiDefinition": {
+          "displayName": "API Token",
+          "description": "API token with Read & Write scope for your ActivityInfo account",
+          "tooltip": "Provide your API Token",
+          "constraints": {
+            "tabIndex": 2,
+            "clearText": false,
+            "required": "true"
+          }
+        }
+      }
+    },
+    "iconBrandColor": "#91F2CA",
+    "capabilities": [],
+    "publisher": "BeDataDriven B.V.",
+    "stackOwner": "BeDataDriven B.V."
+  }
+}


### PR DESCRIPTION
This is a pull request for a certifed connector for ActivityInfo.org, from the publisher BeDataDriven B.V., the company that owns and operates ActivityInfo.org

- [x] I attest that the connector doesn't exist on the Power Platform today. I've verified by checking the pull requests in GitHub and by searching for the connector on the platform or in the documentation. 
- [x] I attest that the connector works and I verified by deploying and testing all the operations. 
- [x] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [x] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [x] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [x] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.

