### PR TITLE
Penneo Connectors - Case file details and download document actions

### DIFF
--- a/certified-connectors/Penneo Sign Sandbox/README.md
+++ b/certified-connectors/Penneo Sign Sandbox/README.md
@@ -14,6 +14,28 @@ Creates a new case file in Penneo with the specified documents and signers. The 
 ### Check job status
 Retrieves the current status of a casefile by providing the job UUID and payloadHash. This endpoint is used to poll for job completion status after submitting a case file creation request. The endpoint is rate-limited to 20 requests per minute per uuid-payloadHash combination.
 
+### Get case file details
+Retrieves the details of a specific case file from Penneo based on case file Id. This includes its signers, documents, and current status.
+
+The available case file statuses are described below.
+
+```
+// 0 : 'new'
+// 1 : 'pending'
+// 2 : 'rejected'
+// 3 : 'deleted'
+// 4 : 'signed'
+// 5 : 'completed'
+// 6 : 'failed'
+// 7 : 'expired'
+// 8 : 'anonymized'
+```
+
+Use status 5: 'completed' as trigger for starting getting the signed documents.
+
+### Download document
+Downloads the content of a document from the Penneo as a base64 encoded string. By default, the signed version of the document is returned; use the `signed` parameter to get the unsigned version instead. If your case file includes more documents ensure to loop over each document.
+
 ## Obtaining Credentials
 
 The connector has been configured to use OAuth with Authorization Code Grant. Users will have to login with their regular credentials when they use the connector.
@@ -44,6 +66,16 @@ The connector has been configured to use OAuth with Authorization Code Grant. Us
     - Respect the rate limit of 20 requests per minute per uuid-hash combination
 
 Note: You can check what each field does by checking https://penneo.readme.io/reference/createcasefile.
+
+### Retrieving a Case File and its Documents
+
+1. **Get the case file details**:
+    - Use the "Get case file details" action with the case file id
+    - The response includes the case file status, signers, and the list of documents (with their document ids)
+
+2. **Download a document**:
+    - Use the "Download document" action with the document id obtained from the case file details
+    - The response contains the document content as a base64 encoded string, which you can decode to retrieve the PDF file
 
 ## Known Issues and Limitations
 

--- a/certified-connectors/Penneo Sign Sandbox/apiDefinition.swagger.json
+++ b/certified-connectors/Penneo Sign Sandbox/apiDefinition.swagger.json
@@ -802,7 +802,7 @@
           "type": "string",
           "format": "email",
           "description": "Email of the recipient"
-        },
+        }
       }
     },
     "CaseFileDetails": {

--- a/certified-connectors/Penneo Sign Sandbox/apiDefinition.swagger.json
+++ b/certified-connectors/Penneo Sign Sandbox/apiDefinition.swagger.json
@@ -803,11 +803,6 @@
           "format": "email",
           "description": "Email of the recipient"
         },
-        "storeAsContact": {
-          "type": "boolean",
-          "default": true,
-          "description": "Signer will be stored as a contact. Defaults to true."
-        }
       }
     },
     "CaseFileDetails": {
@@ -873,10 +868,6 @@
           "type": "integer",
           "description": "UNIX timestamp when the case file was last updated."
         },
-        "language": {
-          "type": "string",
-          "description": "The case file language."
-        }
       }
     },
     "SignerDetails": {
@@ -903,6 +894,10 @@
         "id": {
           "type": "integer",
           "description": "The signing request id."
+        },
+        "email": {
+          "type": "string",
+          "description": "Signer email."
         },
         "status": {
           "type": "integer",

--- a/certified-connectors/Penneo Sign Sandbox/apiDefinition.swagger.json
+++ b/certified-connectors/Penneo Sign Sandbox/apiDefinition.swagger.json
@@ -848,26 +848,10 @@
             "$ref": "#/definitions/DocumentDetails"
           }
         },
-        "signOnMeeting": {
-          "type": "boolean",
-          "description": "Specifies if documents should be signed during a meeting."
-        },
-        "signIteration": {
-          "type": "integer",
-          "description": "The signing iteration of the case file."
-        },
         "expireAt": {
           "type": "integer",
           "x-nullable": true,
           "description": "UNIX timestamp when the case file expires."
-        },
-        "visibilityMode": {
-          "type": "integer",
-          "description": "0 = Signers see all documents. 1 = Signers see only documents they need to sign."
-        },
-        "documentDisplayMode": {
-          "type": "integer",
-          "description": "The document display mode of the case file."
         },
         "sensitiveData": {
           "type": "boolean",
@@ -901,10 +885,6 @@
           "type": "integer",
           "description": "UNIX timestamp when the case file was last updated."
         },
-        "encryptionModeSigned": {
-          "type": "string",
-          "description": "The encryption mode used for the signed case file."
-        },
         "language": {
           "type": "string",
           "description": "The case file language."
@@ -918,13 +898,6 @@
         "name": {
           "type": "string",
           "description": "Name of the signer."
-        },
-        "types": {
-          "type": "array",
-          "description": "List of signer types.",
-          "items": {
-            "type": "string"
-          }
         },
         "id": {
           "type": "integer",
@@ -1069,10 +1042,6 @@
         "created": {
           "type": "integer",
           "description": "Timestamp when the document was created."
-        },
-        "encryptionModeSigned": {
-          "type": "string",
-          "description": "The encryption mode used for the signed document."
         },
         "format": {
           "type": "string",

--- a/certified-connectors/Penneo Sign Sandbox/apiDefinition.swagger.json
+++ b/certified-connectors/Penneo Sign Sandbox/apiDefinition.swagger.json
@@ -853,18 +853,6 @@
           "x-nullable": true,
           "description": "UNIX timestamp when the case file expires."
         },
-        "sensitiveData": {
-          "type": "boolean",
-          "description": "If true, signers must validate their identity before accessing documents."
-        },
-        "disableNotificationsOwner": {
-          "type": "boolean",
-          "description": "If true, the case file owner will not receive notifications for the case file."
-        },
-        "disableEmailAttachments": {
-          "type": "boolean",
-          "description": "If true, signed documents are not attached to completion emails."
-        },
         "ccRecipients": {
           "type": "array",
           "description": "List of CC recipients who receive a copy of the signed documents.",
@@ -903,16 +891,8 @@
           "type": "integer",
           "description": "The signer id."
         },
-        "ssnType": {
-          "type": "string",
-          "description": "The SSN type used for this signer (e.g. 'legacy', 'dk:cpr', 'se:pin', 'no:nin', 'be:nrn', 'fi:pic', 'sms')."
-        },
         "signingRequest": {
           "$ref": "#/definitions/SigningRequestDetails"
-        },
-        "storeAsContact": {
-          "type": "boolean",
-          "description": "If true, the signer is stored as a contact in Penneo."
         }
       }
     },
@@ -920,79 +900,13 @@
       "type": "object",
       "description": "The signing request associated with a signer.",
       "properties": {
-        "communicationChannel": {
-          "type": "string",
-          "description": "The communication channel used to contact the signer (e.g. 'email')."
-        },
-        "insecureSigningMethods": {
-          "type": "array",
-          "description": "Allowed insecure signing methods.",
-          "items": {
-            "type": "string"
-          }
-        },
-        "secureSigningMethods": {
-          "type": "array",
-          "description": "Allowed secure signing methods.",
-          "items": {
-            "type": "string"
-          }
-        },
-        "language": {
-          "type": "string",
-          "description": "The language of the signing request."
-        },
         "id": {
           "type": "integer",
           "description": "The signing request id."
         },
-        "email": {
-          "type": "string",
-          "description": "Signer email."
-        },
-        "emailSubject": {
-          "type": "string",
-          "description": "Subject of the signature request email."
-        },
-        "emailText": {
-          "type": "string",
-          "description": "Text of the signature request email."
-        },
-        "reminderEmailSubject": {
-          "type": "string",
-          "description": "Subject of the reminder email."
-        },
-        "reminderEmailText": {
-          "type": "string",
-          "description": "Text of the reminder email."
-        },
-        "completedEmailSubject": {
-          "type": "string",
-          "description": "Subject of the completed email."
-        },
-        "completedEmailText": {
-          "type": "string",
-          "description": "Text of the completed email."
-        },
-        "emailFormat": {
-          "type": "string",
-          "description": "The format of the emails sent for this signing request."
-        },
         "status": {
           "type": "integer",
           "description": "The status of the signing request."
-        },
-        "reminderInterval": {
-          "type": "integer",
-          "description": "Days before a reminder is sent."
-        },
-        "accessControl": {
-          "type": "boolean",
-          "description": "If enabled, SSN/VATIN/phone is validated before access."
-        },
-        "enableInsecureSigning": {
-          "type": "boolean",
-          "description": "If true, the signer can use insecure signing methods."
         }
       }
     },
@@ -1000,29 +914,9 @@
       "type": "object",
       "description": "A document in a case file.",
       "properties": {
-        "caseFileId": {
-          "type": "integer",
-          "description": "The id of the case file this document belongs to."
-        },
         "id": {
           "type": "integer",
-          "description": "The document id."
-        },
-        "documentId": {
-          "type": "string",
-          "description": "The unique document identifier."
-        },
-        "documentOrder": {
-          "type": "integer",
-          "description": "The signing order of the document."
-        },
-        "fileSize": {
-          "type": "integer",
-          "description": "The file size in bytes."
-        },
-        "title": {
-          "type": "string",
-          "description": "The document title."
+          "description": "The document id. Use this to download the document with the \"Download document\" action."
         },
         "status": {
           "type": "integer",
@@ -1031,52 +925,6 @@
         "signable": {
           "type": "boolean",
           "description": "True if the document is signable."
-        },
-        "signatureLines": {
-          "type": "array",
-          "description": "List of signature lines on the document.",
-          "items": {
-            "$ref": "#/definitions/SignatureLineDetails"
-          }
-        },
-        "created": {
-          "type": "integer",
-          "description": "Timestamp when the document was created."
-        },
-        "format": {
-          "type": "string",
-          "description": "The document format."
-        }
-      }
-    },
-    "SignatureLineDetails": {
-      "type": "object",
-      "description": "A signature line on a document.",
-      "properties": {
-        "signerId": {
-          "type": "integer",
-          "description": "The id of the signer assigned to this signature line."
-        },
-        "documentId": {
-          "type": "integer",
-          "description": "The id of the document this signature line belongs to."
-        },
-        "id": {
-          "type": "integer",
-          "description": "The signature line id."
-        },
-        "role": {
-          "type": "string",
-          "description": "The role assigned to this signature line."
-        },
-        "signOrder": {
-          "type": "integer",
-          "description": "The signing order of this signature line."
-        },
-        "activatedAt": {
-          "type": "integer",
-          "x-nullable": true,
-          "description": "UNIX timestamp when this signature line was activated."
         }
       }
     },

--- a/certified-connectors/Penneo Sign Sandbox/apiDefinition.swagger.json
+++ b/certified-connectors/Penneo Sign Sandbox/apiDefinition.swagger.json
@@ -159,6 +159,85 @@
           }
         }
       }
+    },
+    "/api/v3/casefiles/{caseFileId}": {
+      "get": {
+        "summary": "Get case file details",
+        "description": "Retrieves the details of a specific case file from Penneo, including its signers, documents, and current status. Case file statuses: 0=new, 1=pending, 2=rejected, 3=deleted, 4=signed, 5=completed, 6=failed, 7=expired, 8=anonymized. Use status 5 (completed) as trigger for downloading the signed documents.",
+        "operationId": "GetCaseFileDetails",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "caseFileId",
+            "required": true,
+            "type": "integer",
+            "x-ms-summary": "Case File Id",
+            "x-ms-url-encoding": "single",
+            "description": "The id of the case file to retrieve. Retrieve the case file id with the \"Check job status\" action."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the case file details.",
+            "schema": {
+              "$ref": "#/definitions/CaseFileDetails"
+            }
+          },
+          "403": {
+            "description": "Returned when access to the case file is denied."
+          },
+          "404": {
+            "description": "Returned when the case file is not found."
+          }
+        }
+      }
+    },
+    "/api/v1/documents/{documentId}/content": {
+      "get": {
+        "summary": "Download document",
+        "description": "Downloads the content of a document from Penneo as a base64 encoded string. By default, the signed version of the document is returned.",
+        "operationId": "DownloadDocument",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "documentId",
+            "required": true,
+            "type": "integer",
+            "x-ms-summary": "Document Id",
+            "x-ms-url-encoding": "single",
+            "description": "The id of the document to download. Retrieve the documentIds with the \"Get case file details\"-action."
+          },
+          {
+            "in": "query",
+            "name": "signed",
+            "required": false,
+            "type": "boolean",
+            "default": true,
+            "x-ms-summary": "Signed",
+            "description": "Get the signed or the unsigned document. By default, the signed document is returned if the document has been signed."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the document content.",
+            "schema": {
+              "$ref": "#/definitions/DocumentContent"
+            }
+          },
+          "403": {
+            "description": "Returned when access to the document is denied."
+          },
+          "404": {
+            "description": "Returned when the document is not found."
+          }
+        }
+      }
     }
   },
   "definitions": {
@@ -370,6 +449,25 @@
               "text",
               "draw",
               "image"
+            ]
+          }
+        },
+        "secureSigningMethods": {
+          "type": "array",
+          "description": "The allowed secure electronic signing methods. Overrides case file and customer settings when set.",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "mitid.dk",
+              "bankid_se",
+              "bankid_no",
+              "itsme.be",
+              "ftn.fi",
+              "eid.belgium.be",
+              "passport-reader.eident.dk",
+              "ausweisapp.bund.de",
+              "qes.personal.mitid.dk"
             ]
           }
         },
@@ -709,6 +807,318 @@
           "type": "boolean",
           "default": true,
           "description": "Signer will be stored as a contact. Defaults to true."
+        }
+      }
+    },
+    "CaseFileDetails": {
+      "type": "object",
+      "description": "Details of a case file retrieved from the Penneo secure archive.",
+      "properties": {
+        "userId": {
+          "type": "integer",
+          "description": "Id of the user who owns the case file."
+        },
+        "customerId": {
+          "type": "integer",
+          "description": "Id of the customer the case file belongs to."
+        },
+        "signers": {
+          "type": "array",
+          "description": "List of signers on the case file.",
+          "items": {
+            "$ref": "#/definitions/SignerDetails"
+          }
+        },
+        "id": {
+          "type": "integer",
+          "description": "The case file id."
+        },
+        "title": {
+          "type": "string",
+          "description": "The case file title."
+        },
+        "status": {
+          "type": "integer",
+          "description": "The case file status."
+        },
+        "documents": {
+          "type": "array",
+          "description": "List of documents in the case file.",
+          "items": {
+            "$ref": "#/definitions/DocumentDetails"
+          }
+        },
+        "signOnMeeting": {
+          "type": "boolean",
+          "description": "Specifies if documents should be signed during a meeting."
+        },
+        "signIteration": {
+          "type": "integer",
+          "description": "The signing iteration of the case file."
+        },
+        "expireAt": {
+          "type": "integer",
+          "x-nullable": true,
+          "description": "UNIX timestamp when the case file expires."
+        },
+        "visibilityMode": {
+          "type": "integer",
+          "description": "0 = Signers see all documents. 1 = Signers see only documents they need to sign."
+        },
+        "documentDisplayMode": {
+          "type": "integer",
+          "description": "The document display mode of the case file."
+        },
+        "sensitiveData": {
+          "type": "boolean",
+          "description": "If true, signers must validate their identity before accessing documents."
+        },
+        "disableNotificationsOwner": {
+          "type": "boolean",
+          "description": "If true, the case file owner will not receive notifications for the case file."
+        },
+        "disableEmailAttachments": {
+          "type": "boolean",
+          "description": "If true, signed documents are not attached to completion emails."
+        },
+        "ccRecipients": {
+          "type": "array",
+          "description": "List of CC recipients who receive a copy of the signed documents.",
+          "items": {
+            "$ref": "#/definitions/CcRecipient"
+          }
+        },
+        "created": {
+          "type": "integer",
+          "description": "UNIX timestamp when the case file was created."
+        },
+        "activated": {
+          "type": "integer",
+          "x-nullable": true,
+          "description": "UNIX timestamp when the case file was activated."
+        },
+        "updated": {
+          "type": "integer",
+          "description": "UNIX timestamp when the case file was last updated."
+        },
+        "encryptionModeSigned": {
+          "type": "string",
+          "description": "The encryption mode used for the signed case file."
+        },
+        "language": {
+          "type": "string",
+          "description": "The case file language."
+        }
+      }
+    },
+    "SignerDetails": {
+      "type": "object",
+      "description": "A signer on a case file.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the signer."
+        },
+        "types": {
+          "type": "array",
+          "description": "List of signer types.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "id": {
+          "type": "integer",
+          "description": "The signer id."
+        },
+        "ssnType": {
+          "type": "string",
+          "description": "The SSN type used for this signer (e.g. 'legacy', 'dk:cpr', 'se:pin', 'no:nin', 'be:nrn', 'fi:pic', 'sms')."
+        },
+        "signingRequest": {
+          "$ref": "#/definitions/SigningRequestDetails"
+        },
+        "storeAsContact": {
+          "type": "boolean",
+          "description": "If true, the signer is stored as a contact in Penneo."
+        }
+      }
+    },
+    "SigningRequestDetails": {
+      "type": "object",
+      "description": "The signing request associated with a signer.",
+      "properties": {
+        "communicationChannel": {
+          "type": "string",
+          "description": "The communication channel used to contact the signer (e.g. 'email')."
+        },
+        "insecureSigningMethods": {
+          "type": "array",
+          "description": "Allowed insecure signing methods.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "secureSigningMethods": {
+          "type": "array",
+          "description": "Allowed secure signing methods.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "language": {
+          "type": "string",
+          "description": "The language of the signing request."
+        },
+        "id": {
+          "type": "integer",
+          "description": "The signing request id."
+        },
+        "email": {
+          "type": "string",
+          "description": "Signer email."
+        },
+        "emailSubject": {
+          "type": "string",
+          "description": "Subject of the signature request email."
+        },
+        "emailText": {
+          "type": "string",
+          "description": "Text of the signature request email."
+        },
+        "reminderEmailSubject": {
+          "type": "string",
+          "description": "Subject of the reminder email."
+        },
+        "reminderEmailText": {
+          "type": "string",
+          "description": "Text of the reminder email."
+        },
+        "completedEmailSubject": {
+          "type": "string",
+          "description": "Subject of the completed email."
+        },
+        "completedEmailText": {
+          "type": "string",
+          "description": "Text of the completed email."
+        },
+        "emailFormat": {
+          "type": "string",
+          "description": "The format of the emails sent for this signing request."
+        },
+        "status": {
+          "type": "integer",
+          "description": "The status of the signing request."
+        },
+        "reminderInterval": {
+          "type": "integer",
+          "description": "Days before a reminder is sent."
+        },
+        "accessControl": {
+          "type": "boolean",
+          "description": "If enabled, SSN/VATIN/phone is validated before access."
+        },
+        "enableInsecureSigning": {
+          "type": "boolean",
+          "description": "If true, the signer can use insecure signing methods."
+        }
+      }
+    },
+    "DocumentDetails": {
+      "type": "object",
+      "description": "A document in a case file.",
+      "properties": {
+        "caseFileId": {
+          "type": "integer",
+          "description": "The id of the case file this document belongs to."
+        },
+        "id": {
+          "type": "integer",
+          "description": "The document id."
+        },
+        "documentId": {
+          "type": "string",
+          "description": "The unique document identifier."
+        },
+        "documentOrder": {
+          "type": "integer",
+          "description": "The signing order of the document."
+        },
+        "fileSize": {
+          "type": "integer",
+          "description": "The file size in bytes."
+        },
+        "title": {
+          "type": "string",
+          "description": "The document title."
+        },
+        "status": {
+          "type": "integer",
+          "description": "The document status."
+        },
+        "signable": {
+          "type": "boolean",
+          "description": "True if the document is signable."
+        },
+        "signatureLines": {
+          "type": "array",
+          "description": "List of signature lines on the document.",
+          "items": {
+            "$ref": "#/definitions/SignatureLineDetails"
+          }
+        },
+        "created": {
+          "type": "integer",
+          "description": "Timestamp when the document was created."
+        },
+        "encryptionModeSigned": {
+          "type": "string",
+          "description": "The encryption mode used for the signed document."
+        },
+        "format": {
+          "type": "string",
+          "description": "The document format."
+        }
+      }
+    },
+    "SignatureLineDetails": {
+      "type": "object",
+      "description": "A signature line on a document.",
+      "properties": {
+        "signerId": {
+          "type": "integer",
+          "description": "The id of the signer assigned to this signature line."
+        },
+        "documentId": {
+          "type": "integer",
+          "description": "The id of the document this signature line belongs to."
+        },
+        "id": {
+          "type": "integer",
+          "description": "The signature line id."
+        },
+        "role": {
+          "type": "string",
+          "description": "The role assigned to this signature line."
+        },
+        "signOrder": {
+          "type": "integer",
+          "description": "The signing order of this signature line."
+        },
+        "activatedAt": {
+          "type": "integer",
+          "x-nullable": true,
+          "description": "UNIX timestamp when this signature line was activated."
+        }
+      }
+    },
+    "DocumentContent": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "string",
+          "format": "byte",
+          "x-ms-summary": "Document Content",
+          "description": "Base64 encoded content of the document."
         }
       }
     }

--- a/certified-connectors/Penneo Sign Sandbox/apiDefinition.swagger.json
+++ b/certified-connectors/Penneo Sign Sandbox/apiDefinition.swagger.json
@@ -868,6 +868,11 @@
           "type": "integer",
           "description": "UNIX timestamp when the case file was last updated."
         },
+        "completed": {
+          "type": "integer",
+          "x-nullable": true,
+          "description": "UNIX timestamp when the case file was completed."
+        }
       }
     },
     "SignerDetails": {

--- a/certified-connectors/Penneo Sign Sandbox/script.csx
+++ b/certified-connectors/Penneo Sign Sandbox/script.csx
@@ -1,27 +1,32 @@
 public class Script : ScriptBase
 {
+    private static readonly HashSet<string> LegacyAuthOperations = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        "GetCaseFileDetails",
+        "DownloadDocument"
+    };
+
     public override async Task<HttpResponseMessage> ExecuteAsync()
     {
-        // Get the Authorization header value (which contains "Bearer {access_token}")
         if (this.Context.Request.Headers.TryGetValues("Authorization", out var authHeaderValues))
         {
             var authHeader = authHeaderValues.FirstOrDefault();
             if (!string.IsNullOrEmpty(authHeader))
             {
-                // Remove the "Authorization" header
-                this.Context.Request.Headers.Remove("Authorization");
-                
-                // Extract just the token (remove "Bearer " prefix if present)
-                var token = authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase) 
-                    ? authHeader.Substring(7) 
+                var token = authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase)
+                    ? authHeader.Substring(7)
                     : authHeader;
-                
-                // Add the token to "X-Auth-Token" header WITHOUT "Bearer " prefix
+
+                this.Context.Request.Headers.Remove("Authorization");
                 this.Context.Request.Headers.Add("X-Auth-Token", token);
+
+                if (LegacyAuthOperations.Contains(this.Context.OperationId))
+                {
+                    this.Context.Request.Headers.TryAddWithoutValidation("Authorization", "JWT");
+                }
             }
         }
 
-        // Send the request to the backend API
         var response = await this.Context.SendAsync(this.Context.Request, this.CancellationToken).ConfigureAwait(continueOnCapturedContext: false);
 
         return response;

--- a/certified-connectors/Penneo Sign/README.md
+++ b/certified-connectors/Penneo Sign/README.md
@@ -14,6 +14,28 @@ Creates a new case file in Penneo with the specified documents and signers. The 
 ### Check job status
 Retrieves the current status of a casefile by providing the job UUID and payloadHash. This endpoint is used to poll for job completion status after submitting a case file creation request. The endpoint is rate-limited to 20 requests per minute per uuid-payloadHash combination.
 
+### Get case file details
+Retrieves the details of a specific case file from Penneo based on casefileId. This includes its signers, documents, and current status.
+
+The available case file statuses are described below.
+
+```
+// 0 : 'new'
+// 1 : 'pending'
+// 2 : 'rejected'
+// 3 : 'deleted'
+// 4 : 'signed'
+// 5 : 'completed'
+// 6 : 'failed'
+// 7 : 'expired'
+// 8 : 'anonymized'
+```
+
+Use status 5: 'completed' as trigger for starting getting the signed documents.
+
+### Download document
+Downloads the content of a document from the Penneo as a base64 encoded string. By default, the signed version of the document is returned; use the `signed` parameter to get the unsigned version instead. If your case file includes more documents ensure to loop over each document.
+
 ## Obtaining Credentials
 
 The connector has been configured to use OAuth with Authorization Code Grant. Users will have to login with their regular credentials when they use the connector.
@@ -44,6 +66,16 @@ The connector has been configured to use OAuth with Authorization Code Grant. Us
    - Respect the rate limit of 20 requests per minute per uuid-hash combination
 
 Note: You can check what each field does by checking https://penneo.readme.io/reference/createcasefile.
+
+### Retrieving a Case File and its Documents
+
+1. **Get the case file details**:
+    - Use the "Get case file details" action with the case file id
+    - The response includes the case file status, signers, and the list of documents (with their document ids)
+
+2. **Download a document**:
+    - Use the "Download document" action with the document id obtained from the case file details
+    - The response contains the document content as a base64 encoded string, which you can decode to retrieve the PDF file
 
 ## Known Issues and Limitations
 

--- a/certified-connectors/Penneo Sign/apiDefinition.swagger.json
+++ b/certified-connectors/Penneo Sign/apiDefinition.swagger.json
@@ -869,6 +869,11 @@
           "type": "integer",
           "description": "UNIX timestamp when the case file was last updated."
         },
+        "completed": {
+          "type": "integer",
+          "x-nullable": true,
+          "description": "UNIX timestamp when the case file was completed."
+        }
       }
     },
     "SignerDetails": {

--- a/certified-connectors/Penneo Sign/apiDefinition.swagger.json
+++ b/certified-connectors/Penneo Sign/apiDefinition.swagger.json
@@ -804,11 +804,6 @@
           "format": "email",
           "description": "Email of the recipient"
         },
-        "storeAsContact": {
-          "type": "boolean",
-          "default": true,
-          "description": "Signer will be stored as a contact. Defaults to true."
-        }
       }
     },
     "CaseFileDetails": {
@@ -874,10 +869,6 @@
           "type": "integer",
           "description": "UNIX timestamp when the case file was last updated."
         },
-        "language": {
-          "type": "string",
-          "description": "The case file language."
-        }
       }
     },
     "SignerDetails": {
@@ -904,6 +895,10 @@
         "id": {
           "type": "integer",
           "description": "The signing request id."
+        },
+        "email": {
+          "type": "string",
+          "description": "Signer email."
         },
         "status": {
           "type": "integer",

--- a/certified-connectors/Penneo Sign/apiDefinition.swagger.json
+++ b/certified-connectors/Penneo Sign/apiDefinition.swagger.json
@@ -803,7 +803,7 @@
           "type": "string",
           "format": "email",
           "description": "Email of the recipient"
-        },
+        }
       }
     },
     "CaseFileDetails": {

--- a/certified-connectors/Penneo Sign/apiDefinition.swagger.json
+++ b/certified-connectors/Penneo Sign/apiDefinition.swagger.json
@@ -854,18 +854,6 @@
           "x-nullable": true,
           "description": "UNIX timestamp when the case file expires."
         },
-        "sensitiveData": {
-          "type": "boolean",
-          "description": "If true, signers must validate their identity before accessing documents."
-        },
-        "disableNotificationsOwner": {
-          "type": "boolean",
-          "description": "If true, the case file owner will not receive notifications for the case file."
-        },
-        "disableEmailAttachments": {
-          "type": "boolean",
-          "description": "If true, signed documents are not attached to completion emails."
-        },
         "ccRecipients": {
           "type": "array",
           "description": "List of CC recipients who receive a copy of the signed documents.",
@@ -904,16 +892,8 @@
           "type": "integer",
           "description": "The signer id."
         },
-        "ssnType": {
-          "type": "string",
-          "description": "The SSN type used for this signer (e.g. 'legacy', 'dk:cpr', 'se:pin', 'no:nin', 'be:nrn', 'fi:pic', 'sms')."
-        },
         "signingRequest": {
           "$ref": "#/definitions/SigningRequestDetails"
-        },
-        "storeAsContact": {
-          "type": "boolean",
-          "description": "If true, the signer is stored as a contact in Penneo."
         }
       }
     },
@@ -921,79 +901,13 @@
       "type": "object",
       "description": "The signing request associated with a signer.",
       "properties": {
-        "communicationChannel": {
-          "type": "string",
-          "description": "The communication channel used to contact the signer (e.g. 'email')."
-        },
-        "insecureSigningMethods": {
-          "type": "array",
-          "description": "Allowed insecure signing methods.",
-          "items": {
-            "type": "string"
-          }
-        },
-        "secureSigningMethods": {
-          "type": "array",
-          "description": "Allowed secure signing methods.",
-          "items": {
-            "type": "string"
-          }
-        },
-        "language": {
-          "type": "string",
-          "description": "The language of the signing request."
-        },
         "id": {
           "type": "integer",
           "description": "The signing request id."
         },
-        "email": {
-          "type": "string",
-          "description": "Signer email."
-        },
-        "emailSubject": {
-          "type": "string",
-          "description": "Subject of the signature request email."
-        },
-        "emailText": {
-          "type": "string",
-          "description": "Text of the signature request email."
-        },
-        "reminderEmailSubject": {
-          "type": "string",
-          "description": "Subject of the reminder email."
-        },
-        "reminderEmailText": {
-          "type": "string",
-          "description": "Text of the reminder email."
-        },
-        "completedEmailSubject": {
-          "type": "string",
-          "description": "Subject of the completed email."
-        },
-        "completedEmailText": {
-          "type": "string",
-          "description": "Text of the completed email."
-        },
-        "emailFormat": {
-          "type": "string",
-          "description": "The format of the emails sent for this signing request."
-        },
         "status": {
           "type": "integer",
           "description": "The status of the signing request."
-        },
-        "reminderInterval": {
-          "type": "integer",
-          "description": "Days before a reminder is sent."
-        },
-        "accessControl": {
-          "type": "boolean",
-          "description": "If enabled, SSN/VATIN/phone is validated before access."
-        },
-        "enableInsecureSigning": {
-          "type": "boolean",
-          "description": "If true, the signer can use insecure signing methods."
         }
       }
     },
@@ -1001,29 +915,9 @@
       "type": "object",
       "description": "A document in a case file.",
       "properties": {
-        "caseFileId": {
-          "type": "integer",
-          "description": "The id of the case file this document belongs to."
-        },
         "id": {
           "type": "integer",
-          "description": "The document id."
-        },
-        "documentId": {
-          "type": "string",
-          "description": "The unique document identifier."
-        },
-        "documentOrder": {
-          "type": "integer",
-          "description": "The signing order of the document."
-        },
-        "fileSize": {
-          "type": "integer",
-          "description": "The file size in bytes."
-        },
-        "title": {
-          "type": "string",
-          "description": "The document title."
+          "description": "The document id. Use this to download the document with the \"Download document\" action."
         },
         "status": {
           "type": "integer",
@@ -1032,52 +926,6 @@
         "signable": {
           "type": "boolean",
           "description": "True if the document is signable."
-        },
-        "signatureLines": {
-          "type": "array",
-          "description": "List of signature lines on the document.",
-          "items": {
-            "$ref": "#/definitions/SignatureLineDetails"
-          }
-        },
-        "created": {
-          "type": "integer",
-          "description": "Timestamp when the document was created."
-        },
-        "format": {
-          "type": "string",
-          "description": "The document format."
-        }
-      }
-    },
-    "SignatureLineDetails": {
-      "type": "object",
-      "description": "A signature line on a document.",
-      "properties": {
-        "signerId": {
-          "type": "integer",
-          "description": "The id of the signer assigned to this signature line."
-        },
-        "documentId": {
-          "type": "integer",
-          "description": "The id of the document this signature line belongs to."
-        },
-        "id": {
-          "type": "integer",
-          "description": "The signature line id."
-        },
-        "role": {
-          "type": "string",
-          "description": "The role assigned to this signature line."
-        },
-        "signOrder": {
-          "type": "integer",
-          "description": "The signing order of this signature line."
-        },
-        "activatedAt": {
-          "type": "integer",
-          "x-nullable": true,
-          "description": "UNIX timestamp when this signature line was activated."
         }
       }
     },

--- a/certified-connectors/Penneo Sign/apiDefinition.swagger.json
+++ b/certified-connectors/Penneo Sign/apiDefinition.swagger.json
@@ -160,6 +160,85 @@
           }
         }
       }
+    },
+    "/api/v3/casefiles/{caseFileId}": {
+      "get": {
+        "summary": "Get case file details",
+        "description": "Retrieves the details of a specific case file from Penneo, including its signers, documents, and current status. Case file statuses: 0=new, 1=pending, 2=rejected, 3=deleted, 4=signed, 5=completed, 6=failed, 7=expired, 8=anonymized. Use status 5 (completed) as trigger for downloading the signed documents.",
+        "operationId": "GetCaseFileDetails",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "caseFileId",
+            "required": true,
+            "type": "integer",
+            "x-ms-summary": "Case File Id",
+            "x-ms-url-encoding": "single",
+            "description": "The id of the case file to retrieve. Retrieve the case file id with the \"Check job status\" action."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the case file details.",
+            "schema": {
+              "$ref": "#/definitions/CaseFileDetails"
+            }
+          },
+          "403": {
+            "description": "Returned when access to the case file is denied."
+          },
+          "404": {
+            "description": "Returned when the case file is not found."
+          }
+        }
+      }
+    },
+    "/api/v1/documents/{documentId}/content": {
+      "get": {
+        "summary": "Download document",
+        "description": "Downloads the content of a document from Penneo as a base64 encoded string. By default, the signed version of the document is returned.",
+        "operationId": "DownloadDocument",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "documentId",
+            "required": true,
+            "type": "integer",
+            "x-ms-summary": "Document Id",
+            "x-ms-url-encoding": "single",
+            "description": "The id of the document to download. Retrieve the documentIds with the \"Get case file details\"-action."
+          },
+          {
+            "in": "query",
+            "name": "signed",
+            "required": false,
+            "type": "boolean",
+            "default": true,
+            "x-ms-summary": "Signed",
+            "description": "Get the signed or the unsigned document. By default, the signed document is returned if the document has been signed."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the document content.",
+            "schema": {
+              "$ref": "#/definitions/DocumentContent"
+            }
+          },
+          "403": {
+            "description": "Returned when access to the document is denied."
+          },
+          "404": {
+            "description": "Returned when the document is not found."
+          }
+        }
+      }
     }
   },
   "definitions": {
@@ -371,6 +450,25 @@
               "text",
               "draw",
               "image"
+            ]
+          }
+        },
+        "secureSigningMethods": {
+          "type": "array",
+          "description": "The allowed secure electronic signing methods. Overrides case file and customer settings when set.",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "mitid.dk",
+              "bankid_se",
+              "bankid_no",
+              "itsme.be",
+              "ftn.fi",
+              "eid.belgium.be",
+              "passport-reader.eident.dk",
+              "ausweisapp.bund.de",
+              "qes.personal.mitid.dk"
             ]
           }
         },
@@ -710,6 +808,318 @@
           "type": "boolean",
           "default": true,
           "description": "Signer will be stored as a contact. Defaults to true."
+        }
+      }
+    },
+    "CaseFileDetails": {
+      "type": "object",
+      "description": "Details of a case file retrieved from the Penneo secure archive.",
+      "properties": {
+        "userId": {
+          "type": "integer",
+          "description": "Id of the user who owns the case file."
+        },
+        "customerId": {
+          "type": "integer",
+          "description": "Id of the customer the case file belongs to."
+        },
+        "signers": {
+          "type": "array",
+          "description": "List of signers on the case file.",
+          "items": {
+            "$ref": "#/definitions/SignerDetails"
+          }
+        },
+        "id": {
+          "type": "integer",
+          "description": "The case file id."
+        },
+        "title": {
+          "type": "string",
+          "description": "The case file title."
+        },
+        "status": {
+          "type": "integer",
+          "description": "The case file status."
+        },
+        "documents": {
+          "type": "array",
+          "description": "List of documents in the case file.",
+          "items": {
+            "$ref": "#/definitions/DocumentDetails"
+          }
+        },
+        "signOnMeeting": {
+          "type": "boolean",
+          "description": "Specifies if documents should be signed during a meeting."
+        },
+        "signIteration": {
+          "type": "integer",
+          "description": "The signing iteration of the case file."
+        },
+        "expireAt": {
+          "type": "integer",
+          "x-nullable": true,
+          "description": "UNIX timestamp when the case file expires."
+        },
+        "visibilityMode": {
+          "type": "integer",
+          "description": "0 = Signers see all documents. 1 = Signers see only documents they need to sign."
+        },
+        "documentDisplayMode": {
+          "type": "integer",
+          "description": "The document display mode of the case file."
+        },
+        "sensitiveData": {
+          "type": "boolean",
+          "description": "If true, signers must validate their identity before accessing documents."
+        },
+        "disableNotificationsOwner": {
+          "type": "boolean",
+          "description": "If true, the case file owner will not receive notifications for the case file."
+        },
+        "disableEmailAttachments": {
+          "type": "boolean",
+          "description": "If true, signed documents are not attached to completion emails."
+        },
+        "ccRecipients": {
+          "type": "array",
+          "description": "List of CC recipients who receive a copy of the signed documents.",
+          "items": {
+            "$ref": "#/definitions/CcRecipient"
+          }
+        },
+        "created": {
+          "type": "integer",
+          "description": "UNIX timestamp when the case file was created."
+        },
+        "activated": {
+          "type": "integer",
+          "x-nullable": true,
+          "description": "UNIX timestamp when the case file was activated."
+        },
+        "updated": {
+          "type": "integer",
+          "description": "UNIX timestamp when the case file was last updated."
+        },
+        "encryptionModeSigned": {
+          "type": "string",
+          "description": "The encryption mode used for the signed case file."
+        },
+        "language": {
+          "type": "string",
+          "description": "The case file language."
+        }
+      }
+    },
+    "SignerDetails": {
+      "type": "object",
+      "description": "A signer on a case file.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the signer."
+        },
+        "types": {
+          "type": "array",
+          "description": "List of signer types.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "id": {
+          "type": "integer",
+          "description": "The signer id."
+        },
+        "ssnType": {
+          "type": "string",
+          "description": "The SSN type used for this signer (e.g. 'legacy', 'dk:cpr', 'se:pin', 'no:nin', 'be:nrn', 'fi:pic', 'sms')."
+        },
+        "signingRequest": {
+          "$ref": "#/definitions/SigningRequestDetails"
+        },
+        "storeAsContact": {
+          "type": "boolean",
+          "description": "If true, the signer is stored as a contact in Penneo."
+        }
+      }
+    },
+    "SigningRequestDetails": {
+      "type": "object",
+      "description": "The signing request associated with a signer.",
+      "properties": {
+        "communicationChannel": {
+          "type": "string",
+          "description": "The communication channel used to contact the signer (e.g. 'email')."
+        },
+        "insecureSigningMethods": {
+          "type": "array",
+          "description": "Allowed insecure signing methods.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "secureSigningMethods": {
+          "type": "array",
+          "description": "Allowed secure signing methods.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "language": {
+          "type": "string",
+          "description": "The language of the signing request."
+        },
+        "id": {
+          "type": "integer",
+          "description": "The signing request id."
+        },
+        "email": {
+          "type": "string",
+          "description": "Signer email."
+        },
+        "emailSubject": {
+          "type": "string",
+          "description": "Subject of the signature request email."
+        },
+        "emailText": {
+          "type": "string",
+          "description": "Text of the signature request email."
+        },
+        "reminderEmailSubject": {
+          "type": "string",
+          "description": "Subject of the reminder email."
+        },
+        "reminderEmailText": {
+          "type": "string",
+          "description": "Text of the reminder email."
+        },
+        "completedEmailSubject": {
+          "type": "string",
+          "description": "Subject of the completed email."
+        },
+        "completedEmailText": {
+          "type": "string",
+          "description": "Text of the completed email."
+        },
+        "emailFormat": {
+          "type": "string",
+          "description": "The format of the emails sent for this signing request."
+        },
+        "status": {
+          "type": "integer",
+          "description": "The status of the signing request."
+        },
+        "reminderInterval": {
+          "type": "integer",
+          "description": "Days before a reminder is sent."
+        },
+        "accessControl": {
+          "type": "boolean",
+          "description": "If enabled, SSN/VATIN/phone is validated before access."
+        },
+        "enableInsecureSigning": {
+          "type": "boolean",
+          "description": "If true, the signer can use insecure signing methods."
+        }
+      }
+    },
+    "DocumentDetails": {
+      "type": "object",
+      "description": "A document in a case file.",
+      "properties": {
+        "caseFileId": {
+          "type": "integer",
+          "description": "The id of the case file this document belongs to."
+        },
+        "id": {
+          "type": "integer",
+          "description": "The document id."
+        },
+        "documentId": {
+          "type": "string",
+          "description": "The unique document identifier."
+        },
+        "documentOrder": {
+          "type": "integer",
+          "description": "The signing order of the document."
+        },
+        "fileSize": {
+          "type": "integer",
+          "description": "The file size in bytes."
+        },
+        "title": {
+          "type": "string",
+          "description": "The document title."
+        },
+        "status": {
+          "type": "integer",
+          "description": "The document status."
+        },
+        "signable": {
+          "type": "boolean",
+          "description": "True if the document is signable."
+        },
+        "signatureLines": {
+          "type": "array",
+          "description": "List of signature lines on the document.",
+          "items": {
+            "$ref": "#/definitions/SignatureLineDetails"
+          }
+        },
+        "created": {
+          "type": "integer",
+          "description": "Timestamp when the document was created."
+        },
+        "encryptionModeSigned": {
+          "type": "string",
+          "description": "The encryption mode used for the signed document."
+        },
+        "format": {
+          "type": "string",
+          "description": "The document format."
+        }
+      }
+    },
+    "SignatureLineDetails": {
+      "type": "object",
+      "description": "A signature line on a document.",
+      "properties": {
+        "signerId": {
+          "type": "integer",
+          "description": "The id of the signer assigned to this signature line."
+        },
+        "documentId": {
+          "type": "integer",
+          "description": "The id of the document this signature line belongs to."
+        },
+        "id": {
+          "type": "integer",
+          "description": "The signature line id."
+        },
+        "role": {
+          "type": "string",
+          "description": "The role assigned to this signature line."
+        },
+        "signOrder": {
+          "type": "integer",
+          "description": "The signing order of this signature line."
+        },
+        "activatedAt": {
+          "type": "integer",
+          "x-nullable": true,
+          "description": "UNIX timestamp when this signature line was activated."
+        }
+      }
+    },
+    "DocumentContent": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "string",
+          "format": "byte",
+          "x-ms-summary": "Document Content",
+          "description": "Base64 encoded content of the document."
         }
       }
     }

--- a/certified-connectors/Penneo Sign/apiDefinition.swagger.json
+++ b/certified-connectors/Penneo Sign/apiDefinition.swagger.json
@@ -849,26 +849,10 @@
             "$ref": "#/definitions/DocumentDetails"
           }
         },
-        "signOnMeeting": {
-          "type": "boolean",
-          "description": "Specifies if documents should be signed during a meeting."
-        },
-        "signIteration": {
-          "type": "integer",
-          "description": "The signing iteration of the case file."
-        },
         "expireAt": {
           "type": "integer",
           "x-nullable": true,
           "description": "UNIX timestamp when the case file expires."
-        },
-        "visibilityMode": {
-          "type": "integer",
-          "description": "0 = Signers see all documents. 1 = Signers see only documents they need to sign."
-        },
-        "documentDisplayMode": {
-          "type": "integer",
-          "description": "The document display mode of the case file."
         },
         "sensitiveData": {
           "type": "boolean",
@@ -902,10 +886,6 @@
           "type": "integer",
           "description": "UNIX timestamp when the case file was last updated."
         },
-        "encryptionModeSigned": {
-          "type": "string",
-          "description": "The encryption mode used for the signed case file."
-        },
         "language": {
           "type": "string",
           "description": "The case file language."
@@ -919,13 +899,6 @@
         "name": {
           "type": "string",
           "description": "Name of the signer."
-        },
-        "types": {
-          "type": "array",
-          "description": "List of signer types.",
-          "items": {
-            "type": "string"
-          }
         },
         "id": {
           "type": "integer",
@@ -1070,10 +1043,6 @@
         "created": {
           "type": "integer",
           "description": "Timestamp when the document was created."
-        },
-        "encryptionModeSigned": {
-          "type": "string",
-          "description": "The encryption mode used for the signed document."
         },
         "format": {
           "type": "string",

--- a/certified-connectors/Penneo Sign/script.csx
+++ b/certified-connectors/Penneo Sign/script.csx
@@ -1,27 +1,32 @@
 public class Script : ScriptBase
 {
+    private static readonly HashSet<string> LegacyAuthOperations = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        "GetCaseFileDetails",
+        "DownloadDocument"
+    };
+
     public override async Task<HttpResponseMessage> ExecuteAsync()
     {
-        // Get the Authorization header value (which contains "Bearer {access_token}")
         if (this.Context.Request.Headers.TryGetValues("Authorization", out var authHeaderValues))
         {
             var authHeader = authHeaderValues.FirstOrDefault();
             if (!string.IsNullOrEmpty(authHeader))
             {
-                // Remove the "Authorization" header
-                this.Context.Request.Headers.Remove("Authorization");
-                
-                // Extract just the token (remove "Bearer " prefix if present)
-                var token = authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase) 
-                    ? authHeader.Substring(7) 
+                var token = authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase)
+                    ? authHeader.Substring(7)
                     : authHeader;
-                
-                // Add the token to "X-Auth-Token" header WITHOUT "Bearer " prefix
+
+                this.Context.Request.Headers.Remove("Authorization");
                 this.Context.Request.Headers.Add("X-Auth-Token", token);
+
+                if (LegacyAuthOperations.Contains(this.Context.OperationId))
+                {
+                    this.Context.Request.Headers.TryAddWithoutValidation("Authorization", "JWT");
+                }
             }
         }
 
-        // Send the request to the backend API
         var response = await this.Context.SendAsync(this.Context.Request, this.CancellationToken).ConfigureAwait(continueOnCapturedContext: false);
 
         return response;


### PR DESCRIPTION
### When submitting a connector, please make sure that you follow the requirements below, otherwise your PR might be rejected. We want to make you have a well-built connector, a smooth certification experience, and your users are happy :) 

If this is your first time submitting to GitHub and you need some help, please sign up for this [session](https://forms.office.com/pages/responsepage.aspx?id=KtIy2vgLW0SOgZbwvQuRaXDXyCl9DkBHq4A2OG7uLpdUMTFJWFFGVUxBNUFZQjZWRUdaOE5BMFkwNS4u). 

- [ ] I attest that the connector does not exist on the Power Platform today. I have verified by checking the pull requests in GitHub and by searching for the connector on the platform or in the documentation. 
- [x] I attest that the connector works and I verified by deploying and testing all the operations. 
- [x] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [x] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [x] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [x] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and does not use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.

If you are an Independent Publisher, you must also attest to the following to ensure a smooth publishing process:
- [ ] I have named this PR after the pattern of "Connector Name (Independent Publisher)" ex: HubSpot Marketing (Independent Publisher)
- [ ] Within this PR markdown file, I have pasted screenshots that show: 3 unique operations (actions/triggers) working within a Flow. This can be in one flow or part of multiple flows. For each one of those flows, I have pasted in screenshots of the Flow succeeding. 
- [ ] Within this PR markdown file, I have pasted in a screenshot from the Test operations section within the Custom Connector UI.
- [ ] If the connector uses OAuth, I have provided detailed steps on how to create an app in the readme.md. 

---

## Summary

This PR adds two new actions to both the **Penneo Sign** and **Penneo Sign Sandbox** certified connectors, enabling users to retrieve case file details and download documents from the Penneo secure archive.

### New Actions

**1. Get case file details** (`GetCaseFileDetails`)
Retrieves the full details of a specific case file from the Penneo secure archive, including its signers, documents, signature lines, and current status. Takes a case file ID as input.

**2. Download document** (`DownloadDocument`)
Downloads the content of a document from the Penneo secure archive as a base64-encoded string. The document is always returned decrypted. By default the signed version is returned; an optional `signed` parameter allows retrieving the unsigned version.

### Files Changed

| File | Change |
|---|---|
| `certified-connectors/Penneo Sign/apiDefinition.swagger.json` | Added `GetCaseFileDetails` and `DownloadDocument` operations with full request/response schemas |
| `certified-connectors/Penneo Sign/script.csx` | Updated script to support the new operations |
| `certified-connectors/Penneo Sign/README.md` | Added operation descriptions and a step-by-step usage guide |
| `certified-connectors/Penneo Sign Sandbox/apiDefinition.swagger.json` | Mirror of production connector changes |
| `certified-connectors/Penneo Sign Sandbox/script.csx` | Mirror of production connector changes |
| `certified-connectors/Penneo Sign Sandbox/README.md` | Mirror of production connector changes |

### Typical Usage Flow

1. **Get the case file details** — use the "Get case file details" action with the case file ID. The response includes the case file status, list of signers, and list of documents with their document IDs.
2. **Download a document** — use the "Download document" action with a document ID from the previous step. The response contains the document content as a base64-encoded string, which can be decoded to retrieve the PDF file.