### PR TITLE
Penneo Certified Connectors - UPDATES to existing connectors in dev branch

### DIFF
--- a/certified-connectors/Penneo Sign Sandbox/README.md
+++ b/certified-connectors/Penneo Sign Sandbox/README.md
@@ -11,7 +11,7 @@ To use this connector, you will need an active Penneo Sandbox account.
 ### Create a new case file
 Creates a new case file in Penneo with the specified documents and signers. The case file will be created in Penneo, and a UUID and a payloadHash will be returned that can be used to check the creation status via the queue status endpoint.
 
-### Penneo check status
+### Check job status
 Retrieves the current status of a casefile by providing the job UUID and payloadHash. This endpoint is used to poll for job completion status after submitting a case file creation request. The endpoint is rate-limited to 20 requests per minute per uuid-payloadHash combination.
 
 ## Obtaining Credentials
@@ -40,14 +40,14 @@ The connector has been configured to use OAuth with Authorization Code Grant. Us
 
 4. **Check CaseFile creation status**:
     - After creating a case file, you'll receive a UUID and payloadHash
-    - Use the "Penneo check status" action to poll for job completion
+    - Use the "Check job status" action to poll for job completion
     - Respect the rate limit of 20 requests per minute per uuid-hash combination
 
 Note: You can check what each field does by checking https://penneo.readme.io/reference/createcasefile.
 
 ## Known Issues and Limitations
 
-1. **Rate Limiting**: The Penneo check status endpoint is rate-limited to 20 requests per minute per uuid-hash combination. Implement appropriate retry logic with exponential backoff.
+1. **Rate Limiting**: The Check job status endpoint is rate-limited to 20 requests per minute per uuid-hash combination. Implement appropriate retry logic with exponential backoff.
 
 2. **Asynchronous Processing**: Case file creation is asynchronous. You must use the job status endpoint to check completion rather than expecting immediate results.
 

--- a/certified-connectors/Penneo Sign Sandbox/apiDefinition.swagger.json
+++ b/certified-connectors/Penneo Sign Sandbox/apiDefinition.swagger.json
@@ -72,8 +72,8 @@
     "/send/api/v1/casefiles/json/20251022/create-sandbox-base64": {
       "post": {
         "summary": "Create a new case file",
-        "description": "Creates a new case file in Penneo with the specified documents and signers. The case file will be created asynchronously, and a job UUID and a payloadHash will be returned that can be used to check the creation status via the Penneo check status action. You can configure signers, documents, signing order, email notifications, access control, and various other case file settings.",
-        "operationId": "createCaseFile",
+        "description": "Creates a new case file in Penneo with the specified documents and signers. The case file will be created asynchronously, and a job UUID and a payloadHash will be returned that can be used to check the creation status via the Check job status action. You can configure signers, documents, signing order, email notifications, access control, and various other case file settings.",
+        "operationId": "CreateCaseFile",
         "consumes": [
           "application/json"
         ],
@@ -116,9 +116,9 @@
     },
     "/send/api/v1/queue/public/status": {
       "post": {
-        "summary": "Penneo check status",
+        "summary": "Check job status",
         "description": "Retrieves the current status of an asynchronous job by providing the job UUID and payloadHash. This endpoint is used to poll for job completion status after submitting a case file creation request. The action is rate-limited to 20 requests per minute per uuid-payloadHash combination.",
-        "operationId": "checkJobStatus",
+        "operationId": "CheckJobStatus",
         "consumes": [
           "application/json"
         ],

--- a/certified-connectors/Penneo Sign/README.md
+++ b/certified-connectors/Penneo Sign/README.md
@@ -11,7 +11,7 @@ To use this connector, you will need an active Penneo account.
 ### Create a new case file
 Creates a new case file in Penneo with the specified documents and signers. The case file will be created in Penneo, and a UUID and a payloadHash will be returned that can be used to check the creation status via the queue status endpoint.
 
-### Penneo check status
+### Check job status
 Retrieves the current status of a casefile by providing the job UUID and payloadHash. This endpoint is used to poll for job completion status after submitting a case file creation request. The endpoint is rate-limited to 20 requests per minute per uuid-payloadHash combination.
 
 ## Obtaining Credentials
@@ -40,14 +40,14 @@ The connector has been configured to use OAuth with Authorization Code Grant. Us
 
 4. **Check CaseFile creation status**:
    - After creating a case file, you'll receive a UUID and payloadHash
-   - Use the "Penneo check status" action to poll for job completion
+   - Use the "Check job status" action to poll for job completion
    - Respect the rate limit of 20 requests per minute per uuid-hash combination
 
 Note: You can check what each field does by checking https://penneo.readme.io/reference/createcasefile.
 
 ## Known Issues and Limitations
 
-1. **Rate Limiting**: The Penneo check status endpoint is rate-limited to 20 requests per minute per uuid-hash combination. Implement appropriate retry logic with exponential backoff.
+1. **Rate Limiting**: The Check job status endpoint is rate-limited to 20 requests per minute per uuid-hash combination. Implement appropriate retry logic with exponential backoff.
 
 2. **Asynchronous Processing**: Case file creation is asynchronous. You must use the job status endpoint to check completion rather than expecting immediate results.
 

--- a/certified-connectors/Penneo Sign/apiDefinition.swagger.json
+++ b/certified-connectors/Penneo Sign/apiDefinition.swagger.json
@@ -72,8 +72,8 @@
     "/send/api/v1/casefiles/json/20251022/create-production-base64": {
       "post": {
         "summary": "Create a new case file",
-        "description": "Creates a new case file in Penneo with the specified documents and signers. The case file will be created asynchronously, and a job UUID and a payloadHash will be returned that can be used to check the creation status via the Penneo check status action. You can configure signers, documents, signing order, email notifications, access control, and various other case file settings.",
-        "operationId": "createCaseFile",
+        "description": "Creates a new case file in Penneo with the specified documents and signers. The case file will be created asynchronously, and a job UUID and a payloadHash will be returned that can be used to check the creation status via the Check job status action. You can configure signers, documents, signing order, email notifications, access control, and various other case file settings.",
+        "operationId": "CreateCaseFile",
         "consumes": [
           "application/json"
         ],
@@ -116,9 +116,9 @@
     },
     "/send/api/v1/queue/public/status": {
       "post": {
-        "summary": "Penneo check status",
+        "summary": "Check job status",
         "description": "Retrieves the current status of an asynchronous job by providing the job UUID and payloadHash. This endpoint is used to poll for job completion status after submitting a case file creation request. The action is rate-limited to 20 requests per minute per uuid-payloadHash combination.",
-        "operationId": "checkJobStatus",
+        "operationId": "CheckJobStatus",
         "consumes": [
           "application/json"
         ],


### PR DESCRIPTION
## Update Penneo Sign and Penneo Sign Sandbox connectors
This PR applies corrections to the existing **Penneo Sign** and **Penneo Sign Sandbox** certified connectors, following the initial submission in #4072. The connectors only exists in `dev` branch as of now.
### Changes
**Penneo Sign & Penneo Sign Sandbox** (`certified-connectors/Penneo Sign`, `certified-connectors/Penneo Sign Sandbox`):
- `apiDefinition.swagger.json`:
  - Renamed `operationId` values to PascalCase: `createCaseFile` → `CreateCaseFile`, `checkJobStatus` → `CheckJobStatus`, to align with Microsoft connector conventions.
  - Updated the `"Create a new case file"` action description to reference the correct action name (`Check job status` instead of `Penneo check status`).
  - Renamed action summary: `"Penneo check status"` → `"Check job status"`.
- `README.md`:
  - Updated all references from `"Penneo check status"` to `"Check job status"` to match the updated `operationId` and summary.
### Verification
- Verified that `operationId` values follow PascalCase convention as required for certified connectors.
- Confirmed action names and descriptions are consistent between `apiDefinition.swagger.json` and `README.md`.
- No changes to API endpoints, request/response schemas, authentication, or connector metadata.

---
### When submitting a connector, please make sure that you follow the requirements below, otherwise your PR might be rejected. We want to make you have a well-built connector, a smooth certification experience, and your users are happy :) 

If this is your first time submitting to GitHub and you need some help, please sign up for this [session](https://forms.office.com/pages/responsepage.aspx?id=KtIy2vgLW0SOgZbwvQuRaXDXyCl9DkBHq4A2OG7uLpdUMTFJWFFGVUxBNUFZQjZWRUdaOE5BMFkwNS4u). 

- [ ] I attest that the connector doesn't exist on the Power Platform today. I've verified by checking the pull requests in GitHub and by searching for the connector on the platform or in the documentation. 
- [x] I attest that the connector works and I verified by deploying and testing all the operations. 
- [x] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [x] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [x] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [x] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.

If you are an Independent Publisher, you must also attest to the following to ensure a smooth publishing process:
- [ ] I have named this PR after the pattern of "Connector Name (Independent Publisher)" ex: HubSpot Marketing (Independent Publisher)
- [ ] Within this PR markdown file, I have pasted screenshots that show: 3 unique operations (actions/triggers) working within a Flow. This can be in one flow or part of multiple flows. For each one of those flows, I have pasted in screenshots of the Flow succeeding. 
- [ ] Within this PR markdown file, I have pasted in a screenshot from the Test operations section within the Custom Connector UI.
- [ ] If the connector uses OAuth, I have provided detailed steps on how to create an app in the readme.md. 


