### PR TITLE
Fix folder name extraction in ConnectorPackageValidator script

### DIFF
--- a/scripts/ConnectorPackageValidator.ps1
+++ b/scripts/ConnectorPackageValidator.ps1
@@ -287,7 +287,7 @@ try {
     }
 
     # Step 5: The contents in extracted temp path folder should have no folder, 3 zip files if plugin enabled, 2 zip files if no plugin
-    $pkgAssetFoldereName = Get-ChildItem -Path $tempFolder2 -Directory
+    $pkgAssetFoldereName = Get-ChildItem -Path $tempFolder2 -Directory | Select-Object -ExpandProperty Name
 
     $folderPath = "$tempFolder2/$pkgAssetFoldereName"
 


### PR DESCRIPTION
### Summary

Fixing the validation script `ConnectorPackageValidator.ps1`, which is failing when used with PowerShell Core on Windows.

### Details

When getting name of the folder `pkgAsset` the extraction of the name is missing and full path, including drive name is used. That leads to the error.

Most likely it used to work with Windows PowerShell, where object returned by `Get-ChildItem` resolved itself into just a name of the directory. And now it resolves into the full path. So adding `Select-Object` to explicitly select name only (like it was one on two other occasions in the same script just a few lines above) fixes the problem.

See issue #3752 for more details.

