### PR TITLE
Recorded Future: fix syntax error in JSON

### DIFF
--- a/certified-connectors/RecordedFutureV2/apiDefinition.swagger.json
+++ b/certified-connectors/RecordedFutureV2/apiDefinition.swagger.json
@@ -2932,6 +2932,7 @@
         },
         "alert_description": {
           "type": "string"
+        }
       }
     },
     "ThreatMapActors": {


### PR DESCRIPTION
For some reason the JSON for the RecordedFutureV2 connector is invalid, and has been for quite some time (?).

We noticed that there was something wrong when trying to upload it to Power Automate:
<img width="631" height="353" alt="image" src="https://github.com/user-attachments/assets/a2a8777f-bcc2-4249-8e84-4dc6ce44ac91" />

At least after this PR it is valid json 😅 Please have a look.

---

- [ ] I attest that the connector works and I verified by deploying and testing all the operations. 
- [x] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [x] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [ ] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [x] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.
