### PR TITLE
Snowflake V2 Connector - Fix build warnings

### DIFF
--- a/certified-connectors/Snowflake v2/Contracts/Microsoft.Azure.Connectors.SnowflakeV2Contracts.csproj
+++ b/certified-connectors/Snowflake v2/Contracts/Microsoft.Azure.Connectors.SnowflakeV2Contracts.csproj
@@ -4,6 +4,7 @@
     <AssemblyName>Microsoft.Azure.Connectors.SnowflakeV2Contracts</AssemblyName>
     <TargetFramework>net48</TargetFramework>
     <LangVersion>8.0</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <UseStricterCodeAnalysis>true</UseStricterCodeAnalysis>
     <PackagableLibrary>true</PackagableLibrary>
     <PackageVersion>0.0.1</PackageVersion>

--- a/certified-connectors/Snowflake v2/SnowflakeTestApp.Tests/SnowflakeTestApp.Tests.csproj
+++ b/certified-connectors/Snowflake v2/SnowflakeTestApp.Tests/SnowflakeTestApp.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
@@ -8,7 +8,7 @@
     <IsTestProject>true</IsTestProject>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <CodeAnalysisRuleSet>..\SnowflakeTestApp\SnowflakeV2RuleSet.ruleset</CodeAnalysisRuleSet>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>

--- a/certified-connectors/Snowflake v2/SnowflakeTestApp/SnowflakeTestApp.csproj
+++ b/certified-connectors/Snowflake v2/SnowflakeTestApp/SnowflakeTestApp.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -21,6 +21,7 @@
     <IISExpressWindowsAuthentication />
     <IISExpressUseClassicPipelineMode />
     <UseGlobalApplicationHostFile />
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CodeAnalysisRuleSet>SnowflakeV2RuleSet.ruleset</CodeAnalysisRuleSet>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/certified-connectors/Snowflake v2/SnowflakeV2CoreLogic/Providers/SnowflakeTableDataProvider.cs
+++ b/certified-connectors/Snowflake v2/SnowflakeV2CoreLogic/Providers/SnowflakeTableDataProvider.cs
@@ -65,6 +65,11 @@ namespace SnowflakeV2CoreLogic.Providers
                 throw new ArgumentNullException(nameof(table));
             }
 
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
             SnowflakeConnectionParameters connectionParameters = snowflakeConnectionParametersProvider.GetConnectionParameters();
             connectionParameters = SnowflakeConnectionParametersProvider.UpdateConnParametersToUseDataset(request, dataSet, connectionParameters);
 
@@ -100,7 +105,7 @@ namespace SnowflakeV2CoreLogic.Providers
                 return partitionResponse.ToListOfItems();
             }
 
-            bool countRequested = options?.Count?.RawValue?.Equals("true", StringComparison.InvariantCultureIgnoreCase) == true;
+            bool countRequested = options.Count?.RawValue?.Equals("true", StringComparison.InvariantCultureIgnoreCase) == true;
 
             var dataTask = snowflakeDBOperations.ListAllItemsAsync(table, "GET datasets/{dataset}/tables/{table}/items", options, connectionParameters);
             Task<SnowflakeTableData>? countTask = countRequested
@@ -119,7 +124,7 @@ namespace SnowflakeV2CoreLogic.Providers
             int partitionCount = queryResponse.ResultSetMetaData?.PartitionInfo?.Count ?? 1;
             string? statementHandle = queryResponse.StatementHandle;
 
-            if (partitionCount > 1 && !string.IsNullOrEmpty(statementHandle))
+            if (partitionCount > 1 && statementHandle != null && statementHandle.Length > 0)
             {
                 int rowsReturnedInPartition = queryResponse.Data?.Count ?? 0;
 

--- a/certified-connectors/Snowflake v2/SnowflakeV2CoreLogic/SnowflakeV2CoreLogic.csproj
+++ b/certified-connectors/Snowflake v2/SnowflakeV2CoreLogic/SnowflakeV2CoreLogic.csproj
@@ -4,6 +4,7 @@
     <AssemblyName>Microsoft.Azure.Connectors.SnowflakeV2CoreLogic</AssemblyName>
     <TargetFramework>net48</TargetFramework>
     <LangVersion>8.0</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <UseStricterCodeAnalysis>true</UseStricterCodeAnalysis>
     <CodeAnalysisRuleSet>SnowflakeV2RuleSet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>

--- a/certified-connectors/Snowflake v2/SnowflakeV2CoreLogic/Utilities/SnowflakeToODataHelper.cs
+++ b/certified-connectors/Snowflake v2/SnowflakeV2CoreLogic/Utilities/SnowflakeToODataHelper.cs
@@ -294,7 +294,7 @@ namespace SnowflakeV2CoreLogic.Utilities
             partitionIndex = 0;
             totalPartitions = 0;
 
-            if (string.IsNullOrEmpty(skipToken))
+            if (skipToken == null || skipToken.Length == 0)
             {
                 return false;
             }

--- a/certified-connectors/Snowflake v2/SnowflakeV2CoreLogicTests/SnowflakeV2CoreLogic.Tests.csproj
+++ b/certified-connectors/Snowflake v2/SnowflakeV2CoreLogicTests/SnowflakeV2CoreLogic.Tests.csproj
@@ -5,6 +5,7 @@
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>


### PR DESCRIPTION
---
### When submitting a connector, please make sure that you follow the requirements below, otherwise your PR might be rejected. We want to make you have a well-built connector, a smooth certification experience, and your users are happy :) 

If this is your first time submitting to GitHub and you need some help, please sign up for this [session](https://forms.office.com/pages/responsepage.aspx?id=KtIy2vgLW0SOgZbwvQuRaXDXyCl9DkBHq4A2OG7uLpdUMTFJWFFGVUxBNUFZQjZWRUdaOE5BMFkwNS4u). 

- [ ] I attest that the connector doesn't exist on the Power Platform today. I've verified by checking the pull requests in GitHub and by searching for the connector on the platform or in the documentation. 
- [X] I attest that the connector works and I verified by deploying and testing all the operations. 
- [X] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [X] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [ ] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [X] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.

If you are an Independent Publisher, you must also attest to the following to ensure a smooth publishing process:
- [ ] I have named this PR after the pattern of "Connector Name (Independent Publisher)" ex: HubSpot Marketing (Independent Publisher)
- [ ] Within this PR markdown file, I have pasted screenshots that show: 3 unique operations (actions/triggers) working within a Flow. This can be in one flow or part of multiple flows. For each one of those flows, I have pasted in screenshots of the Flow succeeding. 
- [ ] Within this PR markdown file, I have pasted in a screenshot from the Test operations section within the Custom Connector UI.
- [ ] If the connector uses OAuth, I have provided detailed steps on how to create an app in the readme.md. 


