### PR TITLE
Nosco: Add non-null author email property

### DIFF
--- a/certified-connectors/Nosco/apiDefinition.swagger.json
+++ b/certified-connectors/Nosco/apiDefinition.swagger.json
@@ -252,8 +252,12 @@
                             "title" : "ID",
                             "type" : "string"
                           },
-                          "publicEmail" : {
+                          "email" : {
                             "title" : "Email",
+                            "type" : "string"
+                          },
+                          "publicEmail" : {
+                            "title" : "Public Email",
                             "type" : "string",
                             "x-nullable" : true
                           },
@@ -276,6 +280,7 @@
                         },
                         "required" : [
                           "id",
+                          "email",
                           "familyName",
                           "givenName",
                           "fullName",
@@ -408,7 +413,8 @@
                                 "date" : {
                                   "title" : "Date Value",
                                   "type" : "string",
-                                  "format" : "date-time"
+                                  "format" : "date-time",
+                                  "x-nullable" : true
                                 },
                                 "number" : {
                                   "title" : "Number Value",
@@ -579,8 +585,12 @@
                       "title" : "ID",
                       "type" : "string"
                     },
-                    "publicEmail" : {
+                    "email" : {
                       "title" : "Email",
+                      "type" : "string"
+                    },
+                    "publicEmail" : {
+                      "title" : "Public Email",
                       "type" : "string",
                       "x-nullable" : true
                     },
@@ -603,6 +613,7 @@
                   },
                   "required" : [
                     "id",
+                    "email",
                     "familyName",
                     "givenName",
                     "fullName",
@@ -739,7 +750,8 @@
                           "date" : {
                             "title" : "Date Value",
                             "type" : "string",
-                            "format" : "date-time"
+                            "format" : "date-time",
+                            "x-nullable" : true
                           },
                           "number" : {
                             "title" : "Number Value",
@@ -943,8 +955,12 @@
                             "title" : "ID",
                             "type" : "string"
                           },
-                          "publicEmail" : {
+                          "email" : {
                             "title" : "Email",
+                            "type" : "string"
+                          },
+                          "publicEmail" : {
+                            "title" : "Public Email",
                             "type" : "string",
                             "x-nullable" : true
                           },
@@ -967,6 +983,7 @@
                         },
                         "required" : [
                           "id",
+                          "email",
                           "familyName",
                           "givenName",
                           "fullName",
@@ -1099,7 +1116,8 @@
                                 "date" : {
                                   "title" : "Date Value",
                                   "type" : "string",
-                                  "format" : "date-time"
+                                  "format" : "date-time",
+                                  "x-nullable" : true
                                 },
                                 "number" : {
                                   "title" : "Number Value",
@@ -1276,8 +1294,12 @@
                             "title" : "ID",
                             "type" : "string"
                           },
-                          "publicEmail" : {
+                          "email" : {
                             "title" : "Email",
+                            "type" : "string"
+                          },
+                          "publicEmail" : {
+                            "title" : "Public Email",
                             "type" : "string",
                             "x-nullable" : true
                           },
@@ -1300,6 +1322,7 @@
                         },
                         "required" : [
                           "id",
+                          "email",
                           "familyName",
                           "givenName",
                           "fullName",
@@ -1436,7 +1459,8 @@
                                 "date" : {
                                   "title" : "Date Value",
                                   "type" : "string",
-                                  "format" : "date-time"
+                                  "format" : "date-time",
+                                  "x-nullable" : true
                                 },
                                 "number" : {
                                   "title" : "Number Value",
@@ -1757,8 +1781,12 @@
                             "title" : "ID",
                             "type" : "string"
                           },
-                          "publicEmail" : {
+                          "email" : {
                             "title" : "Email",
+                            "type" : "string"
+                          },
+                          "publicEmail" : {
+                            "title" : "Public Email",
                             "type" : "string",
                             "x-nullable" : true
                           },
@@ -1781,6 +1809,7 @@
                         },
                         "required" : [
                           "id",
+                          "email",
                           "familyName",
                           "givenName",
                           "fullName",
@@ -1913,7 +1942,8 @@
                                 "date" : {
                                   "title" : "Date Value",
                                   "type" : "string",
-                                  "format" : "date-time"
+                                  "format" : "date-time",
+                                  "x-nullable" : true
                                 },
                                 "number" : {
                                   "title" : "Number Value",
@@ -2131,8 +2161,12 @@
                             "title" : "ID",
                             "type" : "string"
                           },
-                          "publicEmail" : {
+                          "email" : {
                             "title" : "Email",
+                            "type" : "string"
+                          },
+                          "publicEmail" : {
+                            "title" : "Public Email",
                             "type" : "string",
                             "x-nullable" : true
                           },
@@ -2155,6 +2189,7 @@
                         },
                         "required" : [
                           "id",
+                          "email",
                           "familyName",
                           "givenName",
                           "fullName",
@@ -2287,7 +2322,8 @@
                                 "date" : {
                                   "title" : "Date Value",
                                   "type" : "string",
-                                  "format" : "date-time"
+                                  "format" : "date-time",
+                                  "x-nullable" : true
                                 },
                                 "number" : {
                                   "title" : "Number Value",


### PR DESCRIPTION
Update the Nosco connector to add the author email property, which is never null. 