### PR TITLE
Adding action-groups to swagger schema

### DIFF
--- a/schemas/apiDefinition.swagger.schema.json
+++ b/schemas/apiDefinition.swagger.schema.json
@@ -366,6 +366,9 @@
         },
         "x-ms-visibility": {
           "$ref": "#/definitions/x-ms-visibility"
+        },
+        "x-ms-action-group": {
+          "$ref": "#/definitions/x-ms-action-group"
         }
       }
     },
@@ -2555,6 +2558,35 @@
         "advanced",
         "internal"
       ]
+    },
+    "x-ms-action-group": {
+      "title": "The list of groups an action belongs to",
+      "description": "The domain and scope of the groups an action belongs to. Actions can belong to multiple groups. For example, the send email action would belong to the email.create and email.destructive groups.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/action-group"
+      },
+      "uniqueItems": true
+    },
+    "action-group": {
+      "title": "The group an action belongs to",
+      "description": "The domain and scope of the group an action belongs to.",
+      "type": "object",
+      "properties": {
+        "domain": {
+          "description": "The domain of the group, e.g. 'email', 'file', 'event', etc.",
+          "type": "string"
+        },
+        "scope": {
+          "description": "The scope of the groups operations",
+          "type": "string",
+          "enum": [
+            "read",
+            "create",
+            "destructive"
+          ]
+        }
+      }
     },
     "x-ms-url-encoding": {
       "title": "Encoding style to use for this parameter",

--- a/schemas/apiDefinition.swagger.schema.json
+++ b/schemas/apiDefinition.swagger.schema.json
@@ -367,8 +367,8 @@
         "x-ms-visibility": {
           "$ref": "#/definitions/x-ms-visibility"
         },
-        "x-ms-action-group": {
-          "$ref": "#/definitions/x-ms-action-group"
+        "x-ms-action-groups": {
+          "$ref": "#/definitions/x-ms-action-groups"
         }
       }
     },
@@ -2559,7 +2559,7 @@
         "internal"
       ]
     },
-    "x-ms-action-group": {
+    "x-ms-action-groups": {
       "title": "The list of groups an action belongs to",
       "description": "The domain and scope of the groups an action belongs to. Actions can belong to multiple groups. For example, the send email action would belong to the email.create and email.destructive groups.",
       "type": "array",


### PR DESCRIPTION
This PR introduces a new operation‑level vendor extension for Swagger 2.0 connectors in the Power Platform schema: x-ms-action-groups. Its value is an array of group objects, each with a domain (e.g., email, file, event) and a scope (read | create | destructive). Actions may belong to multiple groups—e.g., Send email can be both email.create and email.destructive. The extension is defined in #/definitions/x-ms-action-group and exposed on each operation via operation.properties["x-ms-action-group"].

The goal is to enable a grouped “Add tool” experience in Copilot Studio without changing runtime semantics. Today, makers have to enable Outlook/SharePoint/Teams operations one‑by‑one; grouping lets the UX present curated sets (Mail → Read/Create/Destructive, Files → Read, etc.) and add many related actions in one step. This reduces setup time, minimizes omissions, and improves consistency across agents and environments—all while keeping individual actions visible in the tools list after they’re added.

This change is purely additive and non‑breaking. It does not modify execution, planning, or object models, and it has no effect on Power Apps or Power Automate—clients that don’t look for this extension will simply ignore it. Connectors that don’t annotate operations continue to work as they do today; the grouped UX will use the tags when present and fall back to search/individual add when absent. The schema also enforces a consistent mental model via a fixed scope enum and uniqueItems on the array to prevent duplicate tags.

In short, x-ms-action-group gives connector authors a lightweight, forward‑compatible way to describe addition‑time groupings of operations. It delivers immediate UX value (faster, safer tool enablement) with zero runtime risk, and it leaves room to evolve grouping semantics later if we decide to add shared inputs or policy binding in a future phase.