### PR TITLE
Add support for ServiceNow Catalog with dynamic schema

### DIFF
--- a/custom-connectors/ServiceNow/apiDefinition.swagger.json
+++ b/custom-connectors/ServiceNow/apiDefinition.swagger.json
@@ -11,25 +11,11 @@
     "https"
   ],
   "consumes": [],
-  "x-ms-connector-metadata": [
-    {
-      "propertyName": "Website",
-      "propertyValue": "https://www.servicenow.com/"
-    },
-    {
-      "propertyName": "Privacy policy",
-      "propertyValue": "https://www.servicenow.com/privacy-statement.html"
-    },
-    {
-      "propertyName": "Categories",
-      "propertyValue": "IT Operations"
-    }
-  ],
   "produces": [
     "application/json"
   ],
   "paths": {
-        "/api/now/v2/table/sys_user/{sys_id}": {
+    "/api/now/v2/table/sys_user/{sys_id}": {
       "get": {
         "responses": {
           "200": {
@@ -38,99 +24,18 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "type": "object",
-                  "properties": {
-                    "country": {
-                      "type": "string",
-                      "description": "country"
-                    },
-                    "building": {
-                      "type": "string",
-                      "description": "building"
-                    },
-                    "state": {
-                      "type": "string",
-                      "description": "state"
-                    },
-                    "vip": {
-                      "type": "string",
-                      "description": "vip"
-                    },
-                    "zip": {
-                      "type": "string",
-                      "description": "zip"
-                    },
-                    "cost_center": {
-                      "type": "string",
-                      "description": "cost_center"
-                    },
-                    "phone": {
-                      "type": "string",
-                      "description": "phone"
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "name"
-                    },
-                    "city": {
-                      "type": "string",
-                      "description": "city"
-                    },
-                    "user_name": {
-                      "type": "string",
-                      "description": "user_name"
-                    },
-                    "roles": {
-                      "type": "string",
-                      "description": "roles"
-                    },
-                    "title": {
-                      "type": "string",
-                      "description": "title"
-                    },
-                    "sys_id": {
-                      "type": "string",
-                      "description": "sys_id"
-                    },
-                    "mobile_phone": {
-                      "type": "string",
-                      "description": "mobile_phone"
-                    },
-                    "street": {
-                      "type": "string",
-                      "description": "street"
-                    },
-                    "company": {
-                      "type": "string",
-                      "description": "company"
-                    },
-                    "department": {
-                      "type": "string",
-                      "description": "department"
-                    },
-                    "first_name": {
-                      "type": "string",
-                      "description": "first_name"
-                    },
-                    "email": {
-                      "type": "string",
-                      "description": "email"
-                    },
-                    "manager": {
-                      "type": "string",
-                      "description": "manager"
-                    },
-                    "last_name": {
-                      "type": "string",
-                      "description": "last_name"
-                    },
-                    "photo": {
-                      "type": "string",
-                      "description": "photo"
-                    },
-                    "location": {
-                      "type": "string",
-                      "description": "location"
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "sys_id": {
+                        "type": "string",
+                        "description": "sys_id"
+                      },
+                      "name": {
+                        "type": "string",
+                        "description": "name"
+                      }
                     }
                   },
                   "description": "result"
@@ -412,7 +317,11 @@
         "responses": {
           "200": {
             "description": "OK",
-            "schema": {"type":"string" , "format": "binary", "title": "File Content"}
+            "schema": {
+              "type": "string",
+              "format": "binary",
+              "title": "File Content"
+            }
           }
         },
         "summary": "Get Attachment File",
@@ -3160,6 +3069,1037 @@
         "deprecated": false,
         "x-ms-visibility": "advanced"
       }
+    },
+    "/api/sn_sc/servicecatalog/catalogs": {
+      "get": {
+        "responses": {
+          "default": {
+            "description": "default",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "result": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "title": {
+                        "type": "string",
+                        "description": "title"
+                      },
+                      "sys_id": {
+                        "type": "string",
+                        "description": "sys_id"
+                      },
+                      "has_categories": {
+                        "type": "boolean",
+                        "description": "has_categories"
+                      },
+                      "has_items": {
+                        "type": "boolean",
+                        "description": "has_items"
+                      },
+                      "description": {
+                        "type": "string",
+                        "description": "description"
+                      },
+                      "desktop_image": {
+                        "type": "string",
+                        "description": "desktop_image"
+                      }
+                    }
+                  },
+                  "description": "result"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Get catalogs",
+        "description": "Retrieves a list of catalogs",
+        "operationId": "GetCatalogs",
+        "parameters": [
+          {
+            "name": "sysparm_limit",
+            "in": "query",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "sysparm_text",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "/api/sn_sc/servicecatalog/catalogs/{catalogId}/categories": {
+      "get": {
+        "responses": {
+          "default": {
+            "description": "default",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "result": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "title": {
+                        "type": "string",
+                        "description": "title"
+                      },
+                      "description": {
+                        "type": "string",
+                        "description": "description"
+                      },
+                      "full_description": {
+                        "type": "string",
+                        "description": "full_description"
+                      },
+                      "icon": {
+                        "type": "string",
+                        "description": "icon"
+                      },
+                      "header_icon": {
+                        "type": "string",
+                        "description": "header_icon"
+                      },
+                      "homepage_image": {
+                        "type": "string",
+                        "description": "homepage_image"
+                      },
+                      "count": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "count"
+                      },
+                      "subcategories": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "sys_id": {
+                              "type": "string",
+                              "description": "sys_id"
+                            },
+                            "title": {
+                              "type": "string",
+                              "description": "title"
+                            }
+                          }
+                        },
+                        "description": "subcategories"
+                      },
+                      "sys_id": {
+                        "type": "string",
+                        "description": "sys_id"
+                      }
+                    }
+                  },
+                  "description": "result"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Get catalog categories",
+        "description": "Retrieves list of categories for a specific catalog",
+        "operationId": "GetCategories",
+        "parameters": [
+          {
+            "name": "catalogId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "sysparm_limit",
+            "in": "query",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "sysparm_offset",
+            "in": "query",
+            "required": false,
+            "type": "integer"
+          }
+        ]
+      }
+    },
+    "/api/sn_sc/servicecatalog/items": {
+      "get": {
+        "responses": {
+          "default": {
+            "description": "default",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "result": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "short_description": {
+                        "type": "string",
+                        "description": "short_description"
+                      },
+                      "kb_article": {
+                        "type": "string",
+                        "description": "kb_article"
+                      },
+                      "icon": {
+                        "type": "string",
+                        "description": "icon"
+                      },
+                      "description": {
+                        "type": "string",
+                        "description": "description"
+                      },
+                      "availability": {
+                        "type": "string",
+                        "description": "availability"
+                      },
+                      "mandatory_attachment": {
+                        "type": "boolean",
+                        "description": "mandatory_attachment"
+                      },
+                      "request_method": {
+                        "type": "string",
+                        "description": "request_method"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "type"
+                      },
+                      "visible_standalone": {
+                        "type": "boolean",
+                        "description": "visible_standalone"
+                      },
+                      "local_currency": {
+                        "type": "string",
+                        "description": "local_currency"
+                      },
+                      "sys_class_name": {
+                        "type": "string",
+                        "description": "sys_class_name"
+                      },
+                      "sys_id": {
+                        "type": "string",
+                        "description": "sys_id"
+                      },
+                      "content_type": {
+                        "type": "string",
+                        "description": "content_type"
+                      },
+                      "price": {
+                        "type": "string",
+                        "description": "price"
+                      },
+                      "recurring_frequency": {
+                        "type": "string",
+                        "description": "recurring_frequency"
+                      },
+                      "price_currency": {
+                        "type": "string",
+                        "description": "price_currency"
+                      },
+                      "order": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "order"
+                      },
+                      "make_item_non_conversational": {
+                        "type": "boolean",
+                        "description": "make_item_non_conversational"
+                      },
+                      "owner": {
+                        "type": "string",
+                        "description": "owner"
+                      },
+                      "show_price": {
+                        "type": "boolean",
+                        "description": "show_price"
+                      },
+                      "recurring_price": {
+                        "type": "string",
+                        "description": "recurring_price"
+                      },
+                      "show_quantity": {
+                        "type": "boolean",
+                        "description": "show_quantity"
+                      },
+                      "picture": {
+                        "type": "string",
+                        "description": "picture"
+                      },
+                      "url": {
+                        "type": "string",
+                        "description": "url"
+                      },
+                      "recurring_price_currency": {
+                        "type": "string",
+                        "description": "recurring_price_currency"
+                      },
+                      "localized_price": {
+                        "type": "string",
+                        "description": "localized_price"
+                      },
+                      "catalogs": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "sys_id": {
+                              "type": "string",
+                              "description": "sys_id"
+                            },
+                            "active": {
+                              "type": "boolean",
+                              "description": "active"
+                            },
+                            "title": {
+                              "type": "string",
+                              "description": "title"
+                            }
+                          }
+                        },
+                        "description": "catalogs"
+                      },
+                      "name": {
+                        "type": "string",
+                        "description": "name"
+                      },
+                      "localized_recurring_price": {
+                        "type": "string",
+                        "description": "localized_recurring_price"
+                      },
+                      "show_wishlist": {
+                        "type": "boolean",
+                        "description": "show_wishlist"
+                      },
+                      "category": {
+                        "type": "object",
+                        "properties": {
+                          "sys_id": {
+                            "type": "string",
+                            "description": "sys_id"
+                          },
+                          "title": {
+                            "type": "string",
+                            "description": "title"
+                          }
+                        },
+                        "description": "category"
+                      },
+                      "turn_off_nowassist_conversation": {
+                        "type": "boolean",
+                        "description": "turn_off_nowassist_conversation"
+                      },
+                      "show_delivery_time": {
+                        "type": "boolean",
+                        "description": "show_delivery_time"
+                      }
+                    }
+                  },
+                  "description": "result"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Get catalog items",
+        "description": "Retrieves a list of catalog items based on the specified parameters, like a search text or a catalog.",
+        "operationId": "GetCatalogItems",
+        "parameters": [
+          {
+            "name": "sysparm_category",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "sysparm_limit",
+            "in": "query",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "sysparm_text",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "sysparm_catalog",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "/api/sn_sc/servicecatalog/items/{sys_id}": {
+      "get": {
+        "responses": {
+          "default": {
+            "description": "default",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "result": {
+                  "type": "object",
+                  "properties": {
+                    "short_description": {
+                      "type": "string",
+                      "description": "short_description"
+                    },
+                    "kb_article": {
+                      "type": "string",
+                      "description": "kb_article"
+                    },
+                    "icon": {
+                      "type": "string",
+                      "description": "icon"
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "description"
+                    },
+                    "availability": {
+                      "type": "string",
+                      "description": "availability"
+                    },
+                    "mandatory_attachment": {
+                      "type": "boolean",
+                      "description": "mandatory_attachment"
+                    },
+                    "request_method": {
+                      "type": "string",
+                      "description": "request_method"
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "type"
+                    },
+                    "visible_standalone": {
+                      "type": "boolean",
+                      "description": "visible_standalone"
+                    },
+                    "sys_class_name": {
+                      "type": "string",
+                      "description": "sys_class_name"
+                    },
+                    "sys_id": {
+                      "type": "string",
+                      "description": "sys_id"
+                    },
+                    "content_type": {
+                      "type": "string",
+                      "description": "content_type"
+                    },
+                    "order": {
+                      "type": "integer",
+                      "format": "int32",
+                      "description": "order"
+                    },
+                    "make_item_non_conversational": {
+                      "type": "boolean",
+                      "description": "make_item_non_conversational"
+                    },
+                    "owner": {
+                      "type": "string",
+                      "description": "owner"
+                    },
+                    "show_price": {
+                      "type": "boolean",
+                      "description": "show_price"
+                    },
+                    "show_quantity": {
+                      "type": "boolean",
+                      "description": "show_quantity"
+                    },
+                    "picture": {
+                      "type": "string",
+                      "description": "picture"
+                    },
+                    "url": {
+                      "type": "string",
+                      "description": "url"
+                    },
+                    "catalogs": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "sys_id": {
+                            "type": "string",
+                            "description": "sys_id"
+                          },
+                          "active": {
+                            "type": "boolean",
+                            "description": "active"
+                          },
+                          "title": {
+                            "type": "string",
+                            "description": "title"
+                          }
+                        }
+                      },
+                      "description": "catalogs"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name"
+                    },
+                    "show_wishlist": {
+                      "type": "boolean",
+                      "description": "show_wishlist"
+                    },
+                    "category": {
+                      "type": "object",
+                      "properties": {
+                        "sys_id": {
+                          "type": "string",
+                          "description": "sys_id"
+                        },
+                        "title": {
+                          "type": "string",
+                          "description": "title"
+                        }
+                      },
+                      "description": "category"
+                    },
+                    "turn_off_nowassist_conversation": {
+                      "type": "boolean",
+                      "description": "turn_off_nowassist_conversation"
+                    },
+                    "show_delivery_time": {
+                      "type": "boolean",
+                      "description": "show_delivery_time"
+                    },
+                    "categories": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "sys_id": {
+                            "type": "string",
+                            "description": "sys_id"
+                          },
+                          "active": {
+                            "type": "boolean",
+                            "description": "active"
+                          },
+                          "category": {
+                            "type": "object",
+                            "properties": {
+                              "sys_id": {
+                                "type": "string",
+                                "description": "sys_id"
+                              },
+                              "active": {
+                                "type": "boolean",
+                                "description": "active"
+                              },
+                              "title": {
+                                "type": "string",
+                                "description": "title"
+                              }
+                            },
+                            "description": "category"
+                          },
+                          "title": {
+                            "type": "string",
+                            "description": "title"
+                          }
+                        }
+                      },
+                      "description": "categories"
+                    },
+                    "variables": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "containerSplitId": {
+                            "type": "string",
+                            "description": "containerSplitId"
+                          },
+                          "type": {
+                            "type": "integer",
+                            "format": "int32",
+                            "description": "type"
+                          },
+                          "mandatory": {
+                            "type": "boolean",
+                            "description": "mandatory"
+                          },
+                          "friendly_type": {
+                            "type": "string",
+                            "description": "friendly_type"
+                          },
+                          "read_only": {
+                            "type": "boolean",
+                            "description": "read_only"
+                          },
+                          "children": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "active": {
+                                  "type": "boolean",
+                                  "description": "active"
+                                },
+                                "label": {
+                                  "type": "string",
+                                  "description": "label"
+                                },
+                                "dynamic_value_field": {
+                                  "type": "string",
+                                  "description": "dynamic_value_field"
+                                },
+                                "type": {
+                                  "type": "integer",
+                                  "format": "int32",
+                                  "description": "type"
+                                },
+                                "mandatory": {
+                                  "type": "boolean",
+                                  "description": "mandatory"
+                                },
+                                "displayvalue": {
+                                  "type": "string",
+                                  "description": "displayvalue"
+                                },
+                                "friendly_type": {
+                                  "type": "string",
+                                  "description": "friendly_type"
+                                },
+                                "display_type": {
+                                  "type": "string",
+                                  "description": "display_type"
+                                },
+                                "reference": {
+                                  "type": "string",
+                                  "description": "reference"
+                                },
+                                "render_label": {
+                                  "type": "boolean",
+                                  "description": "render_label"
+                                },
+                                "ref_qualifier": {
+                                  "type": "string",
+                                  "description": "ref_qualifier"
+                                },
+                                "read_only": {
+                                  "type": "boolean",
+                                  "description": "read_only"
+                                },
+                                "conversational_label": {
+                                  "type": "string",
+                                  "description": "conversational_label"
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "description": "name"
+                                },
+                                "attributes": {
+                                  "type": "string",
+                                  "description": "attributes"
+                                },
+                                "id": {
+                                  "type": "string",
+                                  "description": "id"
+                                },
+                                "value": {
+                                  "type": "string",
+                                  "description": "value"
+                                },
+                                "dynamic_value_dot_walk_path": {
+                                  "type": "string",
+                                  "description": "dynamic_value_dot_walk_path"
+                                },
+                                "help_text": {
+                                  "type": "string",
+                                  "description": "help_text"
+                                },
+                                "max_length": {
+                                  "type": "integer",
+                                  "format": "int32",
+                                  "description": "max_length"
+                                },
+                                "order": {
+                                  "type": "integer",
+                                  "format": "int32",
+                                  "description": "order"
+                                },
+                                "choices": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "recurring_price_currency": {
+                                        "type": "string",
+                                        "description": "recurring_price_currency"
+                                      },
+                                      "price": {
+                                        "type": "integer",
+                                        "format": "int32",
+                                        "description": "price"
+                                      },
+                                      "index": {
+                                        "type": "integer",
+                                        "format": "int32",
+                                        "description": "index"
+                                      },
+                                      "recurring_price": {
+                                        "type": "integer",
+                                        "format": "int32",
+                                        "description": "recurring_price"
+                                      },
+                                      "label": {
+                                        "type": "string",
+                                        "description": "label"
+                                      },
+                                      "value": {
+                                        "type": "string",
+                                        "description": "value"
+                                      },
+                                      "price_currency": {
+                                        "type": "string",
+                                        "description": "price_currency"
+                                      }
+                                    }
+                                  },
+                                  "description": "choices"
+                                }
+                              }
+                            },
+                            "description": "children"
+                          },
+                          "conversational_label": {
+                            "type": "string",
+                            "description": "conversational_label"
+                          },
+                          "hasSplit": {
+                            "type": "boolean",
+                            "description": "hasSplit"
+                          },
+                          "containerEndId": {
+                            "type": "string",
+                            "description": "containerEndId"
+                          },
+                          "id": {
+                            "type": "string",
+                            "description": "id"
+                          },
+                          "value": {
+                            "type": "string",
+                            "description": "value"
+                          },
+                          "dynamic_value_dot_walk_path": {
+                            "type": "string",
+                            "description": "dynamic_value_dot_walk_path"
+                          },
+                          "max_length": {
+                            "type": "integer",
+                            "format": "int32",
+                            "description": "max_length"
+                          },
+                          "order": {
+                            "type": "integer",
+                            "format": "int32",
+                            "description": "order"
+                          },
+                          "containerType": {
+                            "type": "string",
+                            "description": "containerType"
+                          },
+                          "active": {
+                            "type": "boolean",
+                            "description": "active"
+                          },
+                          "label": {
+                            "type": "string",
+                            "description": "label"
+                          },
+                          "dynamic_value_field": {
+                            "type": "string",
+                            "description": "dynamic_value_field"
+                          },
+                          "columnCount": {
+                            "type": "integer",
+                            "format": "int32",
+                            "description": "columnCount"
+                          },
+                          "displayvalue": {
+                            "type": "string",
+                            "description": "displayvalue"
+                          },
+                          "layout": {
+                            "type": "string",
+                            "description": "layout"
+                          },
+                          "render_label": {
+                            "type": "boolean",
+                            "description": "render_label"
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "name"
+                          },
+                          "attributes": {
+                            "type": "string",
+                            "description": "attributes"
+                          },
+                          "help_text": {
+                            "type": "string",
+                            "description": "help_text"
+                          },
+                          "display_type": {
+                            "type": "string",
+                            "description": "display_type"
+                          }
+                        }
+                      },
+                      "description": "variables"
+                    },
+                    "ui_policy": {
+                      "type": "array",
+                      "items": {},
+                      "description": "ui_policy"
+                    },
+                    "client_script": {
+                      "type": "object",
+                      "properties": {
+                        "onChange": {
+                          "type": "array",
+                          "items": {},
+                          "description": "onChange"
+                        },
+                        "onSubmit": {
+                          "type": "array",
+                          "items": {},
+                          "description": "onSubmit"
+                        },
+                        "onLoad": {
+                          "type": "array",
+                          "items": {},
+                          "description": "onLoad"
+                        }
+                      },
+                      "description": "client_script"
+                    },
+                    "data_lookup": {
+                      "type": "array",
+                      "items": {},
+                      "description": "data_lookup"
+                    },
+                    "variablesSchema": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  },
+                  "description": "result"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Get catalog item",
+        "description": "Retrieve a specific catalog item.",
+        "operationId": "GetCatalogItem",
+        "parameters": [
+          {
+            "name": "sys_id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "/api/now/v2/table/{sys_id}": {
+      "get": {
+        "responses": {
+          "default": {
+            "description": "default",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "result": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "sys_id": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "summary": "List items",
+        "description": "List records from a table",
+        "operationId": "GetRows",
+        "parameters": [
+          {
+            "name": "sys_id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "x-ms-dynamic-values": {
+              "operationId": "GetRows",
+              "value-path": "sys_id",
+              "value-collection": "result",
+              "value-title": "name",
+              "parameters": {
+                "sys_id": "sys_db_object"
+              }
+            }
+          },
+          {
+            "name": "sysparm_limit",
+            "in": "query",
+            "required": false,
+            "type": "integer"
+          }
+        ]
+      }
+    },
+    "/api/sn_sc/servicecatalog/items/{sys_id}/order_now": {
+      "post": {
+        "responses": {
+          "default": {
+            "description": "default",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "result": {
+                  "type": "object",
+                  "properties": {
+                    "sys_id": {
+                      "type": "string",
+                      "description": "sys_id"
+                    },
+                    "number": {
+                      "type": "string",
+                      "description": "number"
+                    },
+                    "request_number": {
+                      "type": "string",
+                      "description": "request_number"
+                    },
+                    "request_id": {
+                      "type": "string",
+                      "description": "request_id"
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "table"
+                    }
+                  },
+                  "description": "result"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Order item",
+        "description": "Orders or buys a specific catalog item.",
+        "operationId": "OrderItem",
+        "parameters": [
+          {
+            "name": "sys_id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "x-ms-dynamic-values": {
+              "operationId": "GetCatalogItems",
+              "value-path": "sys_id",
+              "value-collection": "result",
+              "value-title": "name",
+              "parameters": {
+                "sysparm_limit": 200
+              }
+            }
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "required": [
+                "sysparm_quantity"
+              ],
+              "properties": {
+                "sysparm_quantity": {
+                  "type": "integer",
+                  "format": "int32",
+                  "title": "Quantity",
+                  "description": "Number of items to order."
+                },
+                "sysparm_requested_for": {
+                  "type": "string",
+                  "title": "User Requested for",
+                  "description": "ser for which the item is ordered for.",
+                  "x-ms-dynamic-values": {
+                    "operationId": "GetRows",
+                    "parameters": {
+                      "sys_id": "sys_user",
+                      "sysparm_limit": 200
+                    },
+                    "value-path": "sys_id",
+                    "value-collection": "result",
+                    "value-title": "name"
+                  }
+                },
+                "variables": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": true,
+                  "description": "variables array",
+                  "x-ms-dynamic-schema": {
+                    "operationId": "GetCatalogItem",
+                    "parameters": {
+                      "sys_id": {
+                        "parameter": "sys_id"
+                      }
+                    },
+                    "value-path": "result/variablesSchema"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "/api/now/v2/table": {
+      "get": {
+        "responses": {
+          "default": {
+            "description": "default",
+            "schema": {}
+          }
+        },
+        "summary": "List tables",
+        "description": "Get a list of tables",
+        "operationId": "GetTables",
+        "parameters": []
+      }
     }
   },
   "definitions": {
@@ -3236,7 +4176,7 @@
   },
   "responses": {},
   "securityDefinitions": {
-    "oauth2_auth": {
+    "oauth2-auth": {
       "type": "oauth2",
       "flow": "accessCode",
       "authorizationUrl": "https://YourInstance.service-now.com/oauth_auth.do",
@@ -3246,8 +4186,22 @@
   },
   "security": [
     {
-      "oauth2_auth": []
+      "oauth2-auth": []
     }
   ],
-  "tags": []
+  "tags": [],
+  "x-ms-connector-metadata": [
+    {
+      "propertyName": "Website",
+      "propertyValue": "https://www.servicenow.com/"
+    },
+    {
+      "propertyName": "Privacy policy",
+      "propertyValue": "https://www.servicenow.com/privacy-statement.html"
+    },
+    {
+      "propertyName": "Categories",
+      "propertyValue": "IT Operations"
+    }
+  ]
 }

--- a/custom-connectors/ServiceNow/apiProperties.json
+++ b/custom-connectors/ServiceNow/apiProperties.json
@@ -7,8 +7,8 @@
           "identityProvider": "oauth2",
           "clientId": "<Enter your client ID>",
           "scopes": [],
-          "redirectMode": "Global",
-          "redirectUrl": "https://global.consent.azure-apim.net/redirect",
+          "redirectMode": "GlobalPerConnector",
+          "redirectUrl": "https://global.consent.azure-apim.net/redirect/<UpdateYourPath>",
           "properties": {
             "IsFirstParty": "False"
           },
@@ -27,6 +27,9 @@
       }
     },
     "iconBrandColor": "#D1232B",
+    "scriptOperations": [
+      "GetCatalogItem"
+    ],
     "capabilities": [],
     "publisher": "Microsoft"
   }

--- a/custom-connectors/ServiceNow/script.csx
+++ b/custom-connectors/ServiceNow/script.csx
@@ -1,0 +1,118 @@
+public class Script : ScriptBase
+{
+    public override async Task<HttpResponseMessage> ExecuteAsync()
+    {
+        var response = await this.Context.SendAsync(this.Context.Request, this.CancellationToken);
+
+        if (this.Context.OperationId == "GetCatalogItem")
+        {
+            var responseContent = await response.Content.ReadAsStringAsync();
+            var responseJson = JObject.Parse(responseContent);
+            var resultCatalogItem = responseJson["result"];
+
+            if (resultCatalogItem != null)
+            {
+                var schema = GetVariablesSchema(resultCatalogItem);
+                if (schema != null)
+                {
+                    resultCatalogItem["variablesSchema"] = schema;
+                    response.Content = CreateJsonContent(JsonConvert.SerializeObject(
+                        responseJson,
+                        new JsonSerializerSettings
+                        {
+                            NullValueHandling = NullValueHandling.Ignore
+                        }
+                    ));
+                }
+            }
+        }
+
+        return response;
+    }
+
+    private JObject GetVariablesSchema(JToken resultCatalogItem)
+    {
+        var propertiesSchema = new JObject();
+        var requiredProperties = new JArray();
+        var schema = new JObject()
+        {
+            ["type"] = "object",
+            ["properties"] = propertiesSchema,
+            ["required"] = requiredProperties
+        };
+        
+        var variables = resultCatalogItem?["variables"];
+        if (variables != null)
+        {
+            foreach (var variable in variables)
+            {
+                var children = variable["children"];
+
+                if (children != null && children.Count() > 0)
+                {
+                    foreach (var child in children)
+                    {
+                        HandleVariable(propertiesSchema, requiredProperties, child);
+                    }
+                }
+                else
+                {
+                    HandleVariable(propertiesSchema, requiredProperties, variable);
+                }
+            }
+        }
+
+        return schema;
+    }
+
+    private void HandleVariable(JObject propertiesSchema, JArray requiredProperties, JToken variable)
+    {
+        var isActive = variable["active"]?.Value<bool>() ?? true; // Default to true if not specified
+        if (!isActive) return; // Skip inactive variables
+
+        var propertyName = variable["name"]?.ToString();
+        if (!string.IsNullOrEmpty(propertyName))
+        {
+            propertiesSchema[propertyName] = GenerateSchema(variable);
+            if (variable["mandatory"]?.Value<bool>() == true)
+            {
+                requiredProperties.Add(propertyName);
+            }
+        }
+    }
+
+
+    private JObject GenerateSchema(JToken variable)
+    {
+        var variableSchema = new JObject()
+        {
+            ["type"] = "string",
+            ["title"] = variable["label"]?.ToString() ?? variable["name"]?.ToString(),
+            ["default"] = variable["value"]?.ToString() ?? string.Empty,
+        };
+
+        var choices = variable["choices"];
+        if (choices != null && choices.Count() > 0)
+        {
+            variableSchema["enum"] = new JArray(choices.Select(c => c["value"]));
+        }
+
+        if (variable["friendly_type"]?.Value<string>()?.Equals("reference") == true && variable["reference"] != null)
+        {
+            variableSchema["x-ms-dynamic-values"] = new JObject
+            {
+                ["operationId"] = "GetRows",
+                ["parameters"] = new JObject
+                {
+                    { "sys_id", variable["reference"] },
+                    { "sysparm_limit", 200 }
+                },
+                ["value-collection"] = "result",
+                ["value-title"] = "name",
+                ["value-path"] = "sys_id"
+            };
+        }
+
+        return variableSchema;
+    }
+}

--- a/custom-connectors/ServiceNow/script.csx
+++ b/custom-connectors/ServiceNow/script.csx
@@ -94,7 +94,7 @@ public class Script : ScriptBase
         var choices = variable["choices"];
         if (choices != null && choices.Count() > 0)
         {
-            variableSchema["enum"] = new JArray(choices.Select(c => c["value"]));
+            variableSchema["enum"] = new JArray(choices.Select(c => c["value"]?.ToString()));
         }
 
         if (variable["friendly_type"]?.Value<string>()?.Equals("reference") == true && variable["reference"] != null)


### PR DESCRIPTION
Add support for Catalog Items in the ServiceNow custom connector.

NOTE: This is NOT one of the certified or Independent Publisher connector. Rather, this is the custom connector that we typically put here for samples.

This PR also contains the use of script code to generate a dynamic schema.
