### PR TITLE
Update Converter by Power2Apps to v1.0.11

### DIFF
--- a/certified-connectors/Converter by Power2Apps/Readme.md
+++ b/certified-connectors/Converter by Power2Apps/Readme.md
@@ -1,6 +1,6 @@
 # Converter by Power2Apps for Power Automate
 
-Converter by Power2Apps is a single connector for everyday document and data work. It can convert between CSV, JSON, XML and Excel, create and edit Word (DOCX) files, generate, merge, protect, compress or split PDFs, render HTML to PDF or image, produce charts, QR codes and images, run regular expressions and flatten SharePoint search results — all without custom code or extra services.
+Convert PDF, HTML, Word, Excel, CSV, JSON, XML, PowerPoint and images. Create, merge, split, protect, unlock, compress PDF (incl. PDF/A) and extract pages. Create or edit Word (DOCX), Excel (XLSX), PowerPoint (PPTX) files. Convert CSV/JSON/XML to Excel/CSV, HTML to PDF/image, HTML tables to Excel/CSV. Resize, rotate, compress images (PNG, JPEG, WebP, BMP, SVG). Generate QR codes, barcodes, charts, watermarks. Run regex, translate text, parse XRechnung/ZUGFeRD e-invoices.
 
 ## Setup
 
@@ -89,9 +89,6 @@ Extracts form or content controls (e.g., text fields, checkboxes, dropdowns) fro
 ### Extract results from Send HTTP request to SharePoint search
 Extract results from the action 'Send HTTP request to SharePoint' search - https://converter.power2apps.com/6000_SharePoint/V6011_ConvertSharePointSearchResults
 
-### Convert HTML Table to JSON
-Convert an HTML table to a JSON or extract the first HTML table from an URL and convert it to a JSON - https://converter.power2apps.com/7000_html/V7012_ConvertHtmlTableToJson
-
 ### Convert HTML to Word File
 Convert HTML to a Word file (DOCX) - https://converter.power2apps.com/7000_html/V7041_ConvertHtmlToWord
 
@@ -161,9 +158,6 @@ Updates a Word content control or form element - https://converter.power2apps.co
 ### Update multiple Word Content Controls
 Updates several Word content controls or form element within one action - https://converter.power2apps.com/5000_word/V5151_UpdateMultipleWordContentControls
 
-### Convert CSV to Excel
-Convert a CSV to a Excel file (XLSX) - https://converter.power2apps.com/1000_fileConversions/V1034_ConvertCsvToExcel
-
 ### Convert JSON to Excel
 Convert a JSON to an Excel file (XLSX) - https://converter.power2apps.com/1000_fileConversions/V1064_ConvertJsonToExcel
 
@@ -227,8 +221,26 @@ Convert an HTML to a PDF or convert an URL containing HTML to a PDF - https://co
 ### Convert HTML or URL to JPG Image
 Convert an HTML to an JPG (JPEG) Image or convert an URL containing HTML to an JPG (JPEG) Image - https://converter.power2apps.com/7000_html/V7032_ConvertHtmlToImage
 
-### Convert HTML Table to Excel File
-Convert an HTML table to a Excel (XLSX) or extract the first HTML table from an URL and convert it to a Excel - https://converter.power2apps.com/7000_html/V7081_ConvertHtmlTableToExcel
-
 ### Convert XRechnung to PDF
 Convert a XRechnung to a PDF - https://converter.power2apps.com/8000_XRechnung/V8011_ConvertXRechnungToPdf
+
+### Convert multiple CSVs to one Excel
+Convert multiple CSV files into a single Excel file (XLSX), one sheet per CSV - https://converter.power2apps.com/1000_fileConversions/V1110_ConvertMultiCsvToExcel
+
+### Merge multiple PDFs
+Merge multiple PDF files into one. Optional: add page numbers, bookmarks per source PDF, and PDF metadata - https://converter.power2apps.com/4000_pdf/V4120_MergeMultiplePdfs
+
+### Convert XML to Excel
+Convert an XML to an Excel file (XLSX). Hierarchical XML is automatically flattened (nested elements become prefixed columns) - https://converter.power2apps.com/1000_fileConversions/V1120_ConvertXmlToExcel
+
+### Convert XML to CSV
+Convert an XML to a CSV. Hierarchical XML is automatically flattened into one CSV table - https://converter.power2apps.com/1000_fileConversions/V1130_ConvertXmlToCsv
+
+### Convert CSV to Excel
+Convert a CSV to an Excel file (XLSX). Lets you pick the CSV input encoding (UTF-8, Windows-1252, Latin-1, UTF-16) for cases where special characters arrive garbled - https://converter.power2apps.com/1000_fileConversions/V1035_ConvertCsvToExcel
+
+### Convert HTML Table to JSON
+Convert an HTML table to JSON. Tolerates messy tables: rows with extra or missing cells are auto-padded, duplicate column names are made unique. Any fixes are listed in the 'Notes' field - https://converter.power2apps.com/7000_html/V7013_ConvertHtmlTableToJson
+
+### Convert HTML Table to Excel File
+Convert HTML table(s) to an Excel (XLSX). Tolerates messy tables: rows with extra or missing cells are auto-padded, duplicate column names are made unique. Any fixes are listed in the 'Notes' field - https://converter.power2apps.com/7000_html/V7082_ConvertHtmlTableToExcel

--- a/certified-connectors/Converter by Power2Apps/apiDefinition.swagger.json
+++ b/certified-connectors/Converter by Power2Apps/apiDefinition.swagger.json
@@ -2,19 +2,19 @@
   "swagger": "2.0",
   "info": {
     "title": "Converter by Power2Apps",
-    "description": "Converter by Power2Apps is a single connector for everyday document and data work. It can convert between CSV, JSON, XML and Excel, create and edit Word (DOCX) files, generate, merge, protect, compress or split PDFs, render HTML to PDF or image, produce charts, QR codes and images, run regular expressions and flatten SharePoint search results — all without custom code or extra services.",
+    "description": "Convert PDF, HTML, Word, Excel, CSV, JSON, XML, PowerPoint and images. Create, merge, split, protect, unlock, compress PDF (incl. PDF/A) and extract pages. Create or edit Word (DOCX), Excel (XLSX), PowerPoint (PPTX) files. Convert CSV/JSON/XML to Excel/CSV, HTML to PDF/image, HTML tables to Excel/CSV. Resize, rotate, compress images (PNG, JPEG, WebP, BMP, SVG). Generate QR codes, barcodes, charts, watermarks. Run regex, translate text, parse XRechnung/ZUGFeRD e-invoices.",
     "contact": {
       "name": "Power2Apps Support",
       "url": "https://www.power2apps.de/en/contact",
       "email": "getintouch@power2apps.de"
     },
-    "version": "1.0.10"
+    "version": "1.0.11"
   },
   "host": "webapiconverterservice20211014190508.azurewebsites.net",
+  "basePath": "/Converter",
   "schemes": [
     "https"
   ],
-  "basePath": "/Converter",
   "paths": {
     "/GetHealth": {
       "get": {
@@ -472,6 +472,114 @@
         "description": "Returns list of file response options"
       }
     },
+    "/GetPageNumberFormats": {
+      "get": {
+        "tags": [
+          "Converter"
+        ],
+        "operationId": "GetPageNumberFormats",
+        "produces": [
+          "text/plain",
+          "application/json",
+          "text/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ListOption"
+              }
+            }
+          }
+        },
+        "x-ms-visibility": "internal",
+        "summary": "Get list of Page Number Formats",
+        "description": "Returns list of page number formats"
+      }
+    },
+    "/GetPageNumberPositions": {
+      "get": {
+        "tags": [
+          "Converter"
+        ],
+        "operationId": "GetPageNumberPositions",
+        "produces": [
+          "text/plain",
+          "application/json",
+          "text/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ListOption"
+              }
+            }
+          }
+        },
+        "x-ms-visibility": "internal",
+        "summary": "Get list of Page Number Positions",
+        "description": "Returns list of page number positions"
+      }
+    },
+    "/GetCsvEncodings": {
+      "get": {
+        "tags": [
+          "Converter"
+        ],
+        "operationId": "GetCsvEncodings",
+        "produces": [
+          "text/plain",
+          "application/json",
+          "text/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ListOption"
+              }
+            }
+          }
+        },
+        "x-ms-visibility": "internal",
+        "summary": "Get list of CSV Encodings",
+        "description": "Returns list of CSV input encodings"
+      }
+    },
+    "/GetTextOutputModes": {
+      "get": {
+        "tags": [
+          "Converter"
+        ],
+        "operationId": "GetTextOutputModes",
+        "produces": [
+          "text/plain",
+          "application/json",
+          "text/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ListOption"
+              }
+            }
+          }
+        },
+        "x-ms-visibility": "internal",
+        "summary": "Get list of Text Output Modes",
+        "description": "Returns list of text output modes"
+      }
+    },
     "/GetContentControlSearchOptions": {
       "get": {
         "tags": [
@@ -693,7 +801,7 @@
               "operationId": "GetSeparators",
               "value-path": "name",
               "value-title": "name",
-              "parameters": { }
+              "parameters": {}
             },
             "x-ms-visibility": "advanced",
             "x-ms-summary": "Separator",
@@ -849,7 +957,7 @@
               "operationId": "GetSeparators",
               "value-path": "name",
               "value-title": "name",
-              "parameters": { }
+              "parameters": {}
             },
             "x-ms-visibility": "advanced",
             "x-ms-summary": "Separator",
@@ -1014,7 +1122,7 @@
               "operationId": "GetSeparators",
               "value-path": "name",
               "value-title": "name",
-              "parameters": { }
+              "parameters": {}
             },
             "x-ms-visibility": "advanced",
             "x-ms-summary": "Separator",
@@ -1572,7 +1680,7 @@
               "operationId": "GetLanguages",
               "value-path": "name",
               "value-title": "name",
-              "parameters": { }
+              "parameters": {}
             },
             "x-ms-visibility": "important",
             "x-ms-summary": "From",
@@ -1587,7 +1695,7 @@
               "operationId": "GetLanguages",
               "value-path": "name",
               "value-title": "name",
-              "parameters": { }
+              "parameters": {}
             },
             "x-ms-visibility": "important",
             "x-ms-summary": "To",
@@ -1645,7 +1753,7 @@
               "operationId": "GetImageFormats",
               "value-path": "name",
               "value-title": "name",
-              "parameters": { }
+              "parameters": {}
             },
             "x-ms-visibility": "important",
             "x-ms-summary": "Output format",
@@ -1718,7 +1826,7 @@
               "operationId": "GetImageFormats",
               "value-path": "name",
               "value-title": "name",
-              "parameters": { }
+              "parameters": {}
             },
             "x-ms-visibility": "important",
             "x-ms-summary": "Format",
@@ -1733,7 +1841,7 @@
               "operationId": "GetResizeOptions",
               "value-path": "name",
               "value-title": "name",
-              "parameters": { }
+              "parameters": {}
             },
             "x-ms-visibility": "advanced",
             "x-ms-summary": "Resize By",
@@ -1805,7 +1913,7 @@
               "operationId": "GetResizeOptions",
               "value-path": "name",
               "value-title": "name",
-              "parameters": { }
+              "parameters": {}
             },
             "x-ms-visibility": "advanced",
             "x-ms-summary": "Resize By",
@@ -1869,7 +1977,7 @@
               "operationId": "GetImageFormats",
               "value-path": "name",
               "value-title": "name",
-              "parameters": { }
+              "parameters": {}
             },
             "x-ms-visibility": "important",
             "x-ms-summary": "Output format",
@@ -2038,7 +2146,7 @@
               "operationId": "GetCodeFormats",
               "value-path": "name",
               "value-title": "name",
-              "parameters": { }
+              "parameters": {}
             },
             "x-ms-visibility": "important",
             "x-ms-summary": "Code format",
@@ -2053,7 +2161,7 @@
               "operationId": "GetImageFormats",
               "value-path": "name",
               "value-title": "name",
-              "parameters": { }
+              "parameters": {}
             },
             "x-ms-visibility": "important",
             "x-ms-summary": "Output format",
@@ -2148,7 +2256,7 @@
               "operationId": "GetFileExtensions",
               "value-path": "name",
               "value-title": "name",
-              "parameters": { }
+              "parameters": {}
             },
             "x-ms-visibility": "important",
             "x-ms-summary": "File Extension",
@@ -2214,7 +2322,7 @@
               "operationId": "GetFileExtensions",
               "value-path": "name",
               "value-title": "name",
-              "parameters": { }
+              "parameters": {}
             },
             "x-ms-visibility": "important",
             "x-ms-summary": "Origin File Extension",
@@ -5995,6 +6103,7 @@
             }
           }
         },
+        "deprecated": true,
         "x-ms-visibility": "important",
         "summary": "Convert HTML Table to JSON",
         "description": "Convert an HTML table to a JSON or extract the first HTML table from an URL and convert it to a JSON - https://converter.power2apps.com/7000_html/V7012_ConvertHtmlTableToJson"
@@ -7409,6 +7518,7 @@
             }
           }
         },
+        "deprecated": true,
         "x-ms-visibility": "important",
         "summary": "Convert CSV to Excel",
         "description": "Convert a CSV to a Excel file (XLSX) - https://converter.power2apps.com/1000_fileConversions/V1034_ConvertCsvToExcel"
@@ -8267,6 +8377,7 @@
             }
           }
         },
+        "deprecated": true,
         "x-ms-visibility": "important",
         "summary": "Convert HTML Table to Excel File",
         "description": "Convert an HTML table to a Excel (XLSX) or extract the first HTML table from an URL and convert it to a Excel - https://converter.power2apps.com/7000_html/V7081_ConvertHtmlTableToExcel"
@@ -8309,6 +8420,279 @@
         "x-ms-visibility": "important",
         "summary": "Convert XRechnung to PDF",
         "description": "Convert a XRechnung to a PDF - https://converter.power2apps.com/8000_XRechnung/V8011_ConvertXRechnungToPdf"
+      }
+    },
+    "/V1110_ConvertMultiCsvToExcel": {
+      "post": {
+        "tags": [
+          "Converter"
+        ],
+        "operationId": "V1110_ConvertMultiCsvToExcel",
+        "consumes": [
+          "application/json",
+          "text/json",
+          "application/*+json"
+        ],
+        "produces": [
+          "text/plain",
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "dtoRequest",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DtoRequestV1110_ConvertMultiCsvToExcel"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/DtoResponseV1110_ConvertMultiCsvToExcel"
+            }
+          }
+        },
+        "x-ms-visibility": "important",
+        "summary": "Convert multiple CSVs to one Excel",
+        "description": "Convert multiple CSV files into a single Excel file (XLSX), one sheet per CSV - https://converter.power2apps.com/1000_fileConversions/V1110_ConvertMultiCsvToExcel"
+      }
+    },
+    "/V4120_MergeMultiplePdfs": {
+      "post": {
+        "tags": [
+          "Converter"
+        ],
+        "operationId": "V4120_MergeMultiplePdfs",
+        "consumes": [
+          "application/json",
+          "text/json",
+          "application/*+json"
+        ],
+        "produces": [
+          "text/plain",
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "dtoRequest",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DtoRequestV4120_MergeMultiplePdfs"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/DtoResponseV4120_MergeMultiplePdfs"
+            }
+          }
+        },
+        "x-ms-visibility": "important",
+        "summary": "Merge multiple PDFs",
+        "description": "Merge multiple PDF files into one. Optional: add page numbers, bookmarks per source PDF, and PDF metadata - https://converter.power2apps.com/4000_pdf/V4120_MergeMultiplePdfs"
+      }
+    },
+    "/V1120_ConvertXmlToExcel": {
+      "post": {
+        "tags": [
+          "Converter"
+        ],
+        "operationId": "V1120_ConvertXmlToExcel",
+        "consumes": [
+          "application/json",
+          "text/json",
+          "application/*+json"
+        ],
+        "produces": [
+          "text/plain",
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "dtoRequest",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DtoRequestV1120_ConvertXmlToExcel"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/DtoResponseV1120_ConvertXmlToExcel"
+            }
+          }
+        },
+        "x-ms-visibility": "important",
+        "summary": "Convert XML to Excel",
+        "description": "Convert an XML to an Excel file (XLSX). Hierarchical XML is automatically flattened (nested elements become prefixed columns) - https://converter.power2apps.com/1000_fileConversions/V1120_ConvertXmlToExcel"
+      }
+    },
+    "/V1130_ConvertXmlToCsv": {
+      "post": {
+        "tags": [
+          "Converter"
+        ],
+        "operationId": "V1130_ConvertXmlToCsv",
+        "consumes": [
+          "application/json",
+          "text/json",
+          "application/*+json"
+        ],
+        "produces": [
+          "text/plain",
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "dtoRequest",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DtoRequestV1130_ConvertXmlToCsv"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/DtoResponseV1130_ConvertXmlToCsv"
+            }
+          }
+        },
+        "x-ms-visibility": "important",
+        "summary": "Convert XML to CSV",
+        "description": "Convert an XML to a CSV. Hierarchical XML is automatically flattened into one CSV table - https://converter.power2apps.com/1000_fileConversions/V1130_ConvertXmlToCsv"
+      }
+    },
+    "/V1035_ConvertCsvToExcel": {
+      "post": {
+        "tags": [
+          "Converter"
+        ],
+        "operationId": "V1035_ConvertCsvToExcel",
+        "consumes": [
+          "application/json",
+          "text/json",
+          "application/*+json"
+        ],
+        "produces": [
+          "text/plain",
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "dtoRequest",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DtoRequestV1035_ConvertCsvToExcel"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/DtoResponseV1035_ConvertCsvToExcel"
+            }
+          }
+        },
+        "x-ms-visibility": "important",
+        "summary": "Convert CSV to Excel",
+        "description": "Convert a CSV to an Excel file (XLSX). Lets you pick the CSV input encoding (UTF-8, Windows-1252, Latin-1, UTF-16) for cases where special characters arrive garbled - https://converter.power2apps.com/1000_fileConversions/V1035_ConvertCsvToExcel"
+      }
+    },
+    "/V7013_ConvertHtmlTableToJson": {
+      "post": {
+        "tags": [
+          "Converter"
+        ],
+        "operationId": "V7013_ConvertHtmlTableToJson",
+        "consumes": [
+          "application/json",
+          "text/json",
+          "application/*+json"
+        ],
+        "produces": [
+          "text/plain",
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "dtoRequest",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DtoRequestV7013_ConvertHtmlTableToJson"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/DtoResponseV7013_ConvertHtmlTableToJson"
+            }
+          }
+        },
+        "x-ms-visibility": "important",
+        "summary": "Convert HTML Table to JSON",
+        "description": "Convert an HTML table to JSON. Tolerates messy tables: rows with extra or missing cells are auto-padded, duplicate column names are made unique. Any fixes are listed in the 'Notes' field - https://converter.power2apps.com/7000_html/V7013_ConvertHtmlTableToJson"
+      }
+    },
+    "/V7082_ConvertHtmlTableToExcel": {
+      "post": {
+        "tags": [
+          "Converter"
+        ],
+        "operationId": "V7082_ConvertHtmlTableToExcel",
+        "consumes": [
+          "application/json",
+          "text/json",
+          "application/*+json"
+        ],
+        "produces": [
+          "text/plain",
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "dtoRequest",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DtoRequestV7082_ConvertHtmlTableToExcel"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/DtoResponseV7082_ConvertHtmlTableToExcel"
+            }
+          }
+        },
+        "x-ms-visibility": "important",
+        "summary": "Convert HTML Table to Excel File",
+        "description": "Convert HTML table(s) to an Excel (XLSX). Tolerates messy tables: rows with extra or missing cells are auto-padded, duplicate column names are made unique. Any fixes are listed in the 'Notes' field - https://converter.power2apps.com/7000_html/V7082_ConvertHtmlTableToExcel"
       }
     }
   },
@@ -8450,7 +8834,7 @@
             "operationId": "GetContentControlSearchOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -8480,6 +8864,28 @@
           "x-ms-visibility": "important",
           "x-ms-summary": "CSV response",
           "description": "CSV response"
+        }
+      },
+      "additionalProperties": false
+    },
+    "CsvSheetItem": {
+      "required": [
+        "csv"
+      ],
+      "type": "object",
+      "properties": {
+        "csv": {
+          "minLength": 1,
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "CSV",
+          "description": "CSV content (text, base64, or URL to the CSV file)."
+        },
+        "sheetName": {
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "Name",
+          "description": "Excel sheet name. Leave empty for 'Sheet1', 'Sheet2', ..."
         }
       },
       "additionalProperties": false
@@ -8526,7 +8932,7 @@
             "operationId": "GetChartImageFormats",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "version": {
@@ -8551,7 +8957,7 @@
             "operationId": "GetChartTypes",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -8599,7 +9005,7 @@
             "operationId": "GetChartImageFormats",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "version": {
@@ -8660,7 +9066,7 @@
             "operationId": "GetChartImageFormats",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "version": {
@@ -8731,7 +9137,7 @@
             "operationId": "GetImageFormats",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -8759,7 +9165,7 @@
             "operationId": "GetCodeFormats",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "width": {
@@ -8785,7 +9191,7 @@
             "operationId": "GetImageFormats",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "image": {
@@ -8876,7 +9282,7 @@
             "operationId": "GetSeparators",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "mayHaveQuotedFields": {
@@ -8926,7 +9332,7 @@
             "operationId": "GetFooterOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "headerOption": {
@@ -8939,7 +9345,7 @@
             "operationId": "GetHeaderOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "paperFormat": {
@@ -8951,7 +9357,7 @@
             "operationId": "GetPaperFormats",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "marginTop": {
@@ -9170,7 +9576,7 @@
             "operationId": "GetSeparators",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "mayHaveQuotedFields": {
@@ -9259,7 +9665,7 @@
             "operationId": "GetSeparators",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -9329,7 +9735,7 @@
             "operationId": "GetSeparators",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "mayHaveQuotedFields": {
@@ -9406,7 +9812,7 @@
             "operationId": "GetSeparators",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "mayHaveQuotedFields": {
@@ -9483,7 +9889,7 @@
             "operationId": "GetSeparators",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "mayHaveQuotedFields": {
@@ -9581,7 +9987,7 @@
             "operationId": "GetSeparators",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "mayHaveQuotedFields": {
@@ -9622,7 +10028,131 @@
             "operationId": "GetFileResponseOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "DtoRequestV1035_ConvertCsvToExcel": {
+      "required": [
+        "csv"
+      ],
+      "type": "object",
+      "properties": {
+        "csv": {
+          "minLength": 1,
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "CSV",
+          "description": "CSV"
+        },
+        "dataIncludesHeader": {
+          "default": true,
+          "type": "boolean",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "CSV has Headers?",
+          "description": "CSV has headers?"
+        },
+        "autoDiscoverFieldTypes": {
+          "default": false,
+          "type": "boolean",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Auto-detect Field Types?",
+          "description": "Auto-detect field types?"
+        },
+        "maxScanRows": {
+          "format": "int32",
+          "type": "integer",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Number of Rows for Field Type Detection",
+          "description": "Number of rows for automatic field type detection. Default = 20"
+        },
+        "ignoreEmptyLine": {
+          "default": true,
+          "type": "boolean",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Remove Empty Rows?",
+          "description": "Remove empty rows"
+        },
+        "skip": {
+          "format": "int32",
+          "type": "integer",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Skip a Number of Rows",
+          "description": "Skip a number of rows at beginning. Default = 0"
+        },
+        "skipLast": {
+          "format": "int32",
+          "type": "integer",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Stop at a specific Row",
+          "description": "Stop at a specific row number. Default = convert all rows"
+        },
+        "delimiter": {
+          "type": "string",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Separator",
+          "description": "Field separator (delimiter). Default = 'Auto-detect separator'",
+          "x-ms-dynamic-values": {
+            "operationId": "GetSeparators",
+            "value-path": "name",
+            "value-title": "name",
+            "parameters": {}
+          }
+        },
+        "mayHaveQuotedFields": {
+          "default": true,
+          "type": "boolean",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Auto-detect Quote Delimiter?",
+          "description": "Auto-detect quote delimiter?"
+        },
+        "encoding": {
+          "format": "int32",
+          "type": "integer",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "CSV Input Encoding",
+          "description": "Use 'Auto-detect' if unsure. Pick a specific encoding when umlauts or accents look garbled.",
+          "x-ms-dynamic-values": {
+            "operationId": "GetCsvEncodings",
+            "value-path": "value",
+            "value-title": "name",
+            "parameters": {}
+          }
+        },
+        "adjustColumnToContent": {
+          "default": true,
+          "type": "boolean",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Adjust Excel Column to Content",
+          "description": "Adjust Excel column to content."
+        },
+        "wrapColumnText": {
+          "default": false,
+          "type": "boolean",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Wrap Excel Column Text",
+          "description": "Wrap Excel text of column."
+        },
+        "maxColumnWidth": {
+          "format": "int32",
+          "type": "integer",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Max Excel Column Width",
+          "description": "Maximum of Excel column width. Default = 15"
+        },
+        "fileResponseMode": {
+          "format": "int32",
+          "type": "integer",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Reduce Response Size",
+          "description": "Skip the format you don't need to shrink the response. Default = Both.",
+          "x-ms-dynamic-values": {
+            "operationId": "GetFileResponseOptions",
+            "value-path": "value",
+            "value-title": "name",
+            "parameters": {}
           }
         }
       },
@@ -9800,7 +10330,7 @@
             "operationId": "GetFileResponseOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -9889,6 +10419,249 @@
       },
       "additionalProperties": false
     },
+    "DtoRequestV1110_ConvertMultiCsvToExcel": {
+      "required": [
+        "csvSheets"
+      ],
+      "type": "object",
+      "properties": {
+        "csvSheets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CsvSheetItem"
+          },
+          "x-ms-visibility": "important",
+          "x-ms-summary": "Sheet",
+          "description": "Each entry becomes one sheet in the resulting Excel file."
+        },
+        "dataIncludesHeader": {
+          "default": true,
+          "type": "boolean",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "CSV has Headers?",
+          "description": "All CSVs have headers in the first row?"
+        },
+        "autoDiscoverFieldTypes": {
+          "default": false,
+          "type": "boolean",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Auto-detect Field Types?",
+          "description": "Auto-detect field types?"
+        },
+        "maxScanRows": {
+          "format": "int32",
+          "type": "integer",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Number of Rows for Field Type Detection",
+          "description": "Number of rows for automatic field type detection. Default = 20"
+        },
+        "ignoreEmptyLine": {
+          "default": true,
+          "type": "boolean",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Remove Empty Rows?",
+          "description": "Remove empty rows"
+        },
+        "skip": {
+          "format": "int32",
+          "type": "integer",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Skip a Number of Rows",
+          "description": "Skip a number of rows at beginning. Default = 0"
+        },
+        "skipLast": {
+          "format": "int32",
+          "type": "integer",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Stop at a specific Row",
+          "description": "Stop at a specific row number. Default = convert all rows"
+        },
+        "delimiter": {
+          "type": "string",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Separator",
+          "description": "Field separator for the CSV. Default = auto-detect.",
+          "x-ms-dynamic-values": {
+            "operationId": "GetSeparators",
+            "value-path": "name",
+            "value-title": "name",
+            "parameters": {}
+          }
+        },
+        "mayHaveQuotedFields": {
+          "default": true,
+          "type": "boolean",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Auto-detect Quote Delimiter?",
+          "description": "Auto-detect quote delimiter?"
+        },
+        "adjustColumnToContent": {
+          "default": true,
+          "type": "boolean",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Adjust Excel Column to Content",
+          "description": "Adjust Excel column to content."
+        },
+        "wrapColumnText": {
+          "default": false,
+          "type": "boolean",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Wrap Excel Column Text",
+          "description": "Wrap Excel text of column."
+        },
+        "maxColumnWidth": {
+          "format": "int32",
+          "type": "integer",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Max Excel Column Width",
+          "description": "Maximum of Excel column width. Default = 15"
+        },
+        "fileName": {
+          "type": "string",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Excel file name",
+          "description": "Name for the resulting Excel file (without extension). Leave empty for a default name."
+        },
+        "fileResponseMode": {
+          "format": "int32",
+          "type": "integer",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Reduce Response Size",
+          "description": "Skip the format you don't need to shrink the response. Default = Both.",
+          "x-ms-dynamic-values": {
+            "operationId": "GetFileResponseOptions",
+            "value-path": "value",
+            "value-title": "name",
+            "parameters": {}
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "DtoRequestV1120_ConvertXmlToExcel": {
+      "required": [
+        "xml"
+      ],
+      "type": "object",
+      "properties": {
+        "xml": {
+          "minLength": 1,
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "XML",
+          "description": "XML content (text, base64-encoded text, or a URL to the XML file)."
+        },
+        "ignoreXmlFormatting": {
+          "default": true,
+          "type": "boolean",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Ignore XML formatting",
+          "description": "Yes = compact output (recommended). No = keep XML whitespace."
+        },
+        "allInOneTable": {
+          "default": true,
+          "type": "boolean",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "All in one table?",
+          "description": "Yes = merge all data into one sheet. No = create one sheet per top-level XML element."
+        },
+        "adjustColumnToContent": {
+          "default": true,
+          "type": "boolean",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Adjust Excel Column to Content",
+          "description": "Adjust Excel column to content."
+        },
+        "wrapColumnText": {
+          "default": false,
+          "type": "boolean",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Wrap Excel Column Text",
+          "description": "Wrap Excel text of column."
+        },
+        "maxColumnWidth": {
+          "format": "int32",
+          "type": "integer",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Max Excel Column Width",
+          "description": "Maximum of Excel column width. Default = 15"
+        },
+        "fileName": {
+          "type": "string",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Excel file name",
+          "description": "Name for the resulting Excel file (without extension). Leave empty for 'XmlExcel'."
+        },
+        "fileResponseMode": {
+          "format": "int32",
+          "type": "integer",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Reduce Response Size",
+          "description": "Skip the format you don't need to shrink the response. Default = Both.",
+          "x-ms-dynamic-values": {
+            "operationId": "GetFileResponseOptions",
+            "value-path": "value",
+            "value-title": "name",
+            "parameters": {}
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "DtoRequestV1130_ConvertXmlToCsv": {
+      "required": [
+        "xml"
+      ],
+      "type": "object",
+      "properties": {
+        "xml": {
+          "minLength": 1,
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "XML",
+          "description": "XML content (text, base64-encoded text, or a URL to the XML file)."
+        },
+        "delimiter": {
+          "type": "string",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Separator",
+          "description": "Field separator for the CSV. Default = ';'",
+          "x-ms-dynamic-values": {
+            "operationId": "GetSeparators",
+            "value-path": "name",
+            "value-title": "name",
+            "parameters": {}
+          }
+        },
+        "ignoreXmlFormatting": {
+          "default": true,
+          "type": "boolean",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Ignore XML formatting",
+          "description": "Yes = compact output (recommended). No = keep XML whitespace."
+        },
+        "fileName": {
+          "type": "string",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "CSV file name",
+          "description": "Name for the resulting CSV file (without extension). Leave empty for 'XmlCsv'."
+        },
+        "textOutputMode": {
+          "format": "int32",
+          "type": "integer",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Output Format",
+          "description": "Skip the format you don't need to shrink the response. Default = Both.",
+          "x-ms-dynamic-values": {
+            "operationId": "GetTextOutputModes",
+            "value-path": "value",
+            "value-title": "name",
+            "parameters": {}
+          }
+        }
+      },
+      "additionalProperties": false
+    },
     "DtoRequestV2011_RegularExpression": {
       "required": [
         "input"
@@ -9917,7 +10690,7 @@
             "operationId": "GetRegexOptions",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -9978,7 +10751,7 @@
             "operationId": "GetFileResponseOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -10007,7 +10780,7 @@
             "operationId": "GetLanguages",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "to": {
@@ -10020,7 +10793,7 @@
             "operationId": "GetLanguages",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -10125,7 +10898,7 @@
             "operationId": "GetSeparators",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "mayHaveQuotedFields": {
@@ -10435,7 +11208,7 @@
             "operationId": "GetCodeRuntimeOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "timeoutSec": {
@@ -10477,7 +11250,7 @@
             "operationId": "GetImageFormats",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -10519,7 +11292,7 @@
             "operationId": "GetResizeOptions",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -10561,7 +11334,7 @@
             "operationId": "GetResizeOptions",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "fileResponseMode": {
@@ -10574,7 +11347,7 @@
             "operationId": "GetFileResponseOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -10609,7 +11382,7 @@
             "operationId": "GetImageFormats",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -10644,7 +11417,7 @@
             "operationId": "GetImageFormats",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "fileResponseMode": {
@@ -10657,7 +11430,7 @@
             "operationId": "GetFileResponseOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -10716,7 +11489,7 @@
             "operationId": "GetFileResponseOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -10760,7 +11533,7 @@
             "operationId": "GetCodeFormats",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "width": {
@@ -10786,7 +11559,7 @@
             "operationId": "GetImageFormats",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "image": {
@@ -10835,7 +11608,7 @@
             "operationId": "GetCodeFormats",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "width": {
@@ -10861,7 +11634,7 @@
             "operationId": "GetImageFormats",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "image": {
@@ -10895,7 +11668,7 @@
             "operationId": "GetFileResponseOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -10961,7 +11734,7 @@
             "operationId": "GetImagePositionHorizontal",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "imagePositionVertical": {
@@ -10973,7 +11746,7 @@
             "operationId": "GetImagePositionVertical",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -11023,7 +11796,7 @@
             "operationId": "GetImagePositionHorizontal",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "imagePositionVertical": {
@@ -11035,7 +11808,7 @@
             "operationId": "GetImagePositionVertical",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "fileResponseMode": {
@@ -11048,7 +11821,7 @@
             "operationId": "GetFileResponseOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -11096,7 +11869,7 @@
             "operationId": "GetChartImageFormats",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "version": {
@@ -11121,7 +11894,7 @@
             "operationId": "GetChartTypes",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -11169,7 +11942,7 @@
             "operationId": "GetChartImageFormats",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "version": {
@@ -11194,7 +11967,7 @@
             "operationId": "GetChartTypes",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "fileResponseMode": {
@@ -11207,7 +11980,7 @@
             "operationId": "GetFileResponseOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -11255,7 +12028,7 @@
             "operationId": "GetChartImageFormats",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "version": {
@@ -11329,7 +12102,7 @@
             "operationId": "GetChartImageFormats",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "version": {
@@ -11368,7 +12141,7 @@
             "operationId": "GetFileResponseOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -11416,7 +12189,7 @@
             "operationId": "GetChartImageFormats",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "version": {
@@ -11477,7 +12250,7 @@
             "operationId": "GetChartImageFormats",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "version": {
@@ -11503,7 +12276,7 @@
             "operationId": "GetFileResponseOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -11537,7 +12310,7 @@
             "operationId": "GetFileExtensions",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -11571,7 +12344,7 @@
             "operationId": "GetFileExtensions",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "conformanceLevel": {
@@ -11584,7 +12357,7 @@
             "operationId": "GetPdfConformanceLevels",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -11618,7 +12391,7 @@
             "operationId": "GetFileExtensions",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "conformanceLevel": {
@@ -11631,7 +12404,7 @@
             "operationId": "GetPdfConformanceLevels",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "fileResponseMode": {
@@ -11644,7 +12417,7 @@
             "operationId": "GetFileResponseOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -11705,7 +12478,7 @@
             "operationId": "GetFileResponseOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -11790,7 +12563,7 @@
             "operationId": "GetFileResponseOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -11859,7 +12632,7 @@
             "operationId": "GetFileResponseOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -11920,7 +12693,7 @@
             "operationId": "GetFileResponseOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -11949,7 +12722,7 @@
             "operationId": "GetPdfConformanceLevels",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -11978,7 +12751,7 @@
             "operationId": "GetPdfConformanceLevels",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "fileResponseMode": {
@@ -11991,7 +12764,7 @@
             "operationId": "GetFileResponseOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -12102,7 +12875,7 @@
             "operationId": "GetFileResponseOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -12297,7 +13070,96 @@
             "operationId": "GetFileResponseOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "DtoRequestV4120_MergeMultiplePdfs": {
+      "required": [
+        "pdfFiles"
+      ],
+      "type": "object",
+      "properties": {
+        "pdfFiles": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PdfMergeItem"
+          },
+          "x-ms-visibility": "important",
+          "x-ms-summary": "PDF",
+          "description": "PDFs to merge, joined in the order you list them here."
+        },
+        "addPageNumbers": {
+          "default": false,
+          "type": "boolean",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Add page numbers",
+          "description": "Add a continuous page number in the footer of every page (e.g. '5 / 27')."
+        },
+        "pageNumberFormat": {
+          "format": "int32",
+          "type": "integer",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Page number format",
+          "description": "Format of the page numbers. Default = '1 / N'.",
+          "x-ms-dynamic-values": {
+            "operationId": "GetPageNumberFormats",
+            "value-path": "value",
+            "value-title": "name",
+            "parameters": {}
+          }
+        },
+        "pageNumberPosition": {
+          "format": "int32",
+          "type": "integer",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Page number position",
+          "description": "Position of the page numbers. Default = 'Footer center'.",
+          "x-ms-dynamic-values": {
+            "operationId": "GetPageNumberPositions",
+            "value-path": "value",
+            "value-title": "name",
+            "parameters": {}
+          }
+        },
+        "addBookmarks": {
+          "default": false,
+          "type": "boolean",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Add bookmarks",
+          "description": "Add a bookmark per source PDF (named 'PDF 1', 'PDF 2', ...) for easier navigation."
+        },
+        "pdfTitle": {
+          "type": "string",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "PDF title",
+          "description": "Title shown in the PDF viewer's tab and document properties."
+        },
+        "pdfAuthor": {
+          "type": "string",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "PDF author",
+          "description": "Author metadata of the resulting PDF."
+        },
+        "fileName": {
+          "type": "string",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "PDF file name",
+          "description": "Name for the resulting PDF file (without extension). Leave empty for 'MergedPdfs'."
+        },
+        "fileResponseMode": {
+          "format": "int32",
+          "type": "integer",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Reduce Response Size",
+          "description": "Skip the format you don't need to shrink the response. Default = Both.",
+          "x-ms-dynamic-values": {
+            "operationId": "GetFileResponseOptions",
+            "value-path": "value",
+            "value-title": "name",
+            "parameters": {}
           }
         }
       },
@@ -12360,7 +13222,7 @@
             "operationId": "GetFileResponseOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -12494,7 +13356,7 @@
             "operationId": "GetFileResponseOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -12593,7 +13455,7 @@
             "operationId": "GetFileResponseOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -12636,7 +13498,7 @@
             "operationId": "GetWordTableStyles",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "tableText": {
@@ -12685,7 +13547,7 @@
             "operationId": "GetWordTableStyles",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "tableText": {
@@ -12704,7 +13566,7 @@
             "operationId": "GetFileResponseOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -12734,7 +13596,7 @@
             "operationId": "GetWordSectionTypes",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "text": {
@@ -12771,7 +13633,7 @@
             "operationId": "GetWordSectionTypes",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "text": {
@@ -12791,7 +13653,7 @@
             "operationId": "GetFileResponseOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -12888,7 +13750,7 @@
             "operationId": "GetFileResponseOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -13013,7 +13875,7 @@
             "operationId": "GetFileResponseOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -13054,7 +13916,7 @@
             "operationId": "GetWordTableStyles",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "hasHeader": {
@@ -13114,7 +13976,7 @@
             "operationId": "GetWordTableStyles",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "hasHeader": {
@@ -13146,7 +14008,7 @@
             "operationId": "GetFileResponseOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -13205,7 +14067,7 @@
             "operationId": "GetFileResponseOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -13294,7 +14156,7 @@
             "operationId": "GetFileResponseOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -13367,7 +14229,7 @@
             "operationId": "GetFileResponseOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -13440,7 +14302,7 @@
             "operationId": "GetFileResponseOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -13505,7 +14367,7 @@
             "operationId": "GetFileResponseOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -13577,6 +14439,22 @@
       },
       "additionalProperties": false
     },
+    "DtoRequestV7013_ConvertHtmlTableToJson": {
+      "required": [
+        "htmlTable"
+      ],
+      "type": "object",
+      "properties": {
+        "htmlTable": {
+          "minLength": 1,
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "HTML Table",
+          "description": "HTML or URL containing the table(s) to convert."
+        }
+      },
+      "additionalProperties": false
+    },
     "DtoRequestV7022_ConvertHtmlToPdf": {
       "required": [
         "html"
@@ -13614,7 +14492,7 @@
             "operationId": "GetFooterOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "headerOption": {
@@ -13627,7 +14505,7 @@
             "operationId": "GetHeaderOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "paperFormat": {
@@ -13639,7 +14517,7 @@
             "operationId": "GetPaperFormats",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "marginTop": {
@@ -13723,7 +14601,7 @@
             "operationId": "GetFooterOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "headerOption": {
@@ -13736,7 +14614,7 @@
             "operationId": "GetHeaderOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "paperFormat": {
@@ -13748,7 +14626,7 @@
             "operationId": "GetPaperFormats",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "marginTop": {
@@ -13802,7 +14680,7 @@
             "operationId": "GetFileResponseOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -13875,7 +14753,7 @@
             "operationId": "GetFileResponseOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -13977,7 +14855,7 @@
             "operationId": "GetSeparators",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "mayHaveQuotedFields": {
@@ -14012,7 +14890,7 @@
             "operationId": "GetSeparators",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -14057,7 +14935,36 @@
             "operationId": "GetFileResponseOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "DtoRequestV7082_ConvertHtmlTableToExcel": {
+      "required": [
+        "htmlTable"
+      ],
+      "type": "object",
+      "properties": {
+        "htmlTable": {
+          "minLength": 1,
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "HTML Table",
+          "description": "HTML or URL containing the table(s). Multiple tables become separate Excel sheets."
+        },
+        "fileResponseMode": {
+          "format": "int32",
+          "type": "integer",
+          "x-ms-visibility": "advanced",
+          "x-ms-summary": "Reduce Response Size",
+          "description": "Skip the format you don't need to shrink the response. Default = Both.",
+          "x-ms-dynamic-values": {
+            "operationId": "GetFileResponseOptions",
+            "value-path": "value",
+            "value-title": "name",
+            "parameters": {}
           }
         }
       },
@@ -14102,7 +15009,7 @@
             "operationId": "GetFileResponseOptions",
             "value-path": "value",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -14250,7 +15157,7 @@
             "operationId": "GetImagePositionHorizontal",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "imagePositionVertical": {
@@ -14262,7 +15169,7 @@
             "operationId": "GetImagePositionVertical",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -14313,7 +15220,7 @@
             "operationId": "GetWordTableStyles",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "tableText": {
@@ -14569,6 +15476,49 @@
       },
       "additionalProperties": false
     },
+    "DtoResponseV1035_ConvertCsvToExcel": {
+      "type": "object",
+      "properties": {
+        "file": {
+          "format": "byte",
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "File response",
+          "description": "File response"
+        },
+        "fileString": {
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "File response as string",
+          "description": "File response as string"
+        },
+        "mimeType": {
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "MIME type",
+          "description": "MIME type"
+        },
+        "extension": {
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "Extension",
+          "description": "Extension"
+        },
+        "detectedEncoding": {
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "Detected Encoding",
+          "description": "Which encoding was actually used to decode the CSV (matches your Encoding choice; with Auto-detect this shows what was sniffed from the BOM/heuristic)."
+        },
+        "detectedDelimiter": {
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "Detected Delimiter",
+          "description": "Which column delimiter was used (your Delimiter input, or what was sniffed if you left it blank)."
+        }
+      },
+      "additionalProperties": false
+    },
     "DtoResponseV1042_ConvertJsonToXml": {
       "type": "object",
       "properties": {
@@ -14752,6 +15702,117 @@
       },
       "additionalProperties": false
     },
+    "DtoResponseV1110_ConvertMultiCsvToExcel": {
+      "type": "object",
+      "properties": {
+        "file": {
+          "format": "byte",
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "File response",
+          "description": "File response"
+        },
+        "fileString": {
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "File response as string",
+          "description": "File response as string (base64)"
+        },
+        "mimeType": {
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "MIME type",
+          "description": "MIME type"
+        },
+        "extension": {
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "Extension",
+          "description": "Extension"
+        },
+        "fileName": {
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "File name",
+          "description": "Resulting Excel file name (including extension)."
+        }
+      },
+      "additionalProperties": false
+    },
+    "DtoResponseV1120_ConvertXmlToExcel": {
+      "type": "object",
+      "properties": {
+        "file": {
+          "format": "byte",
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "File response",
+          "description": "File response"
+        },
+        "fileString": {
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "File response as string",
+          "description": "File response as string (base64)"
+        },
+        "mimeType": {
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "MIME type",
+          "description": "MIME type"
+        },
+        "extension": {
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "Extension",
+          "description": "Extension"
+        },
+        "fileName": {
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "File name",
+          "description": "Resulting Excel file name (including extension)."
+        }
+      },
+      "additionalProperties": false
+    },
+    "DtoResponseV1130_ConvertXmlToCsv": {
+      "type": "object",
+      "properties": {
+        "csv": {
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "CSV",
+          "description": "The CSV result as plain text. Filled when output mode is 'String' or 'Both'."
+        },
+        "file": {
+          "format": "byte",
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "File response",
+          "description": "CSV file as UTF-8 bytes. Filled when output mode is 'Bytes' or 'Both'."
+        },
+        "mimeType": {
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "MIME type",
+          "description": "MIME type"
+        },
+        "extension": {
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "Extension",
+          "description": "Extension"
+        },
+        "fileName": {
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "File name",
+          "description": "Resulting CSV file name (including extension)."
+        }
+      },
+      "additionalProperties": false
+    },
     "DtoResponseV2011_RegularExpression": {
       "type": "object",
       "properties": {
@@ -14763,7 +15824,7 @@
         },
         "matches": {
           "type": "array",
-          "items": { }
+          "items": {}
         },
         "firstMatch": {
           "x-ms-visibility": "important",
@@ -16482,6 +17543,43 @@
       },
       "additionalProperties": false
     },
+    "DtoResponseV4120_MergeMultiplePdfs": {
+      "type": "object",
+      "properties": {
+        "file": {
+          "format": "byte",
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "File response",
+          "description": "File response"
+        },
+        "fileString": {
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "File response as string",
+          "description": "File response as string (base64)"
+        },
+        "mimeType": {
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "MIME type",
+          "description": "MIME type"
+        },
+        "extension": {
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "Extension",
+          "description": "Extension"
+        },
+        "fileName": {
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "File name",
+          "description": "Resulting PDF file name (including extension)."
+        }
+      },
+      "additionalProperties": false
+    },
     "DtoResponseV5011_CreateWordFile": {
       "type": "object",
       "properties": {
@@ -17277,6 +18375,40 @@
       },
       "additionalProperties": false
     },
+    "DtoResponseV7013_ConvertHtmlTableToJson": {
+      "required": [
+        "firstTable"
+      ],
+      "type": "object",
+      "properties": {
+        "firstTable": {
+          "minLength": 1,
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "First JSON table response",
+          "description": "First JSON table response"
+        },
+        "tables": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-ms-visibility": "important",
+          "x-ms-summary": "All JSON tables response",
+          "description": "All JSON tables response"
+        },
+        "notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-ms-visibility": "important",
+          "x-ms-summary": "Notes",
+          "description": "Human-readable notes about adjustments made during parsing (e.g. duplicate headers renamed, extra columns auto-added)."
+        }
+      },
+      "additionalProperties": false
+    },
     "DtoResponseV7022_ConvertHtmlToPdf": {
       "type": "object",
       "properties": {
@@ -17484,6 +18616,46 @@
           "x-ms-visibility": "important",
           "x-ms-summary": "Extension",
           "description": "Extension"
+        }
+      },
+      "additionalProperties": false
+    },
+    "DtoResponseV7082_ConvertHtmlTableToExcel": {
+      "type": "object",
+      "properties": {
+        "file": {
+          "format": "byte",
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "File response",
+          "description": "File response"
+        },
+        "fileString": {
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "File response as string",
+          "description": "File response as string"
+        },
+        "mimeType": {
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "MIME type",
+          "description": "MIME type"
+        },
+        "extension": {
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "Extension",
+          "description": "Extension"
+        },
+        "notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-ms-visibility": "important",
+          "x-ms-summary": "Notes",
+          "description": "Human-readable notes about adjustments made during parsing (e.g. duplicate headers renamed, extra columns auto-added)."
         }
       },
       "additionalProperties": false
@@ -17861,7 +19033,7 @@
             "operationId": "GetWordTableStyles",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "placeholderPrefix": {
@@ -18018,6 +19190,22 @@
       },
       "additionalProperties": false
     },
+    "PdfMergeItem": {
+      "required": [
+        "file"
+      ],
+      "type": "object",
+      "properties": {
+        "file": {
+          "format": "byte",
+          "type": "string",
+          "x-ms-visibility": "important",
+          "x-ms-summary": "File",
+          "description": "PDF file to merge."
+        }
+      },
+      "additionalProperties": false
+    },
     "Pdf_Metadata": {
       "type": "object",
       "properties": {
@@ -18123,7 +19311,7 @@
             "operationId": "GetRegexOptions",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "isMatch": {
@@ -18134,7 +19322,7 @@
         },
         "matches": {
           "type": "array",
-          "items": { }
+          "items": {}
         },
         "firstMatch": {
           "x-ms-visibility": "important",
@@ -18178,7 +19366,7 @@
             "operationId": "GetRegexOptions",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -18201,7 +19389,7 @@
             "operationId": "GetWordSectionTypes",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "sectionContent": {
@@ -18434,7 +19622,7 @@
             "operationId": "GetWordTableStyles",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         }
       },
@@ -18459,7 +19647,7 @@
             "operationId": "GetWordSectionTypes",
             "value-path": "name",
             "value-title": "name",
-            "parameters": { }
+            "parameters": {}
           }
         },
         "text": {
@@ -18538,7 +19726,7 @@
   },
   "security": [
     {
-      "ApiKey": [ ]
+      "ApiKey": []
     }
   ],
   "x-ms-connector-metadata": [


### PR DESCRIPTION
## Converter by Power2Apps v1.0.11

Updated by `p2a-connectorsubmission_github-mirror`.

**Files:**
- `certified-connectors/Converter by Power2Apps/apiDefinition.swagger.json`
- `certified-connectors/Converter by Power2Apps/Readme.md`

**Sources:**
- `apiDefinition.swagger.json` ← live service `https://webapiconverterservice20211014190508.azurewebsites.net` (version 1.0.11)
- `Readme.md` ← bundle `Converter by Power2Apps_v11.zip`

Listing fields in `apiProperties.json` (publisher, brand color, capabilities, stack owner) are preserved as-is.