### PR TITLE
Added support for asynchronous pattern and dynamics schema within LogicApps.

### DIFF
--- a/certified-connectors/Experlogix Smart Flows/apiDefinition.swagger.json
+++ b/certified-connectors/Experlogix Smart Flows/apiDefinition.swagger.json
@@ -36,7 +36,8 @@
                             "flowId": {
                                 "parameter": "flowId"
                             }
-                        }
+                        },
+                        "value-path": "schema"
                     },
                     "x-ms-dynamic-properties": {
                         "operationId": "GetFlowSchema",
@@ -44,7 +45,8 @@
                             "flowId": {
                                 "parameterReference": "req/flowId"
                             }
-                        }
+                        },
+                        "itemValuePath": "schema"
                     }
                 },
                 "priority": {
@@ -53,6 +55,13 @@
                     "type": "integer",
                     "format": "int32",
                     "x-ms-visibility": "advanced"
+                },
+                "enableAsynchronousRequestReplyPattern": {
+                    "description": "If enabled, the flow execution will be handled asynchronously by the Power Platform.",
+                    "title": "Asynchronous Request-Reply Pattern",
+                    "type": "boolean",
+                    "x-ms-visibility": "advanced",
+                    "default": true
                 }
             },
             "required": [
@@ -200,7 +209,8 @@
                             "recordType": {
                                 "parameter": "recordType"
                             }
-                        }
+                        },
+                        "value-path": "schema"
                     },
                     "x-ms-dynamic-properties": {
                         "operationId": "GetRecordsSchema",
@@ -211,7 +221,8 @@
                             "recordType": {
                                 "parameterReference": "req/recordType"
                             }
-                        }
+                        },
+                        "itemValuePath": "schema"
                     }
                 },
                 "includeAllDependencies": {
@@ -440,10 +451,7 @@
                         }
                     },
                     "202": {
-                        "description": "Success",
-                        "schema": {
-                            "$ref": "#/definitions/FlowExecutionResponse"
-                        }
+                        "description": "Success"
                     },
                     "400": {
                         "description": "Bad Request"
@@ -493,10 +501,7 @@
                         }
                     },
                     "202": {
-                        "description": "Success",
-                        "schema": {
-                            "$ref": "#/definitions/FlowExecutionResponse"
-                        }
+                        "description": "Success"
                     },
                     "400": {
                         "description": "Bad Request"
@@ -569,7 +574,12 @@
                     "200": {
                         "description": "Success",
                         "schema": {
-                            "type": "object"
+                            "type": "object",
+                            "properties": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
                         }
                     },
                     "400": {
@@ -614,7 +624,12 @@
                     "200": {
                         "description": "Success",
                         "schema": {
-                            "type": "object"
+                            "type": "object",
+                            "properties": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
                         }
                     },
                     "400": {

--- a/certified-connectors/Experlogix Smart Flows/apiProperties.json
+++ b/certified-connectors/Experlogix Smart Flows/apiProperties.json
@@ -49,6 +49,16 @@
           "x-ms-apimTemplateParameter.existsAction": "override",
           "x-ms-apimTemplate-policySection": "Request"
         }
+      },
+      {
+        "templateId": "setheader",
+        "title": "ConnectorVersionHeaderPolicy",
+        "parameters": {
+          "x-ms-apimTemplateParameter.name": "X-PACONNECTOR-VERSION",
+          "x-ms-apimTemplateParameter.value": "2.0",
+          "x-ms-apimTemplateParameter.existsAction": "override",
+          "x-ms-apimTemplate-policySection": "Request"
+        }
       }
     ]
   }


### PR DESCRIPTION
Made some slight modifications to support asynchronous request reply pattern when executing a flow and have the power platform handling the throttling.

LogicApps don't support dynamics schemas that don't provide a 'value-path'. We added a value-path and added a version header to make sure we were backward compatible with existing connectors.