### PR TITLE
Updated connector publisher property to Snowflake

### DIFF
--- a/certified-connectors/Snowflake v2/ConnectorArtifacts/connector-config-internal.json
+++ b/certified-connectors/Snowflake v2/ConnectorArtifacts/connector-config-internal.json
@@ -32,7 +32,7 @@
         "will": [],
         "wont": []
       },
-      "publisher": "Microsoft",
+      "publisher": "Snowflake",
       "connectionDisplayName": "{database} {server}"
     },
     "interfaces": {

--- a/certified-connectors/Snowflake v2/SnowflakeTestApp/Mocks/ConnectionParametersProviderMock.cs
+++ b/certified-connectors/Snowflake v2/SnowflakeTestApp/Mocks/ConnectionParametersProviderMock.cs
@@ -61,6 +61,12 @@ namespace SnowflakeTestApp.Mocks
             // For local testing, pass the token through the Authorization header or set it here.
             string authToken = HttpContext.Current.Request.Headers["Authorization"] ?? string.Empty;
 
+            // Remove the "Bearer " prefix if it exists.
+            if (authToken.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+            {
+                authToken = authToken.Substring("Bearer ".Length).Trim();
+            }
+
             return new TokenMock(authToken);
         }
 


### PR DESCRIPTION
Updated connector publisher property to Snowflake

---
### When submitting a connector, please make sure that you follow the requirements below, otherwise your PR might be rejected. We want to make you have a well-built connector, a smooth certification experience, and your users are happy :) 

If this is your first time submitting to GitHub and you need some help, please sign up for this [session](https://forms.office.com/pages/responsepage.aspx?id=KtIy2vgLW0SOgZbwvQuRaXDXyCl9DkBHq4A2OG7uLpdUMTFJWFFGVUxBNUFZQjZWRUdaOE5BMFkwNS4u). 

- [ ] I attest that the connector doesn't exist on the Power Platform today. I've verified by checking the pull requests in GitHub and by searching for the connector on the platform or in the documentation. 
- [ ] I attest that the connector works and I verified by deploying and testing all the operations. 
- [ ] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [ ] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [ ] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [ ] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.

If you are an Independent Publisher, you must also attest to the following to ensure a smooth publishing process:
- [ ] I have named this PR after the pattern of "Connector Name (Independent Publisher)" ex: HubSpot Marketing (Independent Publisher)
- [ ] Within this PR markdown file, I have pasted screenshots that show: 3 unique operations (actions/triggers) working within a Flow. This can be in one flow or part of multiple flows. For each one of those flows, I have pasted in screenshots of the Flow succeeding. 
- [ ] Within this PR markdown file, I have pasted in a screenshot from the Test operations section within the Custom Connector UI.
- [ ] If the connector uses OAuth, I have provided detailed steps on how to create an app in the readme.md. 


