### PR TITLE
Whisper Agent Identity (Independent Publisher)

### DIFF
--- a/independent-publisher-connectors/Whisper Agent Identity/apiDefinition.swagger.json
+++ b/independent-publisher-connectors/Whisper Agent Identity/apiDefinition.swagger.json
@@ -1,0 +1,586 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Whisper Agent Identity",
+    "description": "Verify the identity of an AI agent by its Whisper IPv6 address. Whisper gives every agent a real, routable IPv6 /128 identity (from 2a04:2a01::/32, AS219419) anchored in DNS. This connector wraps Whisper's public, keyless identity surface: ask \"is this IP a real Whisper agent, and whose?\" and get one signed-where-possible verdict; look up the RDAP record for a /128; read the tamper-evident issuance/revocation transparency log; and see who has been resolving an agent's name. No account, credentials, or API key are required.",
+    "version": "1.0",
+    "contact": {
+      "name": "Whisper Security",
+      "url": "https://whisper.online",
+      "email": "hostmaster@whisper.online"
+    }
+  },
+  "host": "rdap.whisper.online",
+  "basePath": "/",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/verify-identity": {
+      "get": {
+        "summary": "Verify agent identity",
+        "description": "Run the full Whisper-agent verification chain server-side for one IPv6 address (reverse PTR, forward-confirm AAAA / FCrDNS, DANE-TLSA pin, and the signed identity document) and return a single verdict: whether the address is a real Whisper agent, its canonical hostname, its operator/tenant handle, and the supporting evidence. Returns HTTP 200 when the address is a Whisper agent and HTTP 404 (with is_whisper_agent=false) when it is not.",
+        "operationId": "VerifyIdentity",
+        "parameters": [
+          {
+            "name": "ip",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "x-ms-summary": "Agent IPv6 address",
+            "description": "The IPv6 /128 address to verify, e.g. 2a04:2a01:b69a:6717:e3b0:51ff:3bf7:f478.",
+            "default": "2a04:2a01:b69a:6717:e3b0:51ff:3bf7:f478"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The address is a Whisper agent; the verdict describes how strongly it verified.",
+            "schema": {
+              "$ref": "#/definitions/VerifyResult"
+            }
+          },
+          "404": {
+            "description": "The address is not a Whisper agent (no anchoring identity). Body carries is_whisper_agent=false.",
+            "schema": {
+              "$ref": "#/definitions/VerifyResult"
+            }
+          }
+        }
+      }
+    },
+    "/ip/{address}": {
+      "get": {
+        "summary": "RDAP lookup for an agent address",
+        "description": "Return the RDAP (RFC 9082/9083) record for a Whisper agent IPv6 /128: its handle, canonical name, registrant/operator entity, status, country, registration event, behavioural posture, and related links. Returns HTTP 404 when the address has no Whisper agent identity.",
+        "operationId": "LookupRdap",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "x-ms-summary": "Agent IPv6 address",
+            "description": "The IPv6 /128 address to look up, e.g. 2a04:2a01:b69a:6717:e3b0:51ff:3bf7:f478.",
+            "default": "2a04:2a01:b69a:6717:e3b0:51ff:3bf7:f478"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The RDAP IP-network record for the agent address.",
+            "schema": {
+              "$ref": "#/definitions/RdapIpNetwork"
+            }
+          },
+          "404": {
+            "description": "No Whisper agent identity for this address.",
+            "schema": {
+              "$ref": "#/definitions/RdapError"
+            }
+          }
+        }
+      }
+    },
+    "/ip/{address}/transparency": {
+      "get": {
+        "summary": "Get identity transparency log",
+        "description": "Return the public, append-only, tamper-evident transparency log for an agent IPv6 /128: the ordered feed of issuance and revocation events, each chained to the previous by a SHA-256 proof, with a signed (ES256) chain root and an inclusion proof against the global Merkle ledger. A consumer can recompute the chain and verify the signature independently.",
+        "operationId": "GetTransparency",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "x-ms-summary": "Agent IPv6 address",
+            "description": "The IPv6 /128 address whose transparency log to read, e.g. 2a04:2a01:b69a:6717:e3b0:51ff:3bf7:f478.",
+            "default": "2a04:2a01:b69a:6717:e3b0:51ff:3bf7:f478"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "x-ms-summary": "Maximum events",
+            "description": "Maximum number of events to return (default 1000, capped at 10000).",
+            "x-ms-visibility": "advanced"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The (possibly empty) chained transparency feed for the address.",
+            "schema": {
+              "$ref": "#/definitions/TransparencyFeed"
+            }
+          },
+          "400": {
+            "description": "Malformed IP address."
+          }
+        }
+      }
+    },
+    "/ip/{address}/lookups": {
+      "get": {
+        "summary": "Get inbound identity lookups",
+        "description": "Return the public feed of who has resolved or queried this agent's name: the PTR / AAAA / TLSA lookups against its authoritative-zone records and the RDAP accesses to it, each row k-anonymised to the source /48 (IPv6) or /24 (IPv4) prefix. It is the reverse-observability companion to an agent's own outbound resolution log.",
+        "operationId": "GetLookups",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "x-ms-summary": "Agent IPv6 address",
+            "description": "The IPv6 /128 address whose inbound lookups to read, e.g. 2a04:2a01:b69a:6717:e3b0:51ff:3bf7:f478.",
+            "default": "2a04:2a01:b69a:6717:e3b0:51ff:3bf7:f478"
+          },
+          {
+            "name": "kind",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "dns",
+              "rdap"
+            ],
+            "x-ms-summary": "Lookup source filter",
+            "description": "Narrow the feed by lookup source: 'dns' (authoritative-zone queries) or 'rdap' (RDAP accesses). Omit for all sources.",
+            "x-ms-visibility": "advanced"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "x-ms-summary": "Maximum rows",
+            "description": "Maximum number of lookup rows to return (default 1000, capped at 10000).",
+            "x-ms-visibility": "advanced"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The (possibly empty) inbound-lookup feed for the address.",
+            "schema": {
+              "$ref": "#/definitions/LookupsFeed"
+            }
+          },
+          "400": {
+            "description": "Malformed IP address."
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "VerifyResult": {
+      "type": "object",
+      "properties": {
+        "is_whisper_agent": {
+          "type": "boolean",
+          "description": "True when the address is a verified Whisper agent identity.",
+          "title": "Is Whisper agent"
+        },
+        "fqdn": {
+          "type": "string",
+          "description": "The agent's canonical fully-qualified hostname.",
+          "title": "FQDN"
+        },
+        "operator": {
+          "type": "string",
+          "description": "The operator (tenant) handle that holds the identity.",
+          "title": "Operator"
+        },
+        "tenant": {
+          "type": "string",
+          "description": "The tenant handle that holds the identity.",
+          "title": "Tenant"
+        },
+        "dane_ok": {
+          "type": "boolean",
+          "description": "True when a strong DANE-EE TLSA pin is published (and, when checkable, the served leaf matches it).",
+          "title": "DANE OK"
+        },
+        "jws_ok": {
+          "type": "boolean",
+          "description": "True when the signed identity document verified against the fleet key.",
+          "title": "JWS OK"
+        },
+        "verified_at": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Epoch-millisecond timestamp at which the verdict was produced.",
+          "title": "Verified at"
+        },
+        "detail": {
+          "type": "string",
+          "description": "Human-readable explanation, present on a negative verdict.",
+          "title": "Detail"
+        },
+        "evidence": {
+          "type": "object",
+          "description": "The supporting evidence gathered during verification.",
+          "title": "Evidence",
+          "properties": {
+            "address": {
+              "type": "string",
+              "description": "The address that was verified.",
+              "title": "Address"
+            },
+            "ptr": {
+              "type": "string",
+              "description": "The reverse-DNS PTR name for the address (null when none).",
+              "title": "PTR"
+            },
+            "forward_aaaa": {
+              "type": "string",
+              "description": "The forward-confirming AAAA record (FCrDNS).",
+              "title": "Forward AAAA"
+            },
+            "agent": {
+              "type": "string",
+              "description": "The opaque agent handle.",
+              "title": "Agent"
+            },
+            "allocated_at": {
+              "type": "integer",
+              "format": "int64",
+              "description": "Epoch-millisecond time the address was allocated to the agent.",
+              "title": "Allocated at"
+            },
+            "posture": {
+              "type": "string",
+              "description": "The agent's connectivity posture (e.g. tier1, tier1.5).",
+              "title": "Posture"
+            },
+            "dane_tlsa_sha256": {
+              "type": "string",
+              "description": "The SHA-256 DANE-TLSA association data pinned in DNS.",
+              "title": "DANE TLSA SHA-256"
+            },
+            "rdap": {
+              "type": "string",
+              "description": "Canonical RDAP URL for the address.",
+              "title": "RDAP URL"
+            },
+            "identity_doc": {
+              "type": "string",
+              "description": "URL of the agent's signed identity document.",
+              "title": "Identity document URL"
+            }
+          }
+        }
+      }
+    },
+    "RdapIpNetwork": {
+      "type": "object",
+      "properties": {
+        "rdapConformance": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "RDAP conformance levels.",
+          "title": "RDAP conformance"
+        },
+        "objectClassName": {
+          "type": "string",
+          "description": "RDAP object class (ip network).",
+          "title": "Object class"
+        },
+        "handle": {
+          "type": "string",
+          "description": "The agent handle.",
+          "title": "Handle"
+        },
+        "startAddress": {
+          "type": "string",
+          "description": "First address of the network (equals endAddress for a /128).",
+          "title": "Start address"
+        },
+        "endAddress": {
+          "type": "string",
+          "description": "Last address of the network (equals startAddress for a /128).",
+          "title": "End address"
+        },
+        "ipVersion": {
+          "type": "string",
+          "description": "IP version (v6).",
+          "title": "IP version"
+        },
+        "name": {
+          "type": "string",
+          "description": "The agent name.",
+          "title": "Name"
+        },
+        "type": {
+          "type": "string",
+          "description": "The record type (Whisper agent identity).",
+          "title": "Type"
+        },
+        "status": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "RDAP status values (e.g. active).",
+          "title": "Status"
+        },
+        "country": {
+          "type": "string",
+          "description": "ISO country code.",
+          "title": "Country"
+        },
+        "behavioral_posture": {
+          "type": "string",
+          "description": "The agent's behavioural posture (e.g. clean-30d).",
+          "title": "Behavioural posture"
+        },
+        "entities": {
+          "type": "array",
+          "description": "Related RDAP entities (e.g. the registrant).",
+          "title": "Entities",
+          "items": {
+            "type": "object",
+            "properties": {
+              "objectClassName": {
+                "type": "string",
+                "title": "Object class"
+              },
+              "handle": {
+                "type": "string",
+                "title": "Handle"
+              },
+              "roles": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "title": "Roles"
+              }
+            }
+          }
+        },
+        "events": {
+          "type": "array",
+          "description": "RDAP events (e.g. registration).",
+          "title": "Events",
+          "items": {
+            "type": "object",
+            "properties": {
+              "eventAction": {
+                "type": "string",
+                "title": "Event action"
+              },
+              "eventDate": {
+                "type": "string",
+                "title": "Event date"
+              }
+            }
+          }
+        }
+      }
+    },
+    "RdapError": {
+      "type": "object",
+      "properties": {
+        "rdapConformance": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "RDAP conformance"
+        },
+        "errorCode": {
+          "type": "integer",
+          "description": "HTTP-style RDAP error code.",
+          "title": "Error code"
+        },
+        "title": {
+          "type": "string",
+          "description": "Short error title.",
+          "title": "Title"
+        },
+        "description": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Human-readable error detail.",
+          "title": "Description"
+        }
+      }
+    },
+    "TransparencyFeed": {
+      "type": "object",
+      "properties": {
+        "object": {
+          "type": "string",
+          "description": "Object type (identity-transparency).",
+          "title": "Object"
+        },
+        "address": {
+          "type": "string",
+          "description": "The address the feed describes.",
+          "title": "Address"
+        },
+        "count": {
+          "type": "integer",
+          "description": "Number of events in the feed.",
+          "title": "Count"
+        },
+        "events": {
+          "type": "array",
+          "description": "The ordered, hash-chained identity events.",
+          "title": "Events",
+          "items": {
+            "type": "object",
+            "properties": {
+              "event": {
+                "type": "object",
+                "title": "Event",
+                "properties": {
+                  "action": {
+                    "type": "string",
+                    "description": "issuance or revocation.",
+                    "title": "Action"
+                  },
+                  "address": {
+                    "type": "string",
+                    "title": "Address"
+                  },
+                  "holder": {
+                    "type": "string",
+                    "description": "The opaque holder (tenant) handle.",
+                    "title": "Holder"
+                  },
+                  "agent": {
+                    "type": "string",
+                    "title": "Agent"
+                  },
+                  "timestamp": {
+                    "type": "integer",
+                    "format": "int64",
+                    "title": "Timestamp"
+                  }
+                }
+              },
+              "proof": {
+                "type": "string",
+                "description": "SHA-256(prev_proof || event_json) chaining this event.",
+                "title": "Proof"
+              },
+              "prev_proof": {
+                "type": "string",
+                "description": "The proof of the previous event (empty for the base event).",
+                "title": "Previous proof"
+              }
+            }
+          }
+        },
+        "root_hash": {
+          "type": "string",
+          "description": "The hash-chain root.",
+          "title": "Root hash"
+        },
+        "root_signature": {
+          "type": "string",
+          "description": "ES256 JWS over the chain root (empty when unsigned).",
+          "title": "Root signature"
+        },
+        "root_signature_alg": {
+          "type": "string",
+          "description": "Signature algorithm (ES256).",
+          "title": "Root signature algorithm"
+        }
+      }
+    },
+    "LookupsFeed": {
+      "type": "object",
+      "properties": {
+        "object": {
+          "type": "string",
+          "description": "Object type (identity-lookups).",
+          "title": "Object"
+        },
+        "address": {
+          "type": "string",
+          "description": "The address the feed describes.",
+          "title": "Address"
+        },
+        "count": {
+          "type": "integer",
+          "description": "Number of lookup rows in the feed.",
+          "title": "Count"
+        },
+        "lookups": {
+          "type": "array",
+          "description": "The inbound lookup rows (who resolved/queried this agent).",
+          "title": "Lookups",
+          "items": {
+            "type": "object",
+            "properties": {
+              "ts": {
+                "type": "integer",
+                "format": "int64",
+                "description": "Epoch-millisecond time of the lookup.",
+                "title": "Timestamp"
+              },
+              "kind": {
+                "type": "string",
+                "title": "Kind"
+              },
+              "qname": {
+                "type": "string",
+                "description": "The queried name.",
+                "title": "Query name"
+              },
+              "qtype": {
+                "type": "string",
+                "description": "The query type (PTR, AAAA, TLSA, RDAP).",
+                "title": "Query type"
+              },
+              "rcode": {
+                "type": "string",
+                "description": "The response code / outcome.",
+                "title": "Response code"
+              },
+              "source": {
+                "type": "string",
+                "description": "The lookup source (auth-zone or rdap).",
+                "title": "Source"
+              },
+              "agent": {
+                "type": "string",
+                "title": "Agent"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "parameters": {},
+  "responses": {},
+  "securityDefinitions": {},
+  "security": [],
+  "tags": [],
+  "x-ms-connector-metadata": [
+    {
+      "propertyName": "Website",
+      "propertyValue": "https://whisper.online/"
+    },
+    {
+      "propertyName": "Privacy policy",
+      "propertyValue": "https://whisper.online/"
+    },
+    {
+      "propertyName": "Categories",
+      "propertyValue": "Data;IT Operations"
+    }
+  ]
+}

--- a/independent-publisher-connectors/Whisper Agent Identity/apiDefinition.swagger.json
+++ b/independent-publisher-connectors/Whisper Agent Identity/apiDefinition.swagger.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "Whisper Agent Identity",
-    "description": "Verify the identity of an AI agent by its Whisper IPv6 address. Whisper gives every agent a real, routable IPv6 /128 identity (from 2a04:2a01::/32, AS219419) anchored in DNS. This connector wraps Whisper's public, keyless identity surface: ask \"is this IP a real Whisper agent, and whose?\" and get one signed-where-possible verdict; look up the RDAP record for a /128; read the tamper-evident issuance/revocation transparency log; and see who has been resolving an agent's name. No account, credentials, or API key are required.",
+    "description": "Give every AI agent a real, routable IPv6 /128 identity (from 2a04:2a01::/32, announced by AS219419) anchored in DNS, RDAP and a tamper-evident transparency log — and operate it from Power Platform. This is a TWO-TIER connector (Postel's law): with NO key the public, keyless identity operations answer \"is this IP a real Whisper agent, and whose?\", return its RDAP record, its transparency log and who has been resolving its name. Provide your Whisper API key (optional connection field) and the full control plane unlocks — register agents, list your fleet, set per-tenant resolver policy, read activity logs, and revoke. Keyless operations keep working with or without a key.",
     "version": "1.0",
     "contact": {
       "name": "Whisper Security",
@@ -171,6 +171,216 @@
           },
           "400": {
             "description": "Malformed IP address."
+          }
+        }
+      }
+    },
+    "/control/register": {
+      "post": {
+        "summary": "Register a new agent",
+        "description": "Mint a brand-new agent with its own routable IPv6 /128 identity AND its own API key (op:register). The new key is returned once in the result — capture it. Requires your API key in the connection. Edit the label (the agent's human name) and optional contact_email inside args.",
+        "operationId": "RegisterAgent",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "required": [
+                "query"
+              ],
+              "properties": {
+                "query": {
+                  "type": "string",
+                  "x-ms-summary": "Control call",
+                  "description": "The whisper.agents control call to run, expressed as a Cypher CALL. It is pre-filled for this operation — edit the values inside args. Sent verbatim in {\"query\": ...}; keep it well-formed.",
+                  "default": "CALL whisper.agents({op:'register', args:{label:'my-agent'}})"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The control-plane result table (columns + rows).",
+            "schema": {
+              "$ref": "#/definitions/ControlResult"
+            }
+          },
+          "400": {
+            "description": "The request was rejected — e.g. an anonymous call to the control plane (a Whisper API key is required in the connection) or a malformed query.",
+            "schema": {
+              "$ref": "#/definitions/ControlError"
+            }
+          }
+        }
+      }
+    },
+    "/control/list": {
+      "post": {
+        "summary": "List your agents",
+        "description": "List the caller's agents (or, with kind:'records' / kind:'identities', those instead), confined to your tenant (op:list). Requires your API key in the connection.",
+        "operationId": "ListAgents",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "required": [
+                "query"
+              ],
+              "properties": {
+                "query": {
+                  "type": "string",
+                  "x-ms-summary": "Control call",
+                  "description": "The whisper.agents control call to run, expressed as a Cypher CALL. It is pre-filled for this operation — edit the values inside args. Sent verbatim in {\"query\": ...}; keep it well-formed.",
+                  "default": "CALL whisper.agents({op:'list', args:{kind:'agents'}})"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The control-plane result table (columns + rows).",
+            "schema": {
+              "$ref": "#/definitions/ControlResult"
+            }
+          },
+          "400": {
+            "description": "The request was rejected — e.g. an anonymous call to the control plane (a Whisper API key is required in the connection) or a malformed query.",
+            "schema": {
+              "$ref": "#/definitions/ControlError"
+            }
+          }
+        }
+      }
+    },
+    "/control/policy": {
+      "post": {
+        "summary": "Set resolver policy",
+        "description": "Read or set your per-tenant DNS resolver policy (op:policy). default is 'allow' or 'deny'; block and allow are name lists (max 1000 combined). Omit block/allow/default to READ the current policy back. Requires your API key in the connection.",
+        "operationId": "SetPolicy",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "required": [
+                "query"
+              ],
+              "properties": {
+                "query": {
+                  "type": "string",
+                  "x-ms-summary": "Control call",
+                  "description": "The whisper.agents control call to run, expressed as a Cypher CALL. It is pre-filled for this operation — edit the values inside args. Sent verbatim in {\"query\": ...}; keep it well-formed.",
+                  "default": "CALL whisper.agents({op:'policy', args:{default:'allow', block:['ads.example.com']}})"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The control-plane result table (columns + rows).",
+            "schema": {
+              "$ref": "#/definitions/ControlResult"
+            }
+          },
+          "400": {
+            "description": "The request was rejected — e.g. an anonymous call to the control plane (a Whisper API key is required in the connection) or a malformed query.",
+            "schema": {
+              "$ref": "#/definitions/ControlError"
+            }
+          }
+        }
+      }
+    },
+    "/control/logs": {
+      "post": {
+        "summary": "Get activity logs",
+        "description": "Query the caller's recent DNS / connection / allocation activity from warm storage (op:logs). kind is dns | conn | alloc | all; narrow with agent (id or /128), from / to (epoch-ms, RFC-3339, or relative like -1h), and limit (default 1000, cap 10000). Requires your API key in the connection.",
+        "operationId": "GetLogs",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "required": [
+                "query"
+              ],
+              "properties": {
+                "query": {
+                  "type": "string",
+                  "x-ms-summary": "Control call",
+                  "description": "The whisper.agents control call to run, expressed as a Cypher CALL. It is pre-filled for this operation — edit the values inside args. Sent verbatim in {\"query\": ...}; keep it well-formed.",
+                  "default": "CALL whisper.agents({op:'logs', args:{kind:'all', limit:100}})"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The control-plane result table (columns + rows).",
+            "schema": {
+              "$ref": "#/definitions/ControlResult"
+            }
+          },
+          "400": {
+            "description": "The request was rejected — e.g. an anonymous call to the control plane (a Whisper API key is required in the connection) or a malformed query.",
+            "schema": {
+              "$ref": "#/definitions/ControlError"
+            }
+          }
+        }
+      }
+    },
+    "/control/revoke": {
+      "post": {
+        "summary": "Revoke an agent",
+        "description": "Fully revoke an agent (op:revoke): withdraw its /128, PTR, tokens and its API key. IRREVERSIBLE. Set agent to the agent id (or its /128 address). Requires your API key in the connection.",
+        "operationId": "RevokeAgent",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "required": [
+                "query"
+              ],
+              "properties": {
+                "query": {
+                  "type": "string",
+                  "x-ms-summary": "Control call",
+                  "description": "The whisper.agents control call to run, expressed as a Cypher CALL. It is pre-filled for this operation — edit the values inside args. Sent verbatim in {\"query\": ...}; keep it well-formed.",
+                  "default": "CALL whisper.agents({op:'revoke', args:{agent:'agent-abcd1234'}})"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The control-plane result table (columns + rows).",
+            "schema": {
+              "$ref": "#/definitions/ControlResult"
+            }
+          },
+          "400": {
+            "description": "The request was rejected — e.g. an anonymous call to the control plane (a Whisper API key is required in the connection) or a malformed query.",
+            "schema": {
+              "$ref": "#/definitions/ControlError"
+            }
           }
         }
       }
@@ -560,6 +770,93 @@
               }
             }
           }
+        }
+      }
+    },
+    "ControlTable": {
+      "type": "object",
+      "description": "A control-plane result table: column names plus rows of positionally-aligned values.",
+      "properties": {
+        "columns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Column names.",
+          "title": "Columns"
+        },
+        "rows": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {}
+          },
+          "description": "Rows; each row is an array of values aligned with columns.",
+          "title": "Rows"
+        }
+      }
+    },
+    "ControlError": {
+      "type": "object",
+      "description": "RFC 7807 problem object returned when a control call fails.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "title": "Type"
+        },
+        "title": {
+          "type": "string",
+          "title": "Title"
+        },
+        "status": {
+          "type": "integer",
+          "title": "Status"
+        },
+        "detail": {
+          "type": "string",
+          "description": "Human-readable, secret-free explanation.",
+          "title": "Detail"
+        },
+        "suggestions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "Suggestions"
+        }
+      }
+    },
+    "ControlResult": {
+      "type": "object",
+      "description": "The normalised control-plane reply. The live control plane returns the Neo4j procedure-row wrapper (rows[].result); the documented envelope shape (ok/status/result/error) is also accepted.",
+      "properties": {
+        "ok": {
+          "type": "boolean",
+          "description": "True on success (documented envelope shape).",
+          "title": "OK"
+        },
+        "status": {
+          "type": "integer",
+          "title": "Status"
+        },
+        "rows": {
+          "type": "array",
+          "description": "The live wrapper: each element carries a result table.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "result": {
+                "$ref": "#/definitions/ControlTable"
+              }
+            }
+          },
+          "title": "Rows"
+        },
+        "result": {
+          "$ref": "#/definitions/ControlTable"
+        },
+        "error": {
+          "$ref": "#/definitions/ControlError"
         }
       }
     }

--- a/independent-publisher-connectors/Whisper Agent Identity/apiProperties.json
+++ b/independent-publisher-connectors/Whisper Agent Identity/apiProperties.json
@@ -1,0 +1,9 @@
+{
+  "properties": {
+    "connectionParameters": {},
+    "iconBrandColor": "#7a40ff",
+    "capabilities": [],
+    "publisher": "Whisper Security",
+    "stackOwner": "Whisper Security"
+  }
+}

--- a/independent-publisher-connectors/Whisper Agent Identity/apiProperties.json
+++ b/independent-publisher-connectors/Whisper Agent Identity/apiProperties.json
@@ -1,8 +1,70 @@
 {
   "properties": {
-    "connectionParameters": {},
+    "connectionParameters": {
+      "api_key": {
+        "type": "securestring",
+        "uiDefinition": {
+          "displayName": "Whisper API key (optional)",
+          "description": "Your Whisper API key (whisper_live_...). Leave blank to use only the keyless identity operations (verify, RDAP, transparency, lookups). Provide it to unlock the control plane: register, list, set policy, logs, revoke.",
+          "tooltip": "Optional. From 'whisper login' or the Whisper dashboard.",
+          "constraints": {
+            "tabIndex": 1,
+            "clearText": false,
+            "required": "false"
+          }
+        }
+      }
+    },
     "iconBrandColor": "#7a40ff",
     "capabilities": [],
+    "policyTemplateInstances": [
+      {
+        "templateId": "dynamichosturl",
+        "title": "Route control operations to the Whisper control plane",
+        "parameters": {
+          "x-ms-apimTemplateParameter.urlTemplate": "https://graph.whisper.security",
+          "x-ms-apimTemplate-operationName": [
+            "RegisterAgent",
+            "ListAgents",
+            "SetPolicy",
+            "GetLogs",
+            "RevokeAgent"
+          ]
+        }
+      },
+      {
+        "templateId": "routerequesttoendpoint",
+        "title": "Send control operations to /api/query",
+        "parameters": {
+          "x-ms-apimTemplateParameter.newPath": "/api/query",
+          "x-ms-apimTemplateParameter.httpMethod": "@Request.OriginalHTTPMethod",
+          "x-ms-apimTemplate-operationName": [
+            "RegisterAgent",
+            "ListAgents",
+            "SetPolicy",
+            "GetLogs",
+            "RevokeAgent"
+          ]
+        }
+      },
+      {
+        "templateId": "setheader",
+        "title": "Attach the Whisper API key to control operations",
+        "parameters": {
+          "x-ms-apimTemplateParameter.name": "X-API-Key",
+          "x-ms-apimTemplateParameter.value": "@connectionParameters('api_key')",
+          "x-ms-apimTemplateParameter.existsAction": "override",
+          "x-ms-apimTemplate-policySection": "Request",
+          "x-ms-apimTemplate-operationName": [
+            "RegisterAgent",
+            "ListAgents",
+            "SetPolicy",
+            "GetLogs",
+            "RevokeAgent"
+          ]
+        }
+      }
+    ],
     "publisher": "Whisper Security",
     "stackOwner": "Whisper Security"
   }

--- a/independent-publisher-connectors/Whisper Agent Identity/readme.md
+++ b/independent-publisher-connectors/Whisper Agent Identity/readme.md
@@ -1,38 +1,51 @@
 # Whisper Agent Identity
 
-Verify the identity of an AI agent by its Whisper IPv6 address.
+Give every AI agent a real, routable IPv6 `/128` identity — and operate it from Power Platform.
 
-Whisper gives every agent a real, routable IPv6 `/128` identity (allocated from `2a04:2a01::/32`, announced by AS219419) that is anchored in DNS and RDAP. This connector wraps Whisper's public, keyless identity surface so a flow, app, or copilot can answer one question — *"is this IP a real Whisper agent, and whose?"* — and inspect the supporting evidence, without stitching four protocols together itself.
+Whisper allocates each agent an IPv6 `/128` from `2a04:2a01::/32` (announced by AS219419), anchored in DNS, RDAP and a tamper-evident transparency log. This connector is **two-tier** (Postel's law — *be liberal in what you accept*):
+
+- **Keyless (no account, no key).** Verify whether an IP is a real Whisper agent and whose it is, read its RDAP record, its identity transparency log, and who has been resolving its name.
+- **Keyed (your Whisper API key).** Unlock the control plane: register agents, list your fleet, set per-tenant resolver policy, read activity logs, and revoke.
+
+The API key is an **optional** connection field. Leave it blank and the keyless operations work exactly as before; fill it in and the control operations light up. The keyless operations keep working with or without a key.
 
 ## Publisher: Whisper Security
 
 ## Prerequisites
 
-There are no prerequisites to use this connector. All operations are public and keyless — no account, credential, or API key is required.
+- **Keyless operations:** none. No account, credential, or API key.
+- **Control operations:** a Whisper API key (`whisper_live_...`), entered in the optional **Whisper API key** connection field.
 
 ## Obtaining Credentials
 
-There are no credentials needed to use this service. The connector uses anonymous access.
+Run `whisper login` with the Whisper CLI, or copy your key from the Whisper dashboard. The connector accepts the key as an optional connection parameter; it is sent as the `X-API-Key` header **only** on the control operations, and only to the Whisper control plane.
 
 ## Supported Operations
 
-### Verify agent identity
+### Keyless (public) — `rdap.whisper.online`
 
-Run the full Whisper-agent verification chain server-side for one IPv6 address — reverse DNS (PTR), forward-confirm (AAAA / FCrDNS), DANE-TLSA pin, and the signed identity document — and return a single verdict: whether the address is a real Whisper agent, its canonical hostname, its operator/tenant handle, and the supporting evidence.
+| Operation | Description |
+|---|---|
+| **Verify agent identity** | Full verification chain (PTR + FCrDNS AAAA + DANE-TLSA + signed identity doc) → one verdict. |
+| **RDAP lookup for an agent address** | RDAP (RFC 9082/9083) record for a `/128`. |
+| **Get identity transparency log** | Append-only, hash-chained, ES256-signed issuance/revocation log. |
+| **Get inbound identity lookups** | Who resolved/queried the agent's name (k-anonymised source prefixes). |
 
-### RDAP lookup for an agent address
+### Control (requires your API key) — `graph.whisper.security`
 
-Return the RDAP (RFC 9082 / 9083) record for a Whisper agent IPv6 `/128`: handle, canonical name, registrant/operator entity, status, country, registration event, behavioural posture, and related links.
+| Operation | Description |
+|---|---|
+| **Register a new agent** | Mint a new agent with its own `/128` and its own API key (returned once). |
+| **List your agents** | List your fleet (or records / identities), confined to your tenant. |
+| **Set resolver policy** | Read or set your per-tenant DNS policy (default allow/deny + block/allow lists). |
+| **Get activity logs** | Query recent DNS / connection / allocation activity from warm storage. |
+| **Revoke an agent** | Fully revoke an agent — withdraw its `/128`, PTR, tokens and key. Irreversible. |
 
-### Get identity transparency log
-
-Return the public, append-only, tamper-evident transparency log for an agent `/128`: the ordered feed of issuance and revocation events, each chained to the previous by a SHA-256 proof, with a signed (ES256) chain root and an inclusion proof against the global Merkle ledger.
-
-### Get inbound identity lookups
-
-Return the public feed of who has resolved or queried this agent's name — the PTR / AAAA / TLSA lookups against its authoritative-zone records and the RDAP accesses to it — each row k-anonymised to the source `/48` (IPv6) or `/24` (IPv4) prefix.
+Each control operation carries a **`query`** field pre-filled with the exact `whisper.agents` control call for that operation (a Cypher `CALL`). Edit the values inside `args` (e.g. the agent label, the policy lists); the connector POSTs `{"query": ...}` to the control plane.
 
 ## Known Issues and Limitations
 
-- Operations describe IPv6 `/128` agent identities allocated from `2a04:2a01::/32`. An address with no Whisper agent identity returns a clean *not found* (HTTP 404) rather than an error.
-- The transparency and inbound-lookups feeds are live and are not cached.
+- **Single connection, two tiers.** The API key field is optional; keyless operations ignore it and resolve regardless. A control operation invoked with no key returns a clear `400` — *"anonymous callers cannot use the agent control plane — an attributable API key is required"* — never an opaque error.
+- Control operations take the control call as a `query` string (pre-filled per operation). Values inside `args` are sent verbatim; keep them well-formed.
+- An address with no Whisper agent identity returns a clean *not found* (HTTP 404), not an error.
+- No connector icon is submitted (independent-publisher connectors do not ship icons); the brand colour `#7a40ff` is set instead.

--- a/independent-publisher-connectors/Whisper Agent Identity/readme.md
+++ b/independent-publisher-connectors/Whisper Agent Identity/readme.md
@@ -1,0 +1,38 @@
+# Whisper Agent Identity
+
+Verify the identity of an AI agent by its Whisper IPv6 address.
+
+Whisper gives every agent a real, routable IPv6 `/128` identity (allocated from `2a04:2a01::/32`, announced by AS219419) that is anchored in DNS and RDAP. This connector wraps Whisper's public, keyless identity surface so a flow, app, or copilot can answer one question — *"is this IP a real Whisper agent, and whose?"* — and inspect the supporting evidence, without stitching four protocols together itself.
+
+## Publisher: Whisper Security
+
+## Prerequisites
+
+There are no prerequisites to use this connector. All operations are public and keyless — no account, credential, or API key is required.
+
+## Obtaining Credentials
+
+There are no credentials needed to use this service. The connector uses anonymous access.
+
+## Supported Operations
+
+### Verify agent identity
+
+Run the full Whisper-agent verification chain server-side for one IPv6 address — reverse DNS (PTR), forward-confirm (AAAA / FCrDNS), DANE-TLSA pin, and the signed identity document — and return a single verdict: whether the address is a real Whisper agent, its canonical hostname, its operator/tenant handle, and the supporting evidence.
+
+### RDAP lookup for an agent address
+
+Return the RDAP (RFC 9082 / 9083) record for a Whisper agent IPv6 `/128`: handle, canonical name, registrant/operator entity, status, country, registration event, behavioural posture, and related links.
+
+### Get identity transparency log
+
+Return the public, append-only, tamper-evident transparency log for an agent `/128`: the ordered feed of issuance and revocation events, each chained to the previous by a SHA-256 proof, with a signed (ES256) chain root and an inclusion proof against the global Merkle ledger.
+
+### Get inbound identity lookups
+
+Return the public feed of who has resolved or queried this agent's name — the PTR / AAAA / TLSA lookups against its authoritative-zone records and the RDAP accesses to it — each row k-anonymised to the source `/48` (IPv6) or `/24` (IPv4) prefix.
+
+## Known Issues and Limitations
+
+- Operations describe IPv6 `/128` agent identities allocated from `2a04:2a01::/32`. An address with no Whisper agent identity returns a clean *not found* (HTTP 404) rather than an error.
+- The transparency and inbound-lookups feeds are live and are not cached.


### PR DESCRIPTION
Whisper Agent Identity (Independent Publisher)

---
### When submitting a connector, please make sure that you follow the requirements below, otherwise your PR might be rejected.

- [x] I attest that the connector doesn't exist on the Power Platform today. I've verified by checking the pull requests in GitHub and by searching for the connector on the platform or in the documentation.
- [x] I attest that the connector works and I verified by deploying and testing all the operations.
- [x] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [x] I attest that I have added response schemas to my actions, unless the response schema is dynamic.
- [x] I validated the swagger file, `apiDefinition.swagger.json`. (Validated as OpenAPI 2.0 with `openapi-spec-validator`; `paconn validate` requires an interactive Power Platform sign-in.)
- [x] If this is an independent publisher connector, I confirm that I am not submitting a connector icon. (No icon is included; only `iconBrandColor` is set.)

Independent Publisher attestations:
- [x] I have named this PR after the pattern of "Connector Name (Independent Publisher)".
- [ ] Within this PR I have pasted screenshots that show 3 unique operations working within a Flow, with each Flow succeeding. **<-- add screenshots**
- [ ] Within this PR I have pasted a screenshot from the Test operations section within the Custom Connector UI. **<-- add screenshot**
- [x] If the connector uses OAuth, I have provided detailed steps on how to create an app in the readme.md. (N/A — no OAuth. The only credential is an optional API key, documented in the readme.)

---

## Whisper Agent Identity

Give every AI agent a real, routable IPv6 `/128` identity (from `2a04:2a01::/32`, announced by AS219419), anchored in DNS, RDAP and a tamper-evident transparency log — and operate it from Power Platform.

This is a **two-tier** connector (Postel's law):

- **Keyless (no key):** verify an agent's identity by its IPv6 address, look up its RDAP record, read its transparency log, and see who has been resolving its name. Served from `rdap.whisper.online`.
- **Keyed (your Whisper API key):** register agents, list your fleet, set per-tenant resolver policy, read activity logs, and revoke. Served from the Whisper control plane.

### Single connection, both tiers

The API key is an **optional** connection parameter (`api_key`, `securestring`, `required: false`). It is injected as the `X-API-Key` header **only** on the five control operations (via a `setheader` policy), and those operations are routed to the control-plane host/path with `dynamichosturl` + `routerequesttoendpoint`. The four keyless operations stay on the default host and require no key. So:

- Leave the key blank → keyless operations work; a control operation returns a clear `400` ("an attributable API key is required").
- Provide the key → the full control plane unlocks; keyless operations keep working.

This is the same no-auth-plus-connection-parameter-plus-policy pattern used by existing connectors in this repo (e.g. ExchangeRate), so a single connector covers both tiers without a second auth policy.

### Operations

| Operation | Tier | Description |
|---|---|---|
| Verify agent identity | keyless | Full verification chain (PTR + FCrDNS AAAA + DANE-TLSA + signed identity doc) → one verdict. |
| RDAP lookup for an agent address | keyless | RDAP (RFC 9082/9083) record for a `/128`. |
| Get identity transparency log | keyless | Append-only, hash-chained, ES256-signed issuance/revocation log. |
| Get inbound identity lookups | keyless | Who resolved/queried the agent's name (k-anonymised source prefixes). |
| Register a new agent | keyed | Mint a new agent + its own `/128` + its own API key (returned once). |
| List your agents | keyed | List your fleet, confined to your tenant. |
| Set resolver policy | keyed | Read/set per-tenant DNS policy (default allow/deny + block/allow lists). |
| Get activity logs | keyed | Recent DNS / connection / allocation activity. |
| Revoke an agent | keyed | Fully revoke an agent (withdraw `/128`, PTR, tokens, key). |

### Live checks (canonical example agent "scout", no key required)

```
$ curl -s "https://rdap.whisper.online/verify-identity?ip=2a04:2a01:b69a:6717:e3b0:51ff:3bf7:f478"
{ "is_whisper_agent": true, "fqdn": "...agents.whisper.online", "dane_ok": true, "jws_ok": true, ... }

$ curl -s "https://rdap.whisper.online/ip/2a04:2a01:b69a:6717:e3b0:51ff:3bf7:f478"              # RDAP
$ curl -s "https://rdap.whisper.online/ip/2a04:2a01:b69a:6717:e3b0:51ff:3bf7:f478/transparency"
$ curl -s "https://rdap.whisper.online/ip/2a04:2a01:b69a:6717:e3b0:51ff:3bf7:f478/lookups"
```

Control plane (needs your key, `whisper_live_...` — redacted here):

```
$ curl -s -X POST "https://graph.whisper.security/api/query" \
    -H 'content-type: application/json' -H 'X-API-Key: whisper_live_********' \
    -d '{"query":"CALL whisper.agents({op:'\''list'\'', args:{kind:'\''agents'\''}})"}'
```

An anonymous control call returns a clear problem object: *"anonymous callers cannot use the agent control plane — an attributable API key is required"* (HTTP 400).
