### PR TITLE
Firmaradar (Independent Publisher) 0.5.2 — add Get Company IP action

### DIFF
--- a/independent-publisher-connectors/Firmaradar/apiDefinition.swagger.json
+++ b/independent-publisher-connectors/Firmaradar/apiDefinition.swagger.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "Firmaradar",
-    "version": "0.5.1",
+    "version": "0.5.2",
     "description": "Enrichment platform for Norwegian company intelligence. Fuses data from BRREG, Skatteetaten, foreign PEP and sanctions registers, public-grants registries and distress signals, with proprietary enrichment on top (risk scoring, fuzzy person matching, group analytics, audit-grade compliance). Built for KYC, AML, credit, ownership and risk workflows.",
     "contact": {
       "name": "Firmaradar support",
@@ -1208,6 +1208,123 @@
             "schema": {
               "$ref": "#/definitions/Error"
             }
+          }
+        }
+      }
+    },
+    "/api/v1/company/{orgnr}/ip": {
+      "get": {
+        "operationId": "getCompanyIp",
+        "summary": "Get intellectual-property portfolio",
+        "description": "Returns a company's intellectual-property portfolio from Patentstyret (the Norwegian Industrial Property Office): patents, trademarks and industrial designs — totals, active counts, and a list of rights with links to each case. Firmaradar enriches company data with IP from Patentstyret; this is not available from the company register alone.",
+        "tags": [
+          "Selskap"
+        ],
+        "parameters": [
+          {
+            "name": "orgnr",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "^\\d{9}$",
+            "x-ms-summary": "Organization number",
+            "description": "Norwegian organization number (exactly 9 digits) issued by Brønnøysundregistrene.",
+            "x-ms-url-encoding": "single"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "orgnr": {
+                  "type": "string",
+                  "x-ms-summary": "Organization number"
+                },
+                "navn": {
+                  "type": "string",
+                  "x-ms-summary": "Company name"
+                },
+                "ip_rettigheter": {
+                  "type": "object",
+                  "x-ms-summary": "IP rights",
+                  "properties": {
+                    "patents": {
+                      "type": "integer",
+                      "x-ms-summary": "Patents (total)"
+                    },
+                    "patents_active": {
+                      "type": "integer",
+                      "x-ms-summary": "Patents (active)"
+                    },
+                    "trademarks": {
+                      "type": "integer",
+                      "x-ms-summary": "Trademarks (total)"
+                    },
+                    "trademarks_active": {
+                      "type": "integer",
+                      "x-ms-summary": "Trademarks (active)"
+                    },
+                    "designs": {
+                      "type": "integer",
+                      "x-ms-summary": "Designs (total)"
+                    },
+                    "designs_active": {
+                      "type": "integer",
+                      "x-ms-summary": "Designs (active)"
+                    },
+                    "is_ip_active": {
+                      "type": "boolean",
+                      "x-ms-summary": "Has active IP"
+                    },
+                    "rights": {
+                      "type": "array",
+                      "x-ms-summary": "Rights",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "x-ms-summary": "Right type"
+                          },
+                          "title": {
+                            "type": "string",
+                            "x-ms-summary": "Title"
+                          },
+                          "status": {
+                            "type": "string",
+                            "x-ms-summary": "Status"
+                          },
+                          "url": {
+                            "type": "string",
+                            "x-ms-summary": "Patentstyret link"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/responses/ServerError"
           }
         }
       }


### PR DESCRIPTION
## Connector
**Firmaradar** (Independent Publisher) — Norwegian company intelligence. Version **0.5.1 → 0.5.2**.

## What this PR does
Adds one new action, **Get Company IP** (`getCompanyIp`, `GET /api/v1/company/{orgnr}/ip`): a company's intellectual-property portfolio from Patentstyret (the Norwegian Industrial Property Office) — patents, trademarks and industrial designs, with totals, active counts and links to each case.

This capability previously existed only as an `ip=1` query parameter on *Get Company*; a dedicated action makes it discoverable as its own card. Surgical addition — no other operations changed.

## Testing
- The backing endpoint `GET /api/v1/company/{orgnr}/ip` is live in production (`https://firmaradar.no/api`) and behaves like the sibling `/changes` endpoint (API-key auth; 9-digit orgnr; JSON response).
- Swagger validates as JSON; the new path mirrors the existing hand-curated style (`x-ms-summary`, English descriptions).

## Notes
- Independent Publisher connector; publisher **Lars Kvanum**, stack owner **Firmaradar AS** — unchanged.
- Only `apiDefinition.swagger.json` changed (+ version bump). `apiProperties.json`, `README.md` and `icon.png` are unchanged. `ConnectorPackage.zip` (a build artifact) is not regenerated; the swagger is the authoritative definition — happy to rebuild via `paconn` if the reviewer prefers.
- No breaking changes.