### PR TITLE
RecordedFutureV2 updates

### DIFF
--- a/certified-connectors/RecordedFutureV2/apiDefinition.swagger.json
+++ b/certified-connectors/RecordedFutureV2/apiDefinition.swagger.json
@@ -171,6 +171,16 @@
             "x-ms-visibility": "advanced",
             "default": false,
             "description": "Include a HTML template in the response"
+          },
+          {
+            "name": "FirstObservedAt",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "x-ms-summary": "First observed at",
+            "x-ms-visibility": "internal",
+            "example": "2023-01-01T00:00:00Z",
+            "description": "Timestamp when this IP address was first observed. Used within the Recorded Future Intelligence Cloud."
           }
         ]
       }
@@ -330,6 +340,16 @@
             "x-ms-visibility": "advanced",
             "default": false,
             "description": "Include a HTML template in the response"
+          },
+          {
+            "name": "FirstObservedAt",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "x-ms-summary": "First observed at",
+            "x-ms-visibility": "internal",
+            "example": "2023-01-01T00:00:00Z",
+            "description": "Timestamp when this domain was first observed. Used within the Recorded Future Intelligence Cloud."
           }
         ]
       }
@@ -483,6 +503,16 @@
             "x-ms-visibility": "advanced",
             "default": false,
             "description": "Include a HTML template in the response"
+          },
+          {
+            "name": "FirstObservedAt",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "x-ms-summary": "First observed at",
+            "x-ms-visibility": "internal",
+            "example": "2023-01-01T00:00:00Z",
+            "description": "Timestamp when this URL was first observed. Used within the Recorded Future Intelligence Cloud."
           }
         ]
       }
@@ -642,6 +672,16 @@
             "x-ms-visibility": "advanced",
             "default": false,
             "description": "Include a HTML template in the response"
+          },
+          {
+            "name": "FirstObservedAt",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "x-ms-summary": "First observed at",
+            "x-ms-visibility": "internal",
+            "example": "2023-01-01T00:00:00Z",
+            "description": "Timestamp when this hash was first observed. Used within the Recorded Future Intelligence Cloud."
           }
         ]
       }
@@ -799,6 +839,16 @@
             "x-ms-visibility": "advanced",
             "default": false,
             "description": "Include a HTML template in the response"
+          },
+          {
+            "name": "FirstObservedAt",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "x-ms-summary": "First observed at",
+            "x-ms-visibility": "internal",
+            "example": "2023-01-01T00:00:00Z",
+            "description": "Timestamp when this vulnerability was first observed. Used within the Recorded Future Intelligence Cloud."
           }
         ],
         "operationId": "Vuln_E",

--- a/certified-connectors/RecordedFutureV2/apiDefinition.swagger.json
+++ b/certified-connectors/RecordedFutureV2/apiDefinition.swagger.json
@@ -8,7 +8,7 @@
       "url": "https://support.recordedfuture.com",
       "email": "support@recordedfuture.com"
     },
-    "version": "1.2"
+    "version": "1.3"
   },
   "host": "api.recordedfuture.com",
   "basePath": "/gw/azure",

--- a/certified-connectors/RecordedFutureV2/apiDefinition.swagger.json
+++ b/certified-connectors/RecordedFutureV2/apiDefinition.swagger.json
@@ -151,7 +151,7 @@
             "required": true,
             "type": "string",
             "default": "intelCard,risk,links",
-            "x-ms-visibility": "internal"
+            "x-ms-visibility": "advanced"
           },
           {
             "name": "IntelligenceCloud",
@@ -310,7 +310,7 @@
             "required": true,
             "type": "string",
             "default": "intelCard,risk,links",
-            "x-ms-visibility": "internal"
+            "x-ms-visibility": "advanced"
           },
           {
             "name": "IntelligenceCloud",
@@ -463,7 +463,7 @@
             "required": true,
             "type": "string",
             "default": "intelCard,risk,links",
-            "x-ms-visibility": "internal"
+            "x-ms-visibility": "advanced"
           },
           {
             "name": "IntelligenceCloud",
@@ -622,7 +622,7 @@
             "required": true,
             "type": "string",
             "default": "intelCard,risk,links",
-            "x-ms-visibility": "internal"
+            "x-ms-visibility": "advanced"
           },
           {
             "name": "IntelligenceCloud",
@@ -779,7 +779,7 @@
             "required": true,
             "type": "string",
             "default": "intelCard,risk,links",
-            "x-ms-visibility": "internal"
+            "x-ms-visibility": "advanced"
           },
           {
             "name": "IntelligenceCloud",

--- a/certified-connectors/RecordedFutureV2/apiDefinition.swagger.json
+++ b/certified-connectors/RecordedFutureV2/apiDefinition.swagger.json
@@ -151,7 +151,9 @@
             "required": true,
             "type": "string",
             "default": "intelCard,risk,links",
-            "x-ms-visibility": "advanced"
+            "x-ms-summary": "Fields",
+            "x-ms-visibility": "advanced",
+            "description": "Comma-separated list of fields to return in the response"
           },
           {
             "name": "IntelligenceCloud",
@@ -179,8 +181,7 @@
             "type": "string",
             "x-ms-summary": "First observed at",
             "x-ms-visibility": "internal",
-            "example": "2023-01-01T00:00:00Z",
-            "description": "Timestamp when this IP address was first observed. Used within the Recorded Future Intelligence Cloud."
+            "description": "Timestamp when this IP address was first observed in ISO 8601 format. Used within the Recorded Future Intelligence Cloud."
           }
         ]
       }
@@ -320,7 +321,9 @@
             "required": true,
             "type": "string",
             "default": "intelCard,risk,links",
-            "x-ms-visibility": "advanced"
+            "x-ms-summary": "Fields",
+            "x-ms-visibility": "advanced",
+            "description": "Comma-separated list of fields to return in the response"
           },
           {
             "name": "IntelligenceCloud",
@@ -348,8 +351,7 @@
             "type": "string",
             "x-ms-summary": "First observed at",
             "x-ms-visibility": "internal",
-            "example": "2023-01-01T00:00:00Z",
-            "description": "Timestamp when this domain was first observed. Used within the Recorded Future Intelligence Cloud."
+            "description": "Timestamp when this domain was first observed in ISO 8601 format. Used within the Recorded Future Intelligence Cloud."
           }
         ]
       }
@@ -483,7 +485,9 @@
             "required": true,
             "type": "string",
             "default": "intelCard,risk,links",
-            "x-ms-visibility": "advanced"
+            "x-ms-visibility": "advanced",
+            "x-ms-summary": "Fields",
+            "description": "Comma-separated list of fields to return in the response"
           },
           {
             "name": "IntelligenceCloud",
@@ -511,8 +515,7 @@
             "type": "string",
             "x-ms-summary": "First observed at",
             "x-ms-visibility": "internal",
-            "example": "2023-01-01T00:00:00Z",
-            "description": "Timestamp when this URL was first observed. Used within the Recorded Future Intelligence Cloud."
+            "description": "Timestamp when this URL was first observed in ISO 8601 format. Used within the Recorded Future Intelligence Cloud."
           }
         ]
       }
@@ -652,7 +655,9 @@
             "required": true,
             "type": "string",
             "default": "intelCard,risk,links",
-            "x-ms-visibility": "advanced"
+            "x-ms-visibility": "advanced",
+            "x-ms-summary": "Fields",
+            "description": "Comma-separated list of fields to return in the response"
           },
           {
             "name": "IntelligenceCloud",
@@ -680,8 +685,7 @@
             "type": "string",
             "x-ms-summary": "First observed at",
             "x-ms-visibility": "internal",
-            "example": "2023-01-01T00:00:00Z",
-            "description": "Timestamp when this hash was first observed. Used within the Recorded Future Intelligence Cloud."
+            "description": "Timestamp when this hash was first observed in ISO 8601 format. Used within the Recorded Future Intelligence Cloud."
           }
         ]
       }
@@ -819,7 +823,9 @@
             "required": true,
             "type": "string",
             "default": "intelCard,risk,links",
-            "x-ms-visibility": "advanced"
+            "x-ms-visibility": "advanced",
+            "x-ms-summary": "Fields",
+            "description": "Comma-separated list of fields to return in the response"
           },
           {
             "name": "IntelligenceCloud",
@@ -847,8 +853,7 @@
             "type": "string",
             "x-ms-summary": "First observed at",
             "x-ms-visibility": "internal",
-            "example": "2023-01-01T00:00:00Z",
-            "description": "Timestamp when this vulnerability was first observed. Used within the Recorded Future Intelligence Cloud."
+            "description": "Timestamp when this vulnerability was first observed in ISO 8601 format. Used within the Recorded Future Intelligence Cloud."
           }
         ],
         "operationId": "Vuln_E",


### PR DESCRIPTION
Changes to `RecordedFutureV2` enrichment endpoints:
- change visibility of `fields` parameter. This allows users to change which fields are returned when doing enrichment.
- Add internal `FirstObservedAt` parameter that is used within the Recorded Future Intelligence Cloud.