### PR TITLE
fix: add new return param in playbook alerts

### DIFF
--- a/certified-connectors/RecordedFutureV2/apiDefinition.swagger.json
+++ b/certified-connectors/RecordedFutureV2/apiDefinition.swagger.json
@@ -2929,7 +2929,9 @@
         },
         "json_alert": {
           "type": "string"
-        }
+        },
+        "alert_description": {
+          "type": "string"
       }
     },
     "ThreatMapActors": {


### PR DESCRIPTION
Added new return param for `PlaybookAlertLookup`


