### PR TITLE
Jira (certified-connector) - Fix ListProjects_V2 response schema property mismatch

### DIFF
--- a/certified-connectors/JIRA/apiDefinition.swagger.json
+++ b/certified-connectors/JIRA/apiDefinition.swagger.json
@@ -1667,7 +1667,30 @@
             "description": "Next page of projects",
             "x-ms-visibility": "internal"
           },
-          "values": {
+          "isLast": {
+            "type": "boolean",
+            "x-ms-summary": "Is last page",
+            "description": "Whether this is the last page of results"
+          },
+          "maxResults": {
+            "type": "integer",
+            "format": "int32",
+            "x-ms-summary": "Max results",
+            "description": "Maximum number of results per page"
+          },
+          "startAt": {
+            "type": "integer",
+            "format": "int32",
+            "x-ms-summary": "Start at",
+            "description": "Index of the first result returned"
+          },
+          "total": {
+            "type": "integer",
+            "format": "int32",
+            "x-ms-summary": "Total",
+            "description": "Total number of projects"
+          },
+          "value": {
             "$ref": "#/definitions/ProjectArray"
           }
         }


### PR DESCRIPTION
Fixes #4223

`ListProjects_ResponseV2` declares the project array under `values`, but every `x-ms-dynamic-values` block in this connector that points at `ListProjects_V2` uses `"value-collection": "value"`, and the actual runtime response also returns the array under `value`. Because the typed schema disagreed with the real payload, the field showed up fine in things like a Copilot Studio "Send message" node (which just dumps the raw JSON), but was unreachable from a typed Power Fx expression like `Topic.projectList.value` — and the schema-visible `Topic.projectList.values` came back empty.

Renamed `values` to `value` so the schema matches the dynamic-values metadata and the real API response. Also added `isLast`, `maxResults`, `startAt`, and `total`, which the API returns alongside the project array but weren't represented in the schema at all — the issue's reproduction steps show these in the actual payload.

## Testing

I don't have a Jira instance to run this against, so I verified this the way I could:
- Confirmed the swagger file is still valid JSON after the change
- Confirmed every other reference to `ListProjects_V2` in the file (8 total `x-ms-dynamic-values` blocks) already expects `value`, not `values`, so this brings the schema in line with the rest of the file rather than introducing a new convention
- Matched the added field types/names exactly to the sample payload included in #4223

Happy to adjust if the connector owner wants a different approach (e.g. keeping `values` and instead fixing the dynamic-values metadata + runtime to match it instead) — from the issue it sounded like `value` is the one that's actually correct since that's what the live API returns.